### PR TITLE
Escape embedded expressions inside SQLX comments so that they aren't interpreted as expressions at compile-time.

### DIFF
--- a/core/sqlx_parser.ts
+++ b/core/sqlx_parser.ts
@@ -220,11 +220,11 @@ function buildSqlxLexer() {
   };
   sqlLexer[SQL_LEXER_TOKEN_NAMES.SINGLE_LINE_COMMENT] = {
     match: /--.*?$/,
-    value: (value: string) => value.replace(/`/g, "\\`")
+    value: (value: string) => value.replace(/`/g, "\\`").replace(/\${/g, "\\${")
   };
   sqlLexer[SQL_LEXER_TOKEN_NAMES.MULTI_LINE_COMMENT] = {
     match: /\/\*[\s\S]*?\*\//,
-    value: (value: string) => value.replace(/`/g, "\\`")
+    value: (value: string) => value.replace(/`/g, "\\`").replace(/\${/g, "\\${")
   };
   sqlLexer[SQL_LEXER_TOKEN_NAMES.SINGLE_QUOTE_STRING] = /'(?:\\['\\]|[^\n'\\])*'/;
   sqlLexer[SQL_LEXER_TOKEN_NAMES.DOUBLE_QUOTE_STRING] = /"(?:\\["\\]|[^\n"\\])*"/;

--- a/examples/bigquery_language_v2/definitions/example_table.sqlx
+++ b/examples/bigquery_language_v2/definitions/example_table.sqlx
@@ -1,9 +1,9 @@
 config { type: "table" }
 select * from ${ref("sample_data")}
 
--- here is a `comment
+-- here ${"is"} a `comment
 
-/* another ` backtick ` containing ```comment */
+/* ${"another"} ` backtick ` containing ```comment */
 
 post_operations {
     GRANT SELECT ON ${self()} TO GROUP "allusers@dataform.co"

--- a/scripts/publish
+++ b/scripts/publish
@@ -1,6 +1,16 @@
 #!/bin/bash
 set -e
 
+if [ "$(git status --porcelain)" ]; then 
+    echo "There are uncommitted changes; aborting." 1>&2
+    exit 1
+fi
+
+if [ "master" == "$(git branch --show-current)" ]; then 
+    echo "Not on the 'master' branch; aborting." 1>&2
+    exit 1
+fi
+
 # Run all the tests.
 
 bazel test //...

--- a/scripts/publish
+++ b/scripts/publish
@@ -6,7 +6,7 @@ if [ "$(git status --porcelain)" ]; then
     exit 1
 fi
 
-if [ "master" == "$(git branch --show-current)" ]; then 
+if [ "master" != "$(git branch --show-current)" ]; then 
     echo "Not on the 'master' branch; aborting." 1>&2
     exit 1
 fi

--- a/tests/api/api.spec.ts
+++ b/tests/api/api.spec.ts
@@ -667,7 +667,7 @@ describe("@dataform/api", () => {
         expect(exampleTable.query.trim()).equals(
           `select * from \`tada-analytics.${schemaWithSuffix(
             "df_integration_test"
-          )}.sample_data\`\n\n-- here is a \`comment\n\n/* another \` backtick \` containing \`\`\`comment */`
+          )}.sample_data\`\n\n-- here \${"is"} a \`comment\n\n/* \${"another"} \` backtick \` containing \`\`\`comment */`
         );
         expect(exampleTable.dependencies).deep.equals(["sample_data"]);
         expect(exampleTable.preOps).to.eql([]);
@@ -747,7 +747,7 @@ describe("@dataform/api", () => {
         // Check testcase.
         const testCase = graph.tests.find(t => t.name === "example_test_case");
         expect(testCase.testQuery.trim()).equals(
-          "select * from (\n    select 'hi' as faked union all\n    select 'ben' as faked union all\n    select 'sup?' as faked\n)\n\n-- here is a `comment\n\n/* another ` backtick ` containing ```comment */"
+          "select * from (\n    select 'hi' as faked union all\n    select 'ben' as faked union all\n    select 'sup?' as faked\n)\n\n-- here ${\"is\"} a `comment\n\n/* ${\"another\"} ` backtick ` containing ```comment */"
         );
         expect(testCase.expectedOutputQuery.trim()).equals(
           "select 'hi' as faked union all\nselect 'ben' as faked union all\nselect 'sup?' as faked"

--- a/version.bzl
+++ b/version.bzl
@@ -1,3 +1,3 @@
 # NOTE: If you change the format of this line, you must change the bash command
 # in /scripts/publish to extract the version string correctly.
-DF_VERSION = "1.0.3"
+DF_VERSION = "1.0.4"


### PR DESCRIPTION
fixes #309