### PR TITLE
Make building much faster

### DIFF
--- a/api/commands/build.ts
+++ b/api/commands/build.ts
@@ -9,16 +9,13 @@ import { prune } from "df/api/commands/prune";
 export async function build(
   compiledGraph: dataform.ICompiledGraph,
   runConfig: dataform.IRunConfig,
-  credentials: Credentials,
-  overrideState?: dataform.IWarehouseState
+  credentials: Credentials
 ) {
   const prunedGraph = prune(compiledGraph, runConfig);
-  const stateResult =
-    overrideState ||
-    (await state(
-      prunedGraph,
-      dbadapters.create(credentials, compiledGraph.projectConfig.warehouse)
-    ));
+  const stateResult = await state(
+    prunedGraph,
+    dbadapters.create(credentials, compiledGraph.projectConfig.warehouse)
+  );
   return new Builder(prunedGraph, runConfig, stateResult).build();
 }
 

--- a/api/commands/prune.ts
+++ b/api/commands/prune.ts
@@ -1,0 +1,97 @@
+import * as utils from "@dataform/core/utils";
+import { dataform } from "@dataform/protos";
+
+type CompileAction = dataform.ITable | dataform.IOperation | dataform.IAssertion;
+
+export function prune(
+  compiledGraph: dataform.ICompiledGraph,
+  runConfig: dataform.IRunConfig
+): dataform.ICompiledGraph {
+  const includedActionNames = computeIncludedActionNames(compiledGraph, runConfig);
+  return {
+    ...compiledGraph,
+    tables: compiledGraph.tables
+      .filter(action => includedActionNames.has(action.name))
+      .map(action => cleanDependencies(action, includedActionNames)),
+    assertions: compiledGraph.assertions
+      .filter(action => includedActionNames.has(action.name))
+      .map(action => cleanDependencies(action, includedActionNames)),
+    operations: compiledGraph.operations
+      .filter(action => includedActionNames.has(action.name))
+      .map(action => cleanDependencies(action, includedActionNames))
+  };
+}
+function cleanDependencies<T extends CompileAction>(
+  action: T,
+  includedActionNames: Set<string>
+): T {
+  // Remove any excluded dependencies.
+  return {
+    ...action,
+    dependencies: (action.dependencies || []).filter(dep => includedActionNames.has(dep))
+  };
+}
+
+function computeIncludedActionNames(
+  compiledGraph: dataform.ICompiledGraph,
+  runConfig: dataform.IRunConfig
+): Set<string> {
+  // Remove inline tables.
+  const filteredTables = compiledGraph.tables.filter(t => t.type !== "inline");
+
+  // Union all tables, operations, assertions.
+  const allActions: CompileAction[] = [].concat(
+    filteredTables,
+    compiledGraph.operations,
+    compiledGraph.assertions
+  );
+
+  const allActionNames = allActions.map(n => n.name);
+  const allActionsByName: { [name: string]: CompileAction } = {};
+  allActions.forEach(action => (allActionsByName[action.name] = action));
+
+  const hasActionSelector = runConfig.actions && runConfig.actions.length > 0;
+  const hasTagSelector = runConfig.tags && runConfig.tags.length > 0;
+
+  // If no selectors, return all actions.
+  if (!hasActionSelector && !hasTagSelector) {
+    return new Set<string>(allActionNames);
+  }
+
+  const includedActionNames = new Set<string>();
+
+  // Add all actions included by action filters.
+  if (hasActionSelector) {
+    utils
+      .matchPatterns(runConfig.actions, allActionNames)
+      .forEach(actionName => includedActionNames.add(actionName));
+  }
+
+  // Determine actions selected with --tag option and update applicable actions
+  if (hasTagSelector) {
+    allActions
+      .filter(action => action.tags.some(tag => runConfig.tags.includes(tag)))
+      .forEach(action => includedActionNames.add(action.name));
+  }
+
+  // Compute all transitive dependencies.
+  if (runConfig.includeDependencies) {
+    const queue = [...includedActionNames];
+    while (queue.length > 0) {
+      const actionName = queue.pop();
+      const action = allActionsByName[actionName];
+      const matchingDependencyNames =
+        action.dependencies && action.dependencies.length > 0
+          ? utils.matchPatterns(action.dependencies, allActionNames)
+          : [];
+      matchingDependencyNames.forEach(dependencyName => {
+        if (!includedActionNames.has(dependencyName)) {
+          queue.push(dependencyName);
+          includedActionNames.add(dependencyName);
+        }
+      });
+    }
+  }
+
+  return includedActionNames;
+}

