### PR TITLE
Add an integration test that loads data into snowflake via S3.

### DIFF
--- a/core/compilers.ts
+++ b/core/compilers.ts
@@ -118,7 +118,7 @@ switch (sqlxConfig.type) {
   case "incremental":
   case "inline": {
     action.query(ctx => {
-      ${["self", "ref", "resolve"].map(name => `const ${name} = ctx.${name}.bind(ctx);`).join("\n")}
+      ${["self", "ref", "resolve", "name"].map(name => `const ${name} = ctx.${name}.bind(ctx);`).join("\n")}
       ${results.js}
       if (hasIncremental) {
         action.where(\`${results.incremental}\`);
@@ -145,7 +145,7 @@ switch (sqlxConfig.type) {
   }
   case "operations": {
     action.queries(ctx => {
-      ${["self", "ref", "resolve"].map(name => `const ${name} = ctx.${name}.bind(ctx);`).join("\n")}
+      ${["self", "ref", "resolve", "name"].map(name => `const ${name} = ctx.${name}.bind(ctx);`).join("\n")}
       ${results.js}
       const operations = [${results.sql.map(sql => `\`${sql}\``)}];
       return operations;

--- a/core/operation.ts
+++ b/core/operation.ts
@@ -63,6 +63,10 @@ export class OperationContext {
     return this.resolve(this.operation.proto.name);
   }
 
+  public name(): string {
+    return this.operation.proto.name;
+  }
+
   public ref(name: string) {
     this.operation.dependencies(name);
     return this.resolve(name);

--- a/core/session.ts
+++ b/core/session.ts
@@ -76,11 +76,6 @@ export class Session {
         "Actions may only specify 'hasOutput: true' if they are of type 'operations' or create a dataset."
       );
     }
-    if (actionOptions.sqlxConfig.hasOutput && actionOptions.sqlStatementCount !== 1) {
-      this.compileError(
-        "Operations with 'hasOutput: true' must contain exactly one SQL statement."
-      );
-    }
     if (actionOptions.sqlxConfig.protected && actionOptions.sqlxConfig.type !== "incremental") {
       this.compileError(
         "Actions may only specify 'protected: true' if they are of type 'incremental'."

--- a/core/table.ts
+++ b/core/table.ts
@@ -216,6 +216,7 @@ export class Table {
 export interface ITableContext {
   config: (config: TConfig) => string;
   self: () => string;
+  name: () => string;
   ref: (name: string) => string;
   resolve: (name: string) => string;
   type: (type: TableType) => string;
@@ -249,6 +250,10 @@ export class TableContext implements ITableContext {
 
   public self(): string {
     return this.resolve(this.table.proto.name);
+  }
+
+  public name(): string {
+    return this.table.proto.name;
   }
 
   public ref(name: string) {

--- a/core/test.ts
+++ b/core/test.ts
@@ -104,6 +104,10 @@ class RefReplacingContext implements table.ITableContext {
     return "";
   }
 
+  public name() {
+    return "";
+  }
+
   public type(type: table.TableType) {
     return "";
   }

--- a/examples/bigquery_language_v2/definitions/has_compile_errors/op_with_output_multiple_statements.sqlx
+++ b/examples/bigquery_language_v2/definitions/has_compile_errors/op_with_output_multiple_statements.sqlx
@@ -1,4 +1,0 @@
-config { hasOutput: true }
-select 1 as test
----
-select 2 as test

--- a/tests/api/api.spec.ts
+++ b/tests/api/api.spec.ts
@@ -647,10 +647,6 @@ describe("@dataform/api", () => {
                 message: "Actions may only specify 'disabled: true' if they create a dataset."
               }),
               dataform.CompilationError.create({
-                fileName: "definitions/has_compile_errors/op_with_output_multiple_statements.sqlx",
-                message: "Operations with 'hasOutput: true' must contain exactly one SQL statement."
-              }),
-              dataform.CompilationError.create({
                 fileName: "definitions/has_compile_errors/protected_assertion.sqlx",
                 message:
                   "Actions may only specify 'protected: true' if they are of type 'incremental'."

--- a/tests/integration/snowflake.spec.ts
+++ b/tests/integration/snowflake.spec.ts
@@ -58,6 +58,15 @@ describe("@dataform/integration/snowflake", () => {
 
     const actionMap = keyBy(executedGraph.actions, v => v.name);
 
+    // Check the status of the s3 load operation.
+    expect(actionMap.load_from_s3.status).equals(dataform.ActionExecutionStatus.SUCCESSFUL);
+
+    // Check the s3 table has two rows, as per:
+    // https://dataform-integration-tests.s3.us-east-2.amazonaws.com/sample-data/sample_data.csv
+    const s3Table = keyBy(compiledGraph.operations, t => t.name).load_from_s3;
+    const s3Rows = await getTableRows(s3Table.target, adapter, dbadapter);
+    expect(s3Rows.length).equals(2);
+  
     // Check the status of the two assertions.
     expect(actionMap.example_assertion_fail.status).equals(dataform.ActionExecutionStatus.FAILED);
     expect(actionMap.example_assertion_pass.status).equals(

--- a/tests/integration/snowflake_project/definitions/load_from_s3.sqlx
+++ b/tests/integration/snowflake_project/definitions/load_from_s3.sqlx
@@ -1,0 +1,30 @@
+config {
+  type: "operations",
+  hasOutput: true
+}
+ 
+-- Create a temp table to load the s3 data into with the correct schema.
+create or replace table ${resolve(`${name}_temp`)}
+(
+  country string,
+  revenue float
+);
+
+---
+-- Copy the data from s3 into the temporary table.
+copy into ${resolve(`${name}_temp`)}
+from 's3://dataform-integration-tests/sample-data/sample_data.csv'         
+file_format = (
+  type=csv,
+  skip_header=1,
+  field_optionally_enclosed_by='"'
+)
+;
+
+---
+-- Drop the actual table.
+drop table if exists ${self()} cascade;
+
+---
+-- Rename the temporary table to the actual table name.
+alter table ${resolve(`${name}_temp`)} rename to ${self()}


### PR DESCRIPTION
Also adds support multiple queries in operations with `hasOutput`, and add a `name()` function to make it easier to work with temp tables.