### PR TITLE
Fix node module fixtures

### DIFF
--- a/tests/api/api.spec.ts
+++ b/tests/api/api.spec.ts
@@ -436,10 +436,7 @@ describe("@dataform/api", () => {
       });
     });
 
-    // Disabled, because test bind old versions of protos library instead of using local changes
-    // More info: https://github.com/dataform-co/dataform/issues/92
-    // TODO: turn on when issue #92 will be fixed
-    xit("bigquery_with_errors_example", async () => {
+    it("bigquery_with_errors_example", async () => {
       const expectedResults = [
         {
           fileName: "definitions/test.js",

--- a/tools/node_modules.bzl
+++ b/tools/node_modules.bzl
@@ -4,24 +4,44 @@ def _impl(ctx):
     tree = ctx.actions.declare_directory(ctx.attr.name)
     folder_path = tree.path.replace("/node_modules", "")
 
-    # Set a unique yarn cache folder for this rule as sharing a folder between
-    # different calls causes errors.
-    # In the future, we should ideally rm -rf this directory first, or disable yarn cache entirely.
-    arguments = ["--cwd", folder_path, "--cache-folder", "/tmp/.yarn-bazel-cache/" + folder_path, "add"]
-
-    # Running with cwd means we need to go back up dirs for paths to resolve.
-    root_path = "/".join([".." for f in folder_path.split("/")])
+    #   NPM refuses to install into node_modules directly as it's a strange
+    #       symlinky virtual file system.
+    #   Similarly, it won't use a cache folder in this directory, so we stage
+    #       things in /tmp folders then copy back across.
+    #   We override the install dirwith --prefix, changing directory 
+    #       doesn't work due to the virtual file system issues.
+    #   We have to be careful to clean up directories and make sure the workdirs
+    #       are unique to avoid caching issues as there is no way to turn off the cache.
+    packages = []
     for d in ctx.attr.deps:
         for f in d.files.to_list():
-            arguments.append("file:" + root_path + "/" + f.path)
+            # We are going to define $ROOT in the command below to get absolute paths.
+            packages.append("$ROOT/" + f.path)
     for p in ctx.attr.packages:
-        arguments.append(p)
-    ctx.actions.run(
-        inputs = ctx.files.deps,
+        packages.append(p)
+    ctx.action(
+        inputs = ctx.files.deps + [ctx.executable._tool],
         outputs = [tree],
-        arguments = arguments,
+        command = """
+          BIN_PATH=$PWD/{npm};
+          ROOT=$PWD;
+          mkdir -p /tmp/.bazel-node-modules/{folder_path}/workdir;
+          mkdir -p /tmp/.bazel-node-modules/{folder_path}/cache;
+          rm -rf /tmp/.bazel-node-modules/{folder_path}/workdir/*;
+          rm -rf /tmp/.bazel-node-modules/{folder_path}/cache/*;
+          $BIN_PATH \\
+              --prefix /tmp/.bazel-node-modules/{folder_path}/workdir \\
+              --cache=/tmp/.bazel-node-modules/{folder_path}/cache install \\
+              --silent \\
+              --no-update-notifier \\
+              {packages};
+          cp -R /tmp/.bazel-node-modules/{folder_path}/workdir/node_modules {folder_path}/;
+        """.format(
+            npm = ctx.executable._tool.path,
+            packages = " ".join(packages),
+            folder_path = folder_path,
+        ),
         progress_message = "Installing node modules into %s" % tree.path,
-        executable = ctx.executable._tool,
     )
 
     return [DefaultInfo(files = depset([tree]))]
@@ -35,7 +55,7 @@ node_modules = rule(
             executable = True,
             cfg = "host",
             allow_files = True,
-            default = Label("@nodejs//:yarn"),
+            default = Label("@nodejs//:npm"),
         ),
     },
 )

--- a/tools/node_modules.bzl
+++ b/tools/node_modules.bzl
@@ -8,7 +8,7 @@ def _impl(ctx):
     #       symlinky virtual file system.
     #   Similarly, it won't use a cache folder in this directory, so we stage
     #       things in /tmp folders then copy back across.
-    #   We override the install dirwith --prefix, changing directory 
+    #   We override the install directory with --prefix, changing directory 
     #       doesn't work due to the virtual file system issues.
     #   We have to be careful to clean up directories and make sure the workdirs
     #       are unique to avoid caching issues as there is no way to turn off the cache.


### PR DESCRIPTION
Yarn was doing strange things. Go back to NPM which behaves as we want it to (flat node_modules) and a ton of hacks to make it work. This *should* be consistent across platforms/builds.

@BenBirt if you could test this on MacOS, that would be great!