### PR TITLE
Change tsconfig.json tslint configuration

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
     "skipLibCheck": true,
     "experimentalDecorators": true,
     "jsx": "react",
-    "lib": ["es6", "dom"]
+    "lib": ["es2017" ,"dom"]
   },
   "exclude": ["bazel-*", "node_modules"]
 }


### PR DESCRIPTION
This fixes some strange situations where using a `.includes(...)` on a `string[]` object was red-marked by the linter as an error.