### PR TITLE
Fix fully-qualified dependencies.

### DIFF
--- a/core/assertion.ts
+++ b/core/assertion.ts
@@ -44,7 +44,7 @@ export class Assertion {
   public dependencies(value: Resolvable | Resolvable[]) {
     const newDependencies = utils.isResolvable(value) ? [value] : (value as Resolvable[]);
     newDependencies.forEach((d: Resolvable) => {
-      const depName = utils.appendSuffixToSchema(d, this.session.getSuffixWithUnderscore());
+      const depName = utils.stringifyResolvable(d);
       if (this.proto.dependencies.indexOf(depName) < 0) {
         this.proto.dependencies.push(depName);
       }
@@ -68,9 +68,7 @@ export class Assertion {
   }
 
   public schema(schema: string) {
-    if (schema !== this.session.config.assertionSchema) {
-      this.session.setNameAndTarget(this.proto, this.proto.target.name, schema);
-    }
+    this.session.setNameAndTarget(this.proto, this.proto.target.name, schema);
     return this;
   }
 

--- a/core/operation.ts
+++ b/core/operation.ts
@@ -57,7 +57,7 @@ export class Operation {
   public dependencies(value: Resolvable | Resolvable[]) {
     const newDependencies = utils.isResolvable(value) ? [value] : (value as Resolvable[]);
     newDependencies.forEach((d: Resolvable) => {
-      const depName = utils.appendSuffixToSchema(d, this.session.getSuffixWithUnderscore());
+      const depName = utils.stringifyResolvable(d);
       if (this.proto.dependencies.indexOf(depName) < 0) {
         this.proto.dependencies.push(depName);
       }
@@ -97,9 +97,7 @@ export class Operation {
   }
 
   public schema(schema: string) {
-    if (schema !== this.session.config.defaultSchema) {
-      this.session.setNameAndTarget(this.proto, this.proto.target.name, schema);
-    }
+    this.session.setNameAndTarget(this.proto, this.proto.target.name, schema);
     return this;
   }
 

--- a/core/session.ts
+++ b/core/session.ts
@@ -212,14 +212,6 @@ export class Session {
     return action;
   }
 
-  public target(name: string, schema: string): dataform.ITarget {
-    const adapter = this.adapter();
-    return dataform.Target.create({
-      name: adapter.normalizeIdentifier(name),
-      schema: adapter.normalizeIdentifier(schema)
-    });
-  }
-
   public resolve(ref: Resolvable): string {
     const allResolved = this.findActions(ref);
     if (allResolved.length > 1) {
@@ -238,24 +230,28 @@ export class Session {
       );
     }
 
-    // TODO: We fall back to using the plain 'name' here for backwards compatibility with projects that use .sql files.
-    // In these projects, this session may not know about all actions (yet), and thus we need to fall back to assuming
-    // that the target *will* exist in the future. Once we break backwards compatibility with .sql files, we should remove
-    // the code that calls 'this.target(...)' below, and append a compile error if we can't find a dataset whose name is 'name'.
-
-    const target = resolved
-      ? {
-          schema:
-            resolved instanceof Declaration
-              ? resolved.proto.target.schema
-              : `${resolved.proto.target.schema}${this.getSuffixWithUnderscore()}`,
-          name: resolved.proto.target.name
-        }
-      : this.target(
-          typeof ref === "string" ? ref : ref.name,
-          `${this.config.defaultSchema}${this.getSuffixWithUnderscore()}`
-        );
-    return this.adapter().resolveTarget(target);
+    if (resolved) {
+      if (resolved instanceof Declaration) {
+        return this.adapter().resolveTarget(resolved.proto.target);
+      }
+      return this.adapter().resolveTarget({
+        ...resolved.proto.target,
+        schema: `${resolved.proto.target.schema}${this.getSuffixWithUnderscore()}`
+      });
+    }
+    // TODO: Here we allow 'ref' to go unresolved. This is for backwards compatibility with projects
+    // that use .sql files. In these projects, this session may not know about all actions (yet), and
+    // thus we need to fall back to assuming that the target *will* exist in the future. Once we break
+    // backwards compatibility with .sql files, we should remove the below code, and append a compile
+    // error instead.
+    if (typeof ref === "string") {
+      return this.adapter().resolveTarget(
+        this.target(ref, `${this.config.defaultSchema}${this.getSuffixWithUnderscore()}`)
+      );
+    }
+    return this.adapter().resolveTarget(
+      this.target(ref.name, `${ref.schema}${this.getSuffixWithUnderscore()}`)
+    );
   }
 
   public operate(name: string, queries?: OContextable<string | string[]>): Operation {
@@ -304,18 +300,13 @@ export class Session {
   public declare(dataset: FullyQualifiedName): Declaration {
     const declaration = new Declaration();
     declaration.session = this;
-    // We intentionally do not use setNameAndTarget(...) here because that might add a schema suffix,
-    // which would be incorrect in the case of declarations.
-    this.checkTargetIsUnused(dataset);
-    declaration.proto.target = dataset;
-    declaration.proto.name = `${dataset.schema}.${dataset.name}`;
+    this.setNameAndTarget(declaration.proto, dataset.name, dataset.schema);
     declaration.proto.fileName = utils.getCallerFile(this.rootDir);
     this.actions.push(declaration);
     return declaration;
   }
 
   public test(name: string): test.Test {
-    this.checkTestNameIsUnused(name);
     const newTest = new test.Test();
     newTest.session = this;
     newTest.proto.name = name;
@@ -340,21 +331,6 @@ export class Session {
     this.graphErrors.compilationErrors.push(compileError);
   }
 
-  public compileGraphChunk<T>(actions: Array<{ proto: IActionProto; compile(): T }>): T[] {
-    const compiledChunks: T[] = [];
-
-    actions.forEach(action => {
-      try {
-        const compiledChunk = action.compile();
-        compiledChunks.push(compiledChunk);
-      } catch (e) {
-        this.compileError(e, action.proto.fileName);
-      }
-    });
-
-    return compiledChunks;
-  }
-
   public compile(): dataform.ICompiledGraph {
     const compiledGraph = dataform.CompiledGraph.create({
       projectConfig: this.config,
@@ -372,67 +348,29 @@ export class Session {
       graphErrors: this.graphErrors
     });
 
-    const allActionsByName: { [name: string]: IActionProto } = {};
-    ([] as IActionProto[])
-      .concat(
+    this.fullyQualifyDependencies(
+      [].concat(compiledGraph.tables, compiledGraph.assertions, compiledGraph.operations)
+    );
+
+    if (!!this.config.schemaSuffix) {
+      this.appendSchemaSuffix(
+        [].concat(compiledGraph.tables, compiledGraph.assertions, compiledGraph.operations)
+      );
+    }
+
+    this.checkActionNameUniqueness(
+      [].concat(
         compiledGraph.tables,
         compiledGraph.assertions,
         compiledGraph.operations,
         compiledGraph.declarations
       )
-      .forEach(action => (allActionsByName[action.name] = action));
+    );
+    this.checkTestNameUniqueness(compiledGraph.tests);
 
-    ([] as IActionProto[])
-      .concat(compiledGraph.tables, compiledGraph.assertions, compiledGraph.operations)
-      .forEach(action => {
-        action.target = {
-          ...action.target,
-          schema: `${action.target.schema}${this.getSuffixWithUnderscore()}`
-        };
-        action.name = `${action.target.schema}.${action.target.name}`;
-      });
-
-    Object.values(allActionsByName).forEach(action => {
-      const fQDeps = (action.dependencies || []).map(act => {
-        const allActs = this.findActions(act);
-        if (allActs.length === 1) {
-          return `${allActs[0].proto.target.schema}.${allActs[0].proto.target.name}`;
-        } else if (allActs.length >= 1) {
-          this.compileError(new Error(utils.ambiguousActionNameMsg(act, allActs)));
-          return act;
-        } else {
-          this.compileError(
-            new Error(
-              `Missing dependency detected: Node "${action.name}" depends on "${act}" which does not exist.`
-            )
-          );
-          return act;
-        }
-      });
-      action.dependencies = [...new Set(fQDeps || [])];
-    });
-
-    // Check for circular dependencies.
-    const checkCircular = (action: IActionProto, dependents: IActionProto[]): boolean => {
-      if (dependents.indexOf(action) >= 0) {
-        const message = `Circular dependency detected in chain: [${dependents
-          .map(d => d.name)
-          .join(" > ")} > ${action.name}]`;
-        this.compileError(new Error(message));
-        return true;
-      }
-      return (action.dependencies || []).some(d => {
-        return (
-          allActionsByName[d] && checkCircular(allActionsByName[d], dependents.concat([action]))
-        );
-      });
-    };
-
-    for (const action of Object.values(allActionsByName)) {
-      if (checkCircular(action, [])) {
-        break;
-      }
-    }
+    this.checkCircularity(
+      [].concat(compiledGraph.tables, compiledGraph.assertions, compiledGraph.operations)
+    );
 
     return compiledGraph;
   }
@@ -455,33 +393,134 @@ export class Session {
     });
   }
 
-  public checkTargetIsUnused(target: dataform.ITarget) {
-    const duplicateActions = this.findActions({ schema: target.schema, name: target.name });
-    if (duplicateActions && duplicateActions.length > 0) {
-      this.compileError(
-        new Error(
-          `Duplicate action name detected. Names within a schema must be unique across tables, assertions, and operations: "${target.schema}.${target.name}"`
-        )
-      );
-    }
-  }
-
-  public getSuffixWithUnderscore() {
-    return !!this.config.schemaSuffix ? `_${this.config.schemaSuffix}` : "";
-  }
-
   public setNameAndTarget(action: IActionProto, name: string, overrideSchema?: string) {
     const newTarget = this.target(name, overrideSchema || this.config.defaultSchema);
-    this.checkTargetIsUnused(newTarget);
     action.target = newTarget;
     action.name = `${action.target.schema}.${action.target.name}`;
   }
 
-  private checkTestNameIsUnused(name: string) {
-    // Check for duplicate names
-    if (this.tests[name]) {
-      const message = `Duplicate test name detected: "${name}"`;
-      this.compileError(new Error(message));
+  private getSuffixWithUnderscore() {
+    return !!this.config.schemaSuffix ? `_${this.config.schemaSuffix}` : "";
+  }
+
+  private compileGraphChunk<T>(actions: Array<{ proto: IActionProto; compile(): T }>): T[] {
+    const compiledChunks: T[] = [];
+
+    actions.forEach(action => {
+      try {
+        const compiledChunk = action.compile();
+        compiledChunks.push(compiledChunk);
+      } catch (e) {
+        this.compileError(e, action.proto.fileName);
+      }
+    });
+
+    return compiledChunks;
+  }
+
+  private target(name: string, schema: string): dataform.ITarget {
+    const adapter = this.adapter();
+    return dataform.Target.create({
+      name: adapter.normalizeIdentifier(name),
+      schema: adapter.normalizeIdentifier(schema)
+    });
+  }
+
+  private fullyQualifyDependencies(actions: IActionProto[]) {
+    const allActionsByName = keyByName(actions);
+    actions.forEach(action => {
+      action.dependencies = (action.dependencies || []).map(dependencyName => {
+        if (!!allActionsByName[dependencyName]) {
+          // Dependency is already fully-qualified.
+          return dependencyName;
+        }
+        const possibleDeps = this.findActions(dependencyName);
+        if (possibleDeps.length === 1) {
+          return possibleDeps[0].proto.name;
+        }
+        if (possibleDeps.length >= 1) {
+          this.compileError(new Error(utils.ambiguousActionNameMsg(dependencyName, possibleDeps)));
+        } else {
+          this.compileError(
+            new Error(
+              `Missing dependency detected: Action "${action.name}" depends on "${dependencyName}" which does not exist.`
+            )
+          );
+        }
+        return dependencyName;
+      });
+    });
+  }
+
+  private appendSchemaSuffix(actions: IActionProto[]) {
+    const suffixedNames: { [originalName: string]: string } = {};
+    actions.forEach(action => {
+      const originalName = action.name;
+      action.target = {
+        ...action.target,
+        schema: `${action.target.schema}${this.getSuffixWithUnderscore()}`
+      };
+      action.name = `${action.target.schema}.${action.target.name}`;
+      suffixedNames[originalName] = action.name;
+    });
+
+    // Fix up dependencies in case those dependencies' names have changed.
+    actions.forEach(action => {
+      action.dependencies = (action.dependencies || []).map(
+        dependencyName => suffixedNames[dependencyName] || dependencyName
+      );
+    });
+  }
+
+  private checkActionNameUniqueness(actions: IActionProto[]) {
+    const allNames: string[] = [];
+    actions
+      .map(action => action.name)
+      .forEach(name => {
+        if (allNames.includes(name)) {
+          this.compileError(
+            new Error(
+              `Duplicate action name detected. Names within a schema must be unique across tables, declarations, assertions, and operations: "${name}"`
+            )
+          );
+        }
+        allNames.push(name);
+      });
+  }
+
+  private checkTestNameUniqueness(tests: dataform.ITest[]) {
+    const allNames: string[] = [];
+    tests
+      .map(testProto => testProto.name)
+      .forEach(name => {
+        if (allNames.includes(name)) {
+          this.compileError(new Error(`Duplicate test name detected: "${name}"`));
+        }
+        allNames.push(name);
+      });
+  }
+
+  private checkCircularity(actions: IActionProto[]) {
+    const allActionsByName = keyByName(actions);
+    const checkCircular = (action: IActionProto, dependents: IActionProto[]): boolean => {
+      if (dependents.indexOf(action) >= 0) {
+        const message = `Circular dependency detected in chain: [${dependents
+          .map(d => d.name)
+          .join(" > ")} > ${action.name}]`;
+        this.compileError(new Error(message));
+        return true;
+      }
+      return (action.dependencies || []).some(
+        dependencyName =>
+          allActionsByName[dependencyName] &&
+          checkCircular(allActionsByName[dependencyName], dependents.concat([action]))
+      );
+    };
+
+    for (const action of actions) {
+      if (checkCircular(action, [])) {
+        break;
+      }
     }
   }
 }
@@ -492,4 +531,10 @@ function declaresDataset(type: string, hasOutput?: boolean) {
 
 function definesDataset(type: string) {
   return type === "view" || type === "table" || type === "inline" || type === "incremental";
+}
+
+function keyByName(actions: IActionProto[]) {
+  const actionsByName: { [name: string]: IActionProto } = {};
+  actions.forEach(action => (actionsByName[action.name] = action));
+  return actionsByName;
 }

--- a/core/session.ts
+++ b/core/session.ts
@@ -394,8 +394,7 @@ export class Session {
   }
 
   public setNameAndTarget(action: IActionProto, name: string, overrideSchema?: string) {
-    const newTarget = this.target(name, overrideSchema || this.config.defaultSchema);
-    action.target = newTarget;
+    action.target = this.target(name, overrideSchema || this.config.defaultSchema);
     action.name = `${action.target.schema}.${action.target.name}`;
   }
 

--- a/core/session.ts
+++ b/core/session.ts
@@ -444,7 +444,8 @@ export class Session {
           this.compileError(
             new Error(
               `Missing dependency detected: Action "${action.name}" depends on "${dependencyName}" which does not exist.`
-            )
+            ),
+            action.fileName
           );
         }
         return dependencyName;
@@ -474,30 +475,30 @@ export class Session {
 
   private checkActionNameUniqueness(actions: IActionProto[]) {
     const allNames: string[] = [];
-    actions
-      .map(action => action.name)
-      .forEach(name => {
-        if (allNames.includes(name)) {
-          this.compileError(
-            new Error(
-              `Duplicate action name detected. Names within a schema must be unique across tables, declarations, assertions, and operations: "${name}"`
-            )
-          );
-        }
-        allNames.push(name);
-      });
+    actions.forEach(action => {
+      if (allNames.includes(action.name)) {
+        this.compileError(
+          new Error(
+            `Duplicate action name detected. Names within a schema must be unique across tables, declarations, assertions, and operations: "${action.name}"`
+          ),
+          action.fileName
+        );
+      }
+      allNames.push(action.name);
+    });
   }
 
   private checkTestNameUniqueness(tests: dataform.ITest[]) {
     const allNames: string[] = [];
-    tests
-      .map(testProto => testProto.name)
-      .forEach(name => {
-        if (allNames.includes(name)) {
-          this.compileError(new Error(`Duplicate test name detected: "${name}"`));
-        }
-        allNames.push(name);
-      });
+    tests.forEach(testProto => {
+      if (allNames.includes(testProto.name)) {
+        this.compileError(
+          new Error(`Duplicate test name detected: "${testProto.name}"`),
+          testProto.fileName
+        );
+      }
+      allNames.push(testProto.name);
+    });
   }
 
   private checkCircularity(actions: IActionProto[]) {
@@ -507,7 +508,7 @@ export class Session {
         const message = `Circular dependency detected in chain: [${dependents
           .map(d => d.name)
           .join(" > ")} > ${action.name}]`;
-        this.compileError(new Error(message));
+        this.compileError(new Error(message), action.fileName);
         return true;
       }
       return (action.dependencies || []).some(

--- a/core/table.ts
+++ b/core/table.ts
@@ -157,13 +157,12 @@ export class Table {
     newDependencies.forEach((d: Resolvable) => {
       // TODO: This code fails to function correctly if the inline table has not yet
       // been attached to the session. This code probably needs to be moved to compile().
-      const depFinal = utils.appendSuffixToSchema(d, this.session.getSuffixWithUnderscore());
-      const allResolved = this.session.findActions(depFinal);
+      const allResolved = this.session.findActions(d);
       const resolved = allResolved.length > 0 ? allResolved[0] : undefined;
       if (!!resolved && resolved instanceof Table && resolved.proto.type === "inline") {
         resolved.proto.dependencies.forEach(childDep => this.addDependency(childDep));
       } else {
-        this.addDependency(depFinal);
+        this.addDependency(d);
       }
     });
     return this;
@@ -194,9 +193,7 @@ export class Table {
   }
 
   public schema(schema: string) {
-    if (schema !== this.session.config.defaultSchema) {
-      this.session.setNameAndTarget(this.proto, this.proto.target.name, schema);
-    }
+    this.session.setNameAndTarget(this.proto, this.proto.target.name, schema);
     return this;
   }
 
@@ -212,7 +209,7 @@ export class Table {
     this.contextablePreOps.forEach(contextablePreOps => {
       const appliedPres = context.apply(contextablePreOps);
       this.proto.preOps = (this.proto.preOps || []).concat(
-        typeof appliedPres == "string" ? [appliedPres] : appliedPres
+        typeof appliedPres === "string" ? [appliedPres] : appliedPres
       );
     });
     this.contextablePreOps = [];
@@ -220,7 +217,7 @@ export class Table {
     this.contextablePostOps.forEach(contextablePostOps => {
       const appliedPosts = context.apply(contextablePostOps);
       this.proto.postOps = (this.proto.postOps || []).concat(
-        typeof appliedPosts == "string" ? [appliedPosts] : appliedPosts
+        typeof appliedPosts === "string" ? [appliedPosts] : appliedPosts
       );
     });
     this.contextablePostOps = [];

--- a/core/test.ts
+++ b/core/test.ts
@@ -48,18 +48,11 @@ export class Test {
         this.proto.fileName
       );
     } else {
-      const datasetToTestFinal = {
-        schema:
-          typeof this.datasetToTest === "string"
-            ? this.session.config.defaultSchema
-            : this.datasetToTest.schema,
-        name: typeof this.datasetToTest === "string" ? this.datasetToTest : this.datasetToTest.name
-      };
-
-      const allResolved = this.session.findActions(datasetToTestFinal);
+      const allResolved = this.session.findActions(this.datasetToTest);
       if (allResolved.length > 1) {
         this.session.compileError(
-          new Error(utils.ambiguousActionNameMsg(datasetToTestFinal, allResolved))
+          new Error(utils.ambiguousActionNameMsg(this.datasetToTest, allResolved)),
+          this.proto.fileName
         );
       }
       const dataset = allResolved.length > 0 ? allResolved[0] : undefined;

--- a/core/test.ts
+++ b/core/test.ts
@@ -48,12 +48,13 @@ export class Test {
         this.proto.fileName
       );
     } else {
-      const datasetToTestFinal =
-        typeof this.datasetToTest === "string"
-          ? utils.targetAsResolvable(this.session.target(this.datasetToTest))
-          : utils.targetAsResolvable(
-              this.session.target(`${this.datasetToTest.schema}.${this.datasetToTest.name}`)
-            );
+      const datasetToTestFinal = {
+        schema:
+          typeof this.datasetToTest === "string"
+            ? this.session.config.defaultSchema
+            : this.datasetToTest.schema,
+        name: typeof this.datasetToTest === "string" ? this.datasetToTest : this.datasetToTest.name
+      };
 
       const allResolved = this.session.findActions(datasetToTestFinal);
       if (allResolved.length > 1) {

--- a/examples/bigquery_language_v2/definitions/example_assertion_with_tags.sqlx
+++ b/examples/bigquery_language_v2/definitions/example_assertion_with_tags.sqlx
@@ -3,4 +3,4 @@ config {
     tags: ["tag1", "tag2"]
 }
 
-select * from ${ref("sample_data")} where sample = 100
+select * from ${ref({ schema: "df_integration_test", name: "sample_data" })} where sample = 100

--- a/version.bzl
+++ b/version.bzl
@@ -1,3 +1,3 @@
 # NOTE: If you change the format of this line, you must change the bash command
 # in /scripts/publish to extract the version string correctly.
-DF_VERSION = "1.3.2"
+DF_VERSION = "1.3.3"


### PR DESCRIPTION
- Move schema suffixing to only happen at compile()-time, after all contextable queries have run (because otherwise the code has to constantly be aware of actions that effectively have two names, one with and one without the suffix)
- Move dependency checking / qualification to compile()-time (the only safe time to do it since we allow schema overrides)

fixes https://github.com/dataform-co/dataform/issues/411