### PR TITLE
Better formatting for JS.

### DIFF
--- a/api/commands/format.ts
+++ b/api/commands/format.ts
@@ -7,7 +7,8 @@ import { promisify } from "util";
 
 const JS_BEAUTIFY_OPTIONS: JsBeautifyOptions = {
   indent_size: 2,
-  preserve_newlines: false
+  preserve_newlines: true,
+  max_preserve_newlines: 2
 };
 
 export async function formatFile(

--- a/api/commands/format.ts
+++ b/api/commands/format.ts
@@ -24,7 +24,7 @@ export async function formatFile(
         case "sqlx":
           return formatSqlx(constructSyntaxTree(fileText));
         case "js":
-          return formatJavaScript(fileText);
+          return `${formatJavaScript(fileText).trim()}\n`;
         default:
           return fileText;
       }


### PR DESCRIPTION
- Preserve up to one empty line
- Insert a newline at EOF

for dataform-co/dataform-co#142