### PR TITLE
Add version substitutions for package JSON files

### DIFF
--- a/api/api.package.json
+++ b/api/api.package.json
@@ -4,8 +4,8 @@
   "main": "index.js",
   "types": "index.d.ts",
   "dependencies": {
-    "@dataform/core": "1.0.0-alpha.3",
-    "@dataform/protos": "1.0.0-alpha.3",
+    "@dataform/core": "$DF_VERSION",
+    "@dataform/protos": "$DF_VERSION",
     "@google-cloud/bigquery": "^1.3.0",
     "@types/glob": "^7.1.1",
     "bluebird": "^3.5.3",

--- a/cli/cli.package.json
+++ b/cli/cli.package.json
@@ -8,9 +8,9 @@
     "dtfm": "index.js"
   },
   "dependencies": {
-    "@dataform/api": "1.0.0-alpha.3",
-    "@dataform/core": "1.0.0-alpha.3",
-    "@dataform/protos": "1.0.0-alpha.3",
+    "@dataform/api": "$DF_VERSION",
+    "@dataform/core": "$DF_VERSION",
+    "@dataform/protos": "$DF_VERSION",
     "@types/readline-sync": "^1.4.3",
     "@types/yargs": "^11.1.1",
     "chokidar": "^2.0.4",

--- a/common.package.json
+++ b/common.package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0-alpha.3",
+  "version": "$DF_VERSION",
   "homepage": "https://github.com/dataform-co/dataform",
   "license": "MIT",
   "keywords": [

--- a/core/core.package.json
+++ b/core/core.package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "types": "index.d.ts",
   "dependencies": {
-    "@dataform/protos": "1.0.0-alpha.3",
+    "@dataform/protos": "$DF_VERSION",
     "moo": "^0.5.0",
     "protobufjs": "^6.8.8"
   }

--- a/crossdb/crossdb.package.json
+++ b/crossdb/crossdb.package.json
@@ -2,7 +2,7 @@
   "name": "@dataform/crossdb",
   "description": "Cross database utilities for dataform.",
   "dependencies": {
-    "@dataform/core": "1.0.0-alpha.3"
+    "@dataform/core": "$DF_VERSION"
   },
   "main": "index.js",
   "types": "index.d.ts",

--- a/tools/json-merge/index.ts
+++ b/tools/json-merge/index.ts
@@ -1,14 +1,31 @@
 import * as fs from "fs";
 import * as yargs from "yargs";
 
-const argv = yargs.option("output-path", { required: true }).option("layer-paths", { array: true })
-  .argv;
+const argv = yargs
+  .option("output-path", { required: true })
+  .option("layer-paths", { array: true })
+  .option("substitutions", { type: "string" }).argv;
 
-const result = (argv.layerPaths as string[])
+const outputPath = argv.outputPath as string;
+const layerPaths = argv.layerPaths as string[];
+const substitutions = JSON.parse(argv.substitutions || "{}") as { [key: string]: string };
+
+// Merge layers in the given order.
+const result = layerPaths
   .map((layerPath: string) => JSON.parse(fs.readFileSync(layerPath, "utf8")))
   .reduce(
-    (layerJson: object, accumulatorJson: object) => ({ ...accumulatorJson, ...layerJson }),
+    (accumulatorJson: object, layerJson: object) => ({ ...accumulatorJson, ...layerJson }),
     {}
   );
 
-fs.writeFileSync(argv.outputPath as string, JSON.stringify(result, null, 4));
+let resultString = JSON.stringify(result, null, 4);
+
+// Apply any plain string substitutions.
+if (substitutions) {
+  resultString = Object.keys(substitutions).reduce(
+    (original, key) => original.split(key).join(substitutions[key]),
+    resultString
+  );
+}
+
+fs.writeFileSync(outputPath, resultString);

--- a/tools/npm/package.bzl
+++ b/tools/npm/package.bzl
@@ -1,4 +1,5 @@
 load("@build_bazel_rules_nodejs//:defs.bzl", "npm_package")
+load("//:version.bzl", "DF_VERSION")
 
 def dataform_npm_package(name, deps, srcs = [], package_layers = []):
     native.genrule(
@@ -6,7 +7,7 @@ def dataform_npm_package(name, deps, srcs = [], package_layers = []):
         srcs = package_layers,
         tools = ["//tools/json-merge:bin"],
         outs = ["package.json"],
-        cmd = "$(location //tools/json-merge:bin) --output-path $(OUTS) --layer-paths $(SRCS)",
+        cmd = "$(location //tools/json-merge:bin) --output-path $(OUTS) --layer-paths $(SRCS) --substitutions '{{ \"$$DF_VERSION\": \"{df_version}\" }}'".format(df_version = DF_VERSION),
     )
 
     npm_package(

--- a/version.bzl
+++ b/version.bzl
@@ -1,0 +1,1 @@
+DF_VERSION = "1.0.0-alpha.3"


### PR DESCRIPTION
This allows us to control dependency versions along with the package versions too.

This is so I can publish the following: https://github.com/dataform-co/dataform-co/pull/924