### PR TITLE
Add nginx configs for static sites and single page applications

### DIFF
--- a/docs/BUILD
+++ b/docs/BUILD
@@ -56,7 +56,7 @@ load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 
 container_image(
     name = "image",
-    base = "@nginx_base//image",
+    base = "//tools/nginx/static",
     directory = "/usr/share/nginx/html",
     tars = [":docs_pkg"],
 )
@@ -69,5 +69,5 @@ container_push(
     image = ":image",
     registry = "gcr.io",
     repository = "tada-analytics/static-docs",
-    tag = "prod",
+    tag = "debug",
 )

--- a/tools/nginx/spa/BUILD
+++ b/tools/nginx/spa/BUILD
@@ -1,0 +1,11 @@
+package(default_visibility = ["//visibility:public"])
+
+load("@io_bazel_rules_docker//container:container.bzl", "container_image")
+
+container_image(
+    name = "spa",
+    base = "@nginx_base//image",
+    data_path = "/tools/nginx/spa",
+    directory = "/etc/nginx/",
+    files = [":nginx.conf"],
+)

--- a/tools/nginx/spa/nginx.conf
+++ b/tools/nginx/spa/nginx.conf
@@ -1,3 +1,5 @@
+# Basic nginx config for a single page application site (e.g. webpack + react).
+
 # This file is mostly taken from the defaults in the official nginx
 # docker image with a few tweaks as commented below.
 

--- a/tools/nginx/spa/nginx.conf
+++ b/tools/nginx/spa/nginx.conf
@@ -1,0 +1,55 @@
+# This file is mostly taken from the defaults in the official nginx
+# docker image with a few tweaks as commented below.
+
+user  nginx;
+worker_processes  1;
+
+error_log  /var/log/nginx/error.log warn;
+pid  /var/run/nginx.pid;
+
+
+events {
+    worker_connections  1024;
+}
+
+
+http {
+    include  /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile  on;
+
+    keepalive_timeout  65;
+
+    gzip  on;
+
+    server {
+        listen  80;
+        server_name  localhost;
+
+        location / {
+            root  /usr/share/nginx/html;
+            index  index.html;
+
+            # Set a reasonble default cache time.
+            expires  5m;
+            add_header  Cache-Control "public";
+
+            # Disable caching based on last modified headers as
+            # with our docker builds file timestamps are always the same.
+            add_header Last-Modified "";
+            if_modified_since off;
+
+            # Always serve the index.html file on 404 for react browser history.
+            try_files $uri /index.html;
+        }
+
+        error_page  500 502 503 504  /50x.html;
+    }
+}

--- a/tools/nginx/static/BUILD
+++ b/tools/nginx/static/BUILD
@@ -1,0 +1,11 @@
+package(default_visibility = ["//visibility:public"])
+
+load("@io_bazel_rules_docker//container:container.bzl", "container_image")
+
+container_image(
+    name = "static",
+    base = "@nginx_base//image",
+    data_path = "/tools/nginx/static",
+    directory = "/etc/nginx/",
+    files = [":nginx.conf"],
+)

--- a/tools/nginx/static/nginx.conf
+++ b/tools/nginx/static/nginx.conf
@@ -1,3 +1,5 @@
+# Basic nginx config for a static site serving static assets.
+
 # This file is mostly taken from the defaults in the official nginx
 # docker image with a few tweaks as commented below.
 

--- a/tools/nginx/static/nginx.conf
+++ b/tools/nginx/static/nginx.conf
@@ -1,0 +1,53 @@
+# This file is mostly taken from the defaults in the official nginx
+# docker image with a few tweaks as commented below.
+
+user  nginx;
+worker_processes  1;
+
+error_log  /var/log/nginx/error.log warn;
+pid  /var/run/nginx.pid;
+
+
+events {
+    worker_connections  1024;
+}
+
+
+http {
+    include  /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile  on;
+
+    keepalive_timeout  65;
+
+    gzip  on;
+
+    server {
+        listen  80;
+        server_name  localhost;
+
+        location / {
+            root  /usr/share/nginx/html;
+            index  index.html;
+
+            # Set a reasonble default cache time.
+            expires  5m;
+            add_header  Cache-Control "public";
+
+            # Disable caching based on last modified headers as
+            # with our docker builds file timestamps are always the same.
+            add_header Last-Modified "";
+            if_modified_since off;
+        }
+
+        error_page  404              /404.html;
+        error_page  500 502 503 504  /50x.html;
+    }
+}


### PR DESCRIPTION
Two new nginx configs and base nginx images built with them.

The base config for both was built by extracting the configs from the nginx docker image we were originally using.

- Remove last modified headers so we rely purely on etags instead.
- Set a 5m default cache time.
- Always serve the index file for 404's on SPAs so they can use browser history.

Unfortunately there is no easy way to compose these configs into multiple files so there is a bit of duplication.
