### PR TITLE
Resolve backwards incompatible protobuf change

### DIFF
--- a/protos/core.proto
+++ b/protos/core.proto
@@ -171,6 +171,6 @@ message Fields {
 
 message TableMetadata {
   Target target = 1;
-  string type = 3; // "table" or "view"
-  repeated Field fields = 2;
+  string type = 2; // "table" or "view"
+  repeated Field fields = 3;
 }


### PR DESCRIPTION
Issue was introduced in pull request #66
Specifically, change the Tablemetadata data field numbers to match that of the previous protobuf, TableState so that they have compatible wire formats.

Changing the Tablemetadata field numbers is OK this time as that data is never persisted anywhere (yet) - however, TableState protos were persisted as part of the ExecutionGraph.