--- a/api/index.ts
+++ b/api/index.ts
@@ -4,6 +4,7 @@ import * as credentials from "./commands/credentials";
 import * as format from "./commands/format";
 import { init } from "./commands/init";
 import { install } from "./commands/install";
+import { prune } from "./commands/prune";
 import * as query from "./commands/query";
 import { run, Runner } from "./commands/run";
 import * as table from "./commands/table";
@@ -24,5 +25,6 @@ export {
   validateSchedulesFileIfExists,
   Runner,
   Builder,
-  format
+  format,
+  prune
 };

--- a/tests/api/api.spec.ts
+++ b/tests/api/api.spec.ts
@@ -1,4 +1,4 @@
-import { Builder, compile, credentials, format, query, Runner } from "@dataform/api";
+import { build, Builder, compile, credentials, format, query, Runner } from "@dataform/api";
 import { IDbAdapter } from "@dataform/api/dbadapters";
 import { BigQueryDbAdapter } from "@dataform/api/dbadapters/bigquery";
 import * as utils from "@dataform/core/utils";
@@ -49,25 +49,25 @@ describe("@dataform/api", () => {
 
     const TEST_STATE = dataform.WarehouseState.create({ tables: [] });
 
-    it("include_deps", () => {
-      const builder = new Builder(
+    it("include_deps", async () => {
+      const executionGraph = await build(
         TEST_GRAPH,
         { actions: ["schema.a"], includeDependencies: true },
+        null,
         TEST_STATE
       );
-      const executionGraph = builder.build();
       const includedActionNames = executionGraph.actions.map(n => n.name);
       expect(includedActionNames).includes("schema.a");
       expect(includedActionNames).includes("schema.b");
     });
 
-    it("exclude_deps", () => {
-      const builder = new Builder(
+    it("exclude_deps", async () => {
+      const executionGraph = await build(
         TEST_GRAPH,
         { actions: ["schema.a"], includeDependencies: false },
+        null,
         TEST_STATE
       );
-      const executionGraph = builder.build();
       const includedActionNames = executionGraph.actions.map(n => n.name);
       expect(includedActionNames).includes("schema.a");
       expect(includedActionNames).not.includes("schema.b");
@@ -162,7 +162,7 @@ describe("@dataform/api", () => {
       });
     });
 
-    it("inline_tables", () => {
+    it("inline_tables", async () => {
       const graph: dataform.ICompiledGraph = dataform.CompiledGraph.create({
         projectConfig: { warehouse: "bigquery" },
         tables: [
@@ -177,8 +177,7 @@ describe("@dataform/api", () => {
         ]
       });
 
-      const builder = new Builder(graph, {}, TEST_STATE);
-      const executedGraph = builder.build();
+      const executedGraph = await build(graph, {}, null, TEST_STATE);
 
       expect(executedGraph).to.exist;
       expect(executedGraph)
@@ -230,17 +229,17 @@ describe("@dataform/api", () => {
         }
       ]
     });
-    it("build actions with --tags (with dependencies)", () => {
-      const builder = new Builder(
+    it("build actions with --tags (with dependencies)", async () => {
+      const executedGraph = await build(
         TEST_GRAPH_WITH_TAGS,
         {
           actions: ["op_b", "op_d"],
           tags: ["tag1", "tag2", "tag4"],
           includeDependencies: true
         },
+        null,
         TEST_STATE
       );
-      const executedGraph = builder.build();
       const actionNames = executedGraph.actions.map(n => n.name);
       expect(actionNames).includes("op_a");
       expect(actionNames).includes("op_b");
@@ -249,16 +248,16 @@ describe("@dataform/api", () => {
       expect(actionNames).includes("tab_a");
     });
 
-    it("build actions with --tags but without --actions (without dependencies)", () => {
-      const builder = new Builder(
+    it("build actions with --tags but without --actions (without dependencies)", async () => {
+      const executedGraph = await build(
         TEST_GRAPH_WITH_TAGS,
         {
           tags: ["tag1", "tag2", "tag4"],
           includeDependencies: false
         },
+        null,
         TEST_STATE
       );
-      const executedGraph = builder.build();
       const actionNames = executedGraph.actions.map(n => n.name);
       expect(actionNames).includes("op_a");
       expect(actionNames).includes("op_b");


### PR DESCRIPTION
- Introduce a prune command to apply all filters against a compiled graph
- Reduce algorithmic complexity of a lot of the filtering code significantly
- Only compute warehouse state for actions that will actually be run