### PR TITLE
More formatter fixes to make it run on dataform-data.

### DIFF
--- a/api/commands/format.ts
+++ b/api/commands/format.ts
@@ -11,7 +11,7 @@ const JS_BEAUTIFY_OPTIONS: JsBeautifyOptions = {
   max_preserve_newlines: 2
 };
 
-const TEXT_LIFT_PATTERNS = [/r'(\\['\\]|[^\n'\\])*'/, /"(\\["\\]|[^\n"\\])*"/];
+const TEXT_LIFT_PATTERNS = [/r'(\\['\\]|[^\n'\\])*'/, /r"(\\["\\]|[^\n"\\])*"/];
 
 export async function formatFile(
   filename: string,
@@ -54,7 +54,7 @@ function formatSqlx(node: ISyntaxTreeNode, indent: string = "") {
         individualStatement,
         placeholders
       ).join("");
-      const formattedPlaceholderSql = sqlFormatter.format(unformattedPlaceholderSql) as string;
+      const formattedPlaceholderSql = formatSql(unformattedPlaceholderSql);
       return formatEveryLine(
         replacePlaceholders(formattedPlaceholderSql, placeholders),
         line => `${indent}${line}`
@@ -119,6 +119,10 @@ function replacePlaceholders(
 
 function formatJavaScript(text: string) {
   return jsBeautify.js(text, JS_BEAUTIFY_OPTIONS);
+}
+
+function formatSql(text: string) {
+  return sqlFormatter.format(text) as string;
 }
 
 function formatPlaceholderInSqlx(

--- a/sqlx/lexer.ts
+++ b/sqlx/lexer.ts
@@ -61,7 +61,7 @@ const INNER_SQL_BLOCK_LEXER_TOKEN_NAMES = {
 const lexer = moo.states(buildSqlxLexer());
 
 export interface ISyntaxTreeNode {
-  contentType: "sql" | "js" | "jsPlaceholder" | "sqlStatementSeparator";
+  contentType: "sql" | "js" | "jsPlaceholder" | "sqlStatementSeparator" | "sqlComment";
   contents: Array<string | ISyntaxTreeNode>;
 }
 
@@ -104,6 +104,14 @@ export function constructSyntaxTree(code: string): ISyntaxTreeNode {
     } else if (token.type.endsWith("_statementSeparator")) {
       currentNode.contents.push({
         contentType: "sqlStatementSeparator",
+        contents: [token.value]
+      });
+    } else if (
+      (token.type.startsWith("sql") || token.type.startsWith("innerSqlBlock")) &&
+      token.type.endsWith("Comment")
+    ) {
+      currentNode.contents.push({
+        contentType: "sqlComment",
         contents: [token.value]
       });
     } else {


### PR DESCRIPTION
- run post-processing only after the whole file is formatted
- fix double-quote regexp lifting regexp
- push comments to their own lines
- change formatter to always place config/JS blocks first, then SQL statements, then "inner" SQL blocks

for https://github.com/dataform-co/dataform-co/issues/142