### PR TITLE
Update nginx configs.

### DIFF
--- a/tools/nginx/spa/nginx.conf
+++ b/tools/nginx/spa/nginx.conf
@@ -34,14 +34,15 @@ http {
     server {
         listen  80;
         server_name  localhost;
+        root  /usr/share/nginx/html;
+        index  index.html;
 
         location / {
-            root  /usr/share/nginx/html;
-            index  index.html;
-
-            # Set a reasonble default cache time.
-            expires  5m;
-            add_header  Cache-Control "public";
+            # Allow browsers to cache files, but only allow serving files from
+            # the cache after revalidating them (using if-none-match) with the server.
+            add_header  Cache-Control "public, no-cache";
+            # Set a reasonable default cache time.
+            expires  1d;
 
             # Disable caching based on last modified headers as
             # with our docker builds file timestamps are always the same.

--- a/tools/nginx/static/nginx.conf
+++ b/tools/nginx/static/nginx.conf
@@ -34,14 +34,26 @@ http {
     server {
         listen  80;
         server_name  localhost;
+        root  /usr/share/nginx/html;
+        index  index.html;
 
         location / {
-            root  /usr/share/nginx/html;
-            index  index.html;
+            # Allow browsers to cache files, but only allow serving files from
+            # the cache after revalidating them (using if-none-match) with the server.
+            add_header  Cache-Control "public, no-cache";
+            # Set a reasonable default cache time.
+            expires  1d;
 
-            # Set a reasonble default cache time.
-            expires  5m;
-            add_header  Cache-Control "public";
+            # Disable caching based on last modified headers as
+            # with our docker builds file timestamps are always the same.
+            add_header Last-Modified "";
+            if_modified_since off;
+        }
+
+        location ~* \.(?:jpg|jpeg|gif|png|ico|cur|gz|svg|svgz|mp4|ogg|ogv|webm|htc|css|js)$ {
+            # Cache non-HTML static content (presumed to be served under a cachebusting URL) forever.
+            expires 1y;
+            add_header Cache-Control "public";
 
             # Disable caching based on last modified headers as
             # with our docker builds file timestamps are always the same.


### PR DESCRIPTION
For nextJS sites:
- for HTML files, set a cache expiry of 1d but force validation before ever serving from the cache
- for everything else (presumably behind a cachebusting URL), set a cache expiry of 1y

For the single-page app: set a cache expiry of 1d but force validation before ever serving from the cache

For posterity, these were useful:
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control
https://medium.com/pixelpoint/best-practices-for-cache-control-settings-for-your-website-ff262b38c5a2
https://sookocheff.com/post/api/effective-caching/
https://www.keycdn.com/blog/http-cache-headers
https://stackoverflow.com/questions/18148884/difference-between-no-cache-and-must-revalidate
https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/http-caching