### PR TITLE
Various changes to make the CLI more usable.

### DIFF
--- a/api/dbadapters/index.ts
+++ b/api/dbadapters/index.ts
@@ -30,5 +30,9 @@ export function create(credentials: Credentials, warehouseType: string): DbAdapt
 }
 
 register("bigquery", BigQueryDbAdapter);
+// TODO: The redshift client library happens to work well for postgres, but we should probably
+// not be relying on that behaviour. At some point we should replace this with a first-class
+// PostgresAdapter.
+register("postgres", RedshiftDbAdapter);
 register("redshift", RedshiftDbAdapter);
 register("snowflake", SnowflakeDbAdapter);

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -367,9 +367,8 @@ const builtYargs = createYargsCli({
   .wrap(null)
   .recommendCommands()
   .fail((msg, err) => {
-    writeStdErr(
-      errorOutput(`Dataform encountered an error: ${err ? err.stack || err.message : msg}`)
-    );
+    const message = err.message.split("\n")[0];
+    writeStdErr(errorOutput(`Dataform encountered an error: ${message}`));
     process.exit(1);
   }).argv;
 
@@ -527,7 +526,10 @@ function createYargsCli(cli: ICli) {
       command.format,
       command.description,
       yargsChainer => createOptionsChain(yargsChainer, command),
-      command.processFn
+      async (argv: any) => {
+        await command.processFn(argv);
+        process.exit();
+      }
     );
   }
   return yargsChain;

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -526,7 +526,7 @@ function createYargsCli(cli: ICli) {
       command.format,
       command.description,
       yargsChainer => createOptionsChain(yargsChainer, command),
-      async (argv: any) => {
+      async (argv: { [argumentName: string]: any }) => {
         await command.processFn(argv);
         process.exit();
       }


### PR DESCRIPTION
- Properly register postgres as a CLI option, fixes #185 
- Only ever print the first line of an Error's message, fixes #183 
- Exit immediately after any command completes, fixes #186 