### PR TITLE
If incremental (alpha)

### DIFF
--- a/core/adapters/base.ts
+++ b/core/adapters/base.ts
@@ -34,6 +34,6 @@ export abstract class Adapter {
 
   protected where(query: string, where: string) {
     return `select * from (${query}) as subquery
-        where ${where}`;
+        where ${where || "true"}`;
   }
 }

--- a/core/adapters/bigquery.ts
+++ b/core/adapters/bigquery.ts
@@ -38,7 +38,7 @@ export class BigQueryAdapter extends Adapter implements IAdapter {
             this.insertInto(
               table.target,
               tableMetadata.fields.map(f => f.name),
-              this.where(table.query, table.where)
+              this.where(table.incrementalQuery || table.query, table.where)
             )
           )
         );

--- a/core/adapters/redshift.ts
+++ b/core/adapters/redshift.ts
@@ -37,7 +37,7 @@ export class RedshiftAdapter extends Adapter implements IAdapter {
             this.insertInto(
               table.target,
               tableMetadata.fields.map(f => f.name),
-              this.where(table.query, table.where)
+              this.where(table.incrementalQuery || table.query, table.where)
             )
           )
         );

--- a/core/adapters/snowflake.ts
+++ b/core/adapters/snowflake.ts
@@ -41,7 +41,7 @@ export class SnowflakeAdapter extends Adapter implements IAdapter {
             this.insertInto(
               table.target,
               tableMetadata.fields.map(f => f.name),
-              this.where(table.query, table.where)
+              this.where(table.incrementalQuery || table.query, table.where)
             )
           )
         );

--- a/core/adapters/sqldatawarehouse.ts
+++ b/core/adapters/sqldatawarehouse.ts
@@ -30,7 +30,7 @@ export class SQLDataWarehouseAdapter extends Adapter implements IAdapter {
             this.insertInto(
               table.target,
               tableMetadata.fields.map(f => f.name),
-              this.where(table.query, table.where)
+              this.where(table.incrementalQuery || table.query, table.where)
             )
           )
         );

--- a/core/compilers.ts
+++ b/core/compilers.ts
@@ -123,7 +123,7 @@ switch (sqlxConfig.type) {
   case "incremental":
   case "inline": {
     action.query(ctx => {
-      ${["self", "ref", "resolve", "name", "isIncremental"]
+      ${["self", "ref", "resolve", "name", "isIncremental", "ifIncremental"]
         .map(name => `const ${name} = ctx.${name}.bind(ctx);`)
         .join("\n")}
       ${results.js}

--- a/core/compilers.ts
+++ b/core/compilers.ts
@@ -20,10 +20,15 @@ export function compile(code: string, path: string) {
   return code;
 }
 
+// For older versions of @dataform/core, these functions may not actually exist so leave them as undefined.
+function safelyBindCtxFunction(name: string) {
+  return `ctx.${name} ? ctx.${name}.bind(ctx) : undefined`;
+}
+
 function compileTableSql(code: string, path: string) {
   const { sql, js } = extractJsBlocks(code);
   const functionsBindings = getFunctionPropertyNames(TableContext.prototype).map(
-    name => `const ${name} = ctx.${name}.bind(ctx);`
+    name => `const ${name} = ${safelyBindCtxFunction(name)};`
   );
 
   return `
@@ -37,7 +42,7 @@ function compileTableSql(code: string, path: string) {
 function compileOperationSql(code: string, path: string) {
   const { sql, js } = extractJsBlocks(code);
   const functionsBindings = getFunctionPropertyNames(OperationContext.prototype).map(
-    name => `const ${name} = ctx.${name}.bind(ctx);`
+    name => `const ${name} = ${safelyBindCtxFunction(name)};`
   );
 
   return `
@@ -51,7 +56,7 @@ function compileOperationSql(code: string, path: string) {
 function compileAssertionSql(code: string, path: string) {
   const { sql, js } = extractJsBlocks(code);
   const functionsBindings = getFunctionPropertyNames(AssertionContext.prototype).map(
-    name => `const ${name} = ctx.${name}.bind(ctx);`
+    name => `const ${name} = ${safelyBindCtxFunction(name)};`
   );
 
   return `
@@ -118,7 +123,7 @@ switch (sqlxConfig.type) {
   case "incremental":
   case "inline": {
     action.query(ctx => {
-      ${["self", "ref", "resolve", "name"]
+      ${["self", "ref", "resolve", "name", "isIncremental"]
         .map(name => `const ${name} = ctx.${name}.bind(ctx);`)
         .join("\n")}
       ${results.js}

--- a/core/session.ts
+++ b/core/session.ts
@@ -331,7 +331,7 @@ export class Session {
     this.graphErrors.compilationErrors.push(compileError);
   }
 
-  public compile(): dataform.ICompiledGraph {
+  public compile(): dataform.CompiledGraph {
     const compiledGraph = dataform.CompiledGraph.create({
       projectConfig: this.config,
       tables: this.compileGraphChunk(this.actions.filter(action => action instanceof table.Table)),

--- a/core/table.ts
+++ b/core/table.ts
@@ -253,6 +253,7 @@ export interface ITableContext {
   type: (type: TableType) => string;
   where: (where: TContextable<string>) => string;
   isIncremental: () => boolean;
+  ifIncremental: (value: string) => string;
   preOps: (statement: TContextable<string | string[]>) => string;
   postOps: (statement: TContextable<string | string[]>) => string;
   disabled: () => string;
@@ -310,6 +311,10 @@ export class TableContext implements ITableContext {
 
   public isIncremental() {
     return !!this.incremental;
+  }
+
+  public ifIncremental(value: string) {
+    return this.isIncremental() ? value : "";
   }
 
   public preOps(statement: TContextable<string | string[]>) {

--- a/core/test.ts
+++ b/core/test.ts
@@ -140,6 +140,10 @@ class RefReplacingContext implements table.ITableContext {
     return "";
   }
 
+  public isIncremental() {
+    return false;
+  }
+
   public preOps(statement: table.TContextable<string | string[]>) {
     return "";
   }

--- a/core/test.ts
+++ b/core/test.ts
@@ -144,6 +144,11 @@ class RefReplacingContext implements table.ITableContext {
     return false;
   }
 
+  public ifIncremental(value: string) {
+    // Use the non-incremental query for unit tests.
+    return "";
+  }
+
   public preOps(statement: table.TContextable<string | string[]>) {
     return "";
   }

--- a/core/utils.ts
+++ b/core/utils.ts
@@ -124,12 +124,6 @@ export function validate(compiledGraph: dataform.ICompiledGraph): dataform.IGrap
       validationErrors.push(dataform.ValidationError.create({ message, actionName }));
     }
 
-    // "where" property
-    if (action.type === TableTypes.INCREMENTAL && (!action.where || action.where.length === 0)) {
-      const message = `"where" property is not defined. With the type “incremental” you must also specify the property “where”!`;
-      validationErrors.push(dataform.ValidationError.create({ message, actionName }));
-    }
-
     // sqldatawarehouse config
     if (action.sqlDataWarehouse && action.sqlDataWarehouse.distribution) {
       const distribution = action.sqlDataWarehouse.distribution.toUpperCase();

--- a/examples/common_v2/definitions/example_is_incremental.sqlx
+++ b/examples/common_v2/definitions/example_is_incremental.sqlx
@@ -1,0 +1,8 @@
+config { type: "incremental", protected: true }
+
+js {  const crossdb = require("@dataform/crossdb"); }
+
+select * from (
+    select ${crossdb.currentTimestampUTC()} as ts
+)
+${isIncremental() ? `where ts > (select max(ts) from ${self()}) or (select max(ts) from ${self()}) is null` : ""}

--- a/examples/common_v2/definitions/example_is_incremental.sqlx
+++ b/examples/common_v2/definitions/example_is_incremental.sqlx
@@ -5,4 +5,5 @@ js {  const crossdb = require("@dataform/crossdb"); }
 select * from (
     select ${crossdb.currentTimestampUTC()} as ts
 )
-${isIncremental() ? `where ts > (select max(ts) from ${self()}) or (select max(ts) from ${self()}) is null` : ""}
+
+${ifIncremental(`where ts > (select max(ts) from ${self()}) or (select max(ts) from ${self()}) is null`)}

--- a/protos/core.proto
+++ b/protos/core.proto
@@ -132,6 +132,7 @@ message Table {
 
   // Incremental only.
   string where = 8;
+  string incremental_query = 26;
 
   // Pre/post operations.
   repeated string pre_ops = 13;

--- a/tests/api/examples.spec.ts
+++ b/tests/api/examples.spec.ts
@@ -90,6 +90,24 @@ describe("examples", () => {
           )}.example_incremental\`) is null`
         );
 
+        const exampleIsIncremental = graph.tables.filter(
+          (t: dataform.ITable) =>
+            t.name === schemaWithSuffix("df_integration_test") + ".example_is_incremental"
+        )[0];
+        expect(cleanSql(exampleIsIncremental.query.trim())).equals(
+          "select * from (select current_timestamp() as ts)"
+        );
+        expect(cleanSql(exampleIsIncremental.incrementalQuery)).equals(
+          cleanSql(
+            `select * from (select current_timestamp() as ts)
+           where ts > (select max(ts) from \`tada-analytics.${schemaWithSuffix(
+            "df_integration_test"
+          )}.example_is_incremental\`) or (select max(ts) from \`tada-analytics.${schemaWithSuffix(
+            "df_integration_test"
+          )}.example_is_incremental\`) is null`
+          )
+        );
+
         // Check tables defined in includes are not included.
         const exampleIgnore = graph.tables.find(
           (t: dataform.ITable) => t.name === "example_ignore"


### PR DESCRIPTION
This adds support for inline if-incremental statements. There are more use cases we are coming across where this approach makes sense.

- SQLX code is now evaluated twice in incremental tables. It's up to the user to make sure that it has no side-effects, this is a requirement I am happy to have
- This code is backwards compatible with the incremental_where behaviour
- Removes requirement for incremental_where to be set
- There is deliberately no documentation on this just yet, as it's not launch ready, but we'd like to try it in some projects


