### PR TITLE
Fixes #124. Loudly print compile/run errors to the console.

### DIFF
--- a/api/commands/init.ts
+++ b/api/commands/init.ts
@@ -2,6 +2,7 @@ import { dataform } from "@dataform/protos";
 import * as fs from "fs";
 import * as path from "path";
 import { install } from "@dataform/api/commands/install";
+import { prettyJsonStringify } from "@dataform/api/utils";
 
 const { version } = require("../package.json");
 
@@ -75,8 +76,4 @@ export async function init(
     dirsCreated,
     installedNpmPackages: !skipInstall
   };
-}
-
-function prettyJsonStringify(obj) {
-  return JSON.stringify(obj, null, 4) + "\n";
 }

--- a/api/commands/init.ts
+++ b/api/commands/init.ts
@@ -5,11 +5,17 @@ import { install } from "@dataform/api/commands/install";
 
 const { version } = require("../package.json");
 
-export function init(
+export interface InitResult {
+  filesWritten: string[];
+  dirsCreated: string[];
+  installedNpmPackages: boolean;
+}
+
+export async function init(
   projectDir: string,
   projectConfig: dataform.IProjectConfig,
   skipInstall?: boolean
-): Promise<any> {
+): Promise<InitResult> {
   const dataformJsonPath = path.join(projectDir, "dataform.json");
   const packageJsonPath = path.join(projectDir, "package.json");
   const gitignorePath = path.join(projectDir, ".gitignore");
@@ -19,45 +25,58 @@ export function init(
     );
   }
 
+  const filesWritten = [];
+  const dirsCreated = [];
+
   if (!fs.existsSync(projectDir)) {
     fs.mkdirSync(projectDir);
+    dirsCreated.push(projectDir);
   }
+
   fs.writeFileSync(
     dataformJsonPath,
-    JSON.stringify(
-      Object.assign(
-        {},
-        dataform.ProjectConfig.create({
-          defaultSchema: "dataform",
-          assertionSchema: "dataform_assertions"
-        }),
-        projectConfig
-      ),
-      null,
-      4
-    ) + "\n"
+    prettyJsonStringify(
+      dataform.ProjectConfig.create({
+        defaultSchema: "dataform",
+        assertionSchema: "dataform_assertions",
+        ...projectConfig
+      })
+    )
   );
+  filesWritten.push(dataformJsonPath);
+
   fs.writeFileSync(
     packageJsonPath,
-    JSON.stringify(
-      {
-        dependencies: {
-          "@dataform/core": version
-        }
-      },
-      null,
-      4
-    ) + "\n"
+    prettyJsonStringify({
+      dependencies: {
+        "@dataform/core": version
+      }
+    })
   );
-  fs.writeFileSync(
-    gitignorePath,
-    `node_modules/
-  `
-  );
+  filesWritten.push(packageJsonPath);
+
+  fs.writeFileSync(gitignorePath, "node_modules/\n");
+  filesWritten.push(gitignorePath);
+
   // Make the default models, includes folders.
-  fs.mkdirSync(path.join(projectDir, "definitions"));
-  fs.mkdirSync(path.join(projectDir, "includes"));
+  const definitionsDir = path.join(projectDir, "definitions");
+  fs.mkdirSync(definitionsDir);
+  dirsCreated.push(definitionsDir);
+
+  const includesDir = path.join(projectDir, "includes");
+  fs.mkdirSync(includesDir);
+  dirsCreated.push(includesDir);
 
   // Install packages.
-  return install(projectDir, skipInstall);
+  await install(projectDir, skipInstall);
+
+  return {
+    filesWritten,
+    dirsCreated,
+    installedNpmPackages: !skipInstall
+  };
+}
+
+function prettyJsonStringify(obj) {
+  return JSON.stringify(obj, null, 4) + "\n";
 }

--- a/api/utils.ts
+++ b/api/utils.ts
@@ -2,6 +2,10 @@ import { requiredWarehouseProps, WarehouseTypes } from "@dataform/core/adapters"
 import { dataform } from "@dataform/protos";
 import * as fs from "fs";
 
+export function prettyJsonStringify(obj) {
+  return JSON.stringify(obj, null, 4) + "\n";
+}
+
 export type Credentials = dataform.IBigQuery | dataform.IJDBC | dataform.ISnowflake;
 
 export function readCredentials(warehouse: string, credentialsPath: string): Credentials {


### PR DESCRIPTION
Also: 
- Suggest commands when the user requests a non-existent one.
- Use nice output colours where useful.
- Require strict command setting.
- Set script name so that help output reads cleanly.