### PR TITLE
Make the CLI more usable.

### DIFF
--- a/cli/BUILD
+++ b/cli/BUILD
@@ -16,6 +16,7 @@ ts_library(
         "@npm//@types/yargs",
         "@npm//chokidar",
         "@npm//readline-sync",
+        "@npm//untildify",
         "@npm//yargs",
     ],
 )

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -22,9 +22,7 @@ const errorOutput = (output: string) => coloredOutput(output, 91);
 const writeStdOut = (output: string) => process.stdout.write(output + "\n");
 const writeStdErr = (output: string) => process.stderr.write(output + "\n");
 
-const actuallyResolve = filePath => {
-  return path.resolve(untildify(filePath));
-};
+const actuallyResolve = filePath => path.resolve(untildify(filePath));
 
 const projectDirOption: INamedOption<yargs.PositionalOptions> = {
   name: "project-dir",

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { build, compile, credentials, init, run, table } from "@dataform/api";
 import { prettyJsonStringify } from "@dataform/api/utils";
-import { WarehouseType, supportsCancel } from "@dataform/core/adapters";
+import { supportsCancel, WarehouseType } from "@dataform/core/adapters";
 import { dataform } from "@dataform/protos";
 import * as chokidar from "chokidar";
 import * as fs from "fs";
@@ -458,7 +458,7 @@ function getJdbcCredentials(hostQuestion: string, defaultPort: number): dataform
   const port = parseInt(
     readlineSync.prompt({
       limit: value => {
-        const intValue = parseInt(value);
+        const intValue = parseInt(value, 10);
         return (
           !isNaN(intValue) && typeof intValue === "number" && intValue >= 0 && intValue <= 65536
         );
@@ -466,7 +466,8 @@ function getJdbcCredentials(hostQuestion: string, defaultPort: number): dataform
       limitMessage: errorOutput("Port numbers must be integers and lie in the [0, 65535] range."),
       prompt: `[${defaultPort}] `,
       defaultInput: `${defaultPort}`
-    })
+    }),
+    10
   );
   const username = readlineSync.question(commandOutput("Enter your database username:\n"));
   const password = readlineSync.question(commandOutput("Enter your database password:\n"), {

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -1,12 +1,13 @@
 #!/usr/bin/env node
 import { build, compile, credentials, init, run, table } from "@dataform/api";
 import { prettyJsonStringify } from "@dataform/api/utils";
-import { WarehouseType } from "@dataform/core/adapters";
+import { WarehouseType, supportsCancel } from "@dataform/core/adapters";
 import { dataform } from "@dataform/protos";
 import * as chokidar from "chokidar";
 import * as fs from "fs";
 import * as path from "path";
 import * as readlineSync from "readline-sync";
+import * as untildify from "untildify";
 import * as yargs from "yargs";
 
 const RECOMPILE_DELAY = 2000;
@@ -21,18 +22,33 @@ const errorOutput = (output: string) => coloredOutput(output, 91);
 const writeStdOut = (output: string) => process.stdout.write(output + "\n");
 const writeStdErr = (output: string) => process.stderr.write(output + "\n");
 
+const actuallyResolve = filePath => {
+  return path.resolve(untildify(filePath));
+};
+
 const projectDirOption: INamedOption<yargs.PositionalOptions> = {
   name: "project-dir",
   option: {
     describe: "The Dataform project directory.",
     default: ".",
-    coerce: path.resolve
+    coerce: actuallyResolve
   }
 };
 
 const projectDirMustExistOption = {
   ...projectDirOption,
-  check: (argv: yargs.Arguments) => assertPathExists(argv["project-dir"])
+  check: (argv: yargs.Arguments) => {
+    assertPathExists(argv["project-dir"]);
+    try {
+      assertPathExists(path.resolve(argv["project-dir"], "dataform.json"));
+    } catch (e) {
+      throw new Error(
+        `${
+          argv["project-dir"]
+        } does not appear to be a dataform directory (missing dataform.json file).`
+      );
+    }
+  }
 };
 
 const fullRefreshOption: INamedOption<yargs.Options> = {
@@ -85,7 +101,7 @@ const credentialsOption: INamedOption<yargs.Options> = {
   option: {
     describe: "The location of the credentials JSON file to use.",
     default: credentials.CREDENTIALS_FILENAME,
-    coerce: path.resolve
+    coerce: actuallyResolve
   },
   check: (argv: yargs.Arguments) => assertPathExists(argv.credentials)
 };
@@ -315,6 +331,9 @@ const builtYargs = createYargsCli({
 
         const runner = run(executionGraph, readCredentials);
         process.on("SIGINT", () => {
+          if (!supportsCancel(WarehouseType[compiledGraph.projectConfig.warehouse])) {
+            process.exit();
+          }
           runner.cancel();
         });
         const executedGraph = await runner.resultPromise();
@@ -325,11 +344,15 @@ const builtYargs = createYargsCli({
             .filter(node => node.status === dataform.NodeExecutionStatus.FAILED)
             .forEach(node => {
               writeStdErr(errorOutput(`Execution failed on node "${node.name}":`));
-              node.tasks.filter(task => !task.ok).forEach(task => {
-                writeStdErr(
-                  errorOutput(`Statement "${task.task.statement}" failed with error: ${task.error}`)
-                );
-              });
+              node.tasks
+                .filter(task => !task.ok)
+                .forEach(task => {
+                  writeStdErr(
+                    errorOutput(
+                      `Statement "${task.task.statement}" failed with error: ${task.error}`
+                    )
+                  );
+                });
             });
         }
       }
@@ -371,7 +394,7 @@ const builtYargs = createYargsCli({
   .wrap(null)
   .recommendCommands()
   .fail((msg, err) => {
-    const message = err.message.split("\n")[0];
+    const message = err ? err.message.split("\n")[0] : msg;
     writeStdErr(errorOutput(`Dataform encountered an error: ${message}`));
     process.exit(1);
   }).argv;
@@ -395,7 +418,7 @@ function getBigQueryCredentials(): dataform.IBigQuery {
         "(You can delete this file after credential initialization is complete.)\n"
     )
   );
-  const cloudCredentialsPath = path.resolve(
+  const cloudCredentialsPath = actuallyResolve(
     readlineSync.question(commandOutput("Enter the path to your Google Cloud private key file:\n"))
   );
   if (!fs.existsSync(cloudCredentialsPath)) {
@@ -418,7 +441,7 @@ function getBigQueryCredentials(): dataform.IBigQuery {
 
 function getRedshiftCredentials() {
   return getJdbcCredentials(
-    "Enter the hostname of your Redshift instance (in the form '[name].[id].[region].redshift.amazonaws.com'):\n",
+    "Enter the hostname of your Redshift instance (in the form 'name.id.region.redshift.amazonaws.com'):\n",
     5439
   );
 }
@@ -429,12 +452,26 @@ function getPostgresCredentials() {
 
 function getJdbcCredentials(hostQuestion: string, defaultPort: number): dataform.IJDBC {
   const host = readlineSync.question(commandOutput(hostQuestion));
-  const port = readlineSync.questionInt(
-    commandOutput(`Enter the port that Dataform should connect to (usually ${defaultPort}):\n`)
+  writeStdOut(
+    commandOutput(`Enter the port that Dataform should connect to (leave blank to use default):`)
+  );
+  const port = parseInt(
+    readlineSync.prompt({
+      limit: value => {
+        const intValue = parseInt(value);
+        return (
+          !isNaN(intValue) && typeof intValue === "number" && intValue >= 0 && intValue <= 65536
+        );
+      },
+      limitMessage: errorOutput("Port numbers must be integers and lie in the [0, 65535] range."),
+      prompt: `[${defaultPort}] `,
+      defaultInput: `${defaultPort}`
+    })
   );
   const username = readlineSync.question(commandOutput("Enter your database username:\n"));
   const password = readlineSync.question(commandOutput("Enter your database password:\n"), {
-    hideEchoBack: true
+    hideEchoBack: true,
+    mask: ""
   });
   const databaseName = readlineSync.question(commandOutput("Enter the database name:\n"));
   return {

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -457,9 +457,7 @@ function getJdbcCredentials(hostQuestion: string, defaultPort: number): dataform
     readlineSync.prompt({
       limit: value => {
         const intValue = parseInt(value, 10);
-        return (
-          !isNaN(intValue) && typeof intValue === "number" && intValue >= 0 && intValue <= 65536
-        );
+        return !isNaN(intValue) && intValue >= 0 && intValue <= 65536;
       },
       limitMessage: errorOutput("Port numbers must be integers and lie in the [0, 65535] range."),
       prompt: `[${defaultPort}] `,

--- a/cli/package.json
+++ b/cli/package.json
@@ -16,6 +16,7 @@
     "@types/yargs": "^11.1.1",
     "chokidar": "^2.0.4",
     "readline-sync": "^1.4.9",
+    "untildify": "^3.0.3",
     "yargs": "^12.0.1"
   },
   "publishConfig": {

--- a/core/adapters/index.ts
+++ b/core/adapters/index.ts
@@ -29,6 +29,13 @@ export enum WarehouseType {
   SNOWFLAKE = "snowflake"
 }
 
+export function supportsCancel(warehouseType: WarehouseType) {
+  if (warehouseType === WarehouseType.BIGQUERY) {
+    return true;
+  }
+  return false;
+}
+
 const requiredBigQueryWarehouseProps: Array<keyof dataform.IBigQuery> = [
   "projectId",
   "credentials"

--- a/core/adapters/index.ts
+++ b/core/adapters/index.ts
@@ -30,10 +30,7 @@ export enum WarehouseType {
 }
 
 export function supportsCancel(warehouseType: WarehouseType) {
-  if (warehouseType === WarehouseType.BIGQUERY) {
-    return true;
-  }
-  return false;
+  return warehouseType === WarehouseType.BIGQUERY;
 }
 
 const requiredBigQueryWarehouseProps: Array<keyof dataform.IBigQuery> = [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1196,9 +1196,9 @@
       }
     },
     "@types/node": {
-      "version": "9.6.40",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.40.tgz",
-      "integrity": "sha512-M3HHoXXndsho/sTbQML2BJr7/uwNhMg8P0D4lb+UsM65JQZx268faiz9hKpY4FpocWqpwlLwa8vevw8hLtKjOw=="
+      "version": "9.6.47",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.47.tgz",
+      "integrity": "sha512-56wEJWXZs+3XXoTe/OCpdZ6czrONhy+6hT0GdPOb7HvudLTMJ1T5tuZPs37K5cPR5t+J9+vLPFDQgUQ8NWJE1w=="
     },
     "@types/node-fetch": {
       "version": "2.1.4",
@@ -2062,7 +2062,7 @@
     },
     "babel-plugin-react-require": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-react-require/-/babel-plugin-react-require-3.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/babel-plugin-react-require/-/babel-plugin-react-require-3.0.0.tgz",
       "integrity": "sha1-Lk57RJa5OmVKHIAEInbeTk7rIOM="
     },
     "babel-plugin-syntax-jsx": {
@@ -6032,7 +6032,7 @@
       "dependencies": {
         "commander": {
           "version": "2.15.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+          "resolved": "http://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
           "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="
         },
         "debug": {
@@ -6870,7 +6870,7 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.10",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
           "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
         },
         "wordwrap": {
@@ -7945,7 +7945,7 @@
         },
         "globby": {
           "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
+          "resolved": "http://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
           "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
           "requires": {
             "array-union": "^1.0.1",
@@ -7958,7 +7958,7 @@
         },
         "pify": {
           "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
         }
       }
@@ -8040,7 +8040,7 @@
       "dependencies": {
         "jsesc": {
           "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+          "resolved": "http://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
           "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
         }
       }
@@ -10015,6 +10015,11 @@
           "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
         }
       }
+    },
+    "untildify": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/untildify/-/untildify-3.0.3.tgz",
+      "integrity": "sha512-iSk/J8efr8uPT/Z4eSUywnqyrQU7DSdMfdqK4iWEaUVVmcP5JcnpRqmVMwcwcnmI1ATFNgC5V90u09tBynNFKA=="
     },
     "upath": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@types/long": "^4.0.0",
     "@types/mocha": "^5.2.5",
     "@types/next": "^7.0.5",
-    "@types/node": "^9.6.32",
+    "@types/node": "^9.6.47",
     "@types/react": "^16.7.17",
     "@types/readline-sync": "^1.4.3",
     "@types/rimraf": "^2.0.2",
@@ -67,6 +67,7 @@
     "uglify-es": "^3.3.9",
     "uglify-js": "^3.4.9",
     "umd-compat-loader": "^2.1.1",
+    "untildify": "^3.0.3",
     "vm2": "^3.6.3",
     "webpack": "4.20.2",
     "yargs": "^12.0.1"


### PR DESCRIPTION
- Correctly interpret `~` tildes in flag paths
- In all situations that require a project directory to exist, check that it really does appear to be a dataform directory: fixes #192 
- Enable cancelling runs on non-bigquery warehouses with ctrl+C: fixes #190 
- Enable the user to simply use the default port number for redshift/postgres: fixes #191 
- Hide the asterisks that were printed as part of password entry