### PR TITLE
Add versioning to make bind default in redshift before 1.4.1

### DIFF
--- a/api/commands/build.ts
+++ b/api/commands/build.ts
@@ -34,7 +34,7 @@ export class Builder {
     this.compiledGraph = compiledGraph;
     this.runConfig = runConfig;
     this.state = state;
-    this.adapter = adapters.create(compiledGraph.projectConfig);
+    this.adapter = adapters.create(compiledGraph.projectConfig, compiledGraph.version || "1.0.0");
   }
 
   public build(): dataform.ExecutionGraph {

--- a/api/commands/build.ts
+++ b/api/commands/build.ts
@@ -34,7 +34,10 @@ export class Builder {
     this.compiledGraph = compiledGraph;
     this.runConfig = runConfig;
     this.state = state;
-    this.adapter = adapters.create(compiledGraph.projectConfig, compiledGraph.version || "1.0.0");
+    this.adapter = adapters.create(
+      compiledGraph.projectConfig,
+      compiledGraph.dataformCoreVersion || "1.0.0"
+    );
   }
 
   public build(): dataform.ExecutionGraph {

--- a/core/BUILD
+++ b/core/BUILD
@@ -10,9 +10,14 @@ ts_library(
         "//protos",
         "//sqlx",
         "@npm//@types/node",
+        "@npm//@types/semver",
         "@npm//protobufjs",
+        "@npm//semver",
         "@npm//tarjan-graph",
     ],
+    data = [
+        ":package.json"
+    ]
 )
 
 load("//tools/npm:package.bzl", "dataform_npm_package")

--- a/core/adapters/bigquery.ts
+++ b/core/adapters/bigquery.ts
@@ -4,11 +4,8 @@ import { Adapter } from "./base";
 import { IAdapter } from "./index";
 
 export class BigQueryAdapter extends Adapter implements IAdapter {
-  private project: dataform.IProjectConfig;
-
-  constructor(project: dataform.IProjectConfig) {
+  constructor(private project: dataform.IProjectConfig, private version: string) {
     super();
-    this.project = project;
   }
 
   public resolveTarget(target: dataform.ITarget) {

--- a/core/adapters/bigquery.ts
+++ b/core/adapters/bigquery.ts
@@ -1,10 +1,10 @@
+import { IAdapter } from "@dataform/core/adapters";
+import { Adapter } from "@dataform/core/adapters/base";
+import { Task, Tasks } from "@dataform/core/tasks";
 import { dataform } from "@dataform/protos";
-import { Task, Tasks } from "../tasks";
-import { Adapter } from "./base";
-import { IAdapter } from "./index";
 
 export class BigQueryAdapter extends Adapter implements IAdapter {
-  constructor(private project: dataform.IProjectConfig, private version: string) {
+  constructor(private project: dataform.IProjectConfig, private dataformCoreVersion: string) {
     super();
   }
 

--- a/core/adapters/index.ts
+++ b/core/adapters/index.ts
@@ -21,7 +21,8 @@ export interface IAdapter {
 }
 
 export type AdapterConstructor<T extends IAdapter> = new (
-  projectConfig: dataform.IProjectConfig
+  projectConfig: dataform.IProjectConfig,
+  version: string
 ) => T;
 
 export enum WarehouseType {
@@ -81,11 +82,11 @@ export function register(warehouseType: string, c: AdapterConstructor<IAdapter>)
   registry[warehouseType] = c;
 }
 
-export function create(projectConfig: dataform.IProjectConfig): IAdapter {
+export function create(projectConfig: dataform.IProjectConfig, version: string): IAdapter {
   if (!registry[projectConfig.warehouse]) {
     throw new Error(`Unsupported warehouse: ${projectConfig.warehouse}`);
   }
-  return new registry[projectConfig.warehouse](projectConfig);
+  return new registry[projectConfig.warehouse](projectConfig, version);
 }
 
 register("bigquery", BigQueryAdapter);

--- a/core/adapters/index.ts
+++ b/core/adapters/index.ts
@@ -22,7 +22,7 @@ export interface IAdapter {
 
 export type AdapterConstructor<T extends IAdapter> = new (
   projectConfig: dataform.IProjectConfig,
-  version: string
+  dataformCoreVersion: string
 ) => T;
 
 export enum WarehouseType {
@@ -82,11 +82,14 @@ export function register(warehouseType: string, c: AdapterConstructor<IAdapter>)
   registry[warehouseType] = c;
 }
 
-export function create(projectConfig: dataform.IProjectConfig, version: string): IAdapter {
+export function create(
+  projectConfig: dataform.IProjectConfig,
+  dataformCoreVersion: string
+): IAdapter {
   if (!registry[projectConfig.warehouse]) {
     throw new Error(`Unsupported warehouse: ${projectConfig.warehouse}`);
   }
-  return new registry[projectConfig.warehouse](projectConfig, version);
+  return new registry[projectConfig.warehouse](projectConfig, dataformCoreVersion);
 }
 
 register("bigquery", BigQueryAdapter);

--- a/core/adapters/redshift.ts
+++ b/core/adapters/redshift.ts
@@ -1,14 +1,12 @@
 import { dataform } from "@dataform/protos";
+import * as semver from "semver";
 import { Task, Tasks } from "../tasks";
 import { Adapter } from "./base";
 import { IAdapter } from "./index";
 
 export class RedshiftAdapter extends Adapter implements IAdapter {
-  private project: dataform.IProjectConfig;
-
-  constructor(project: dataform.IProjectConfig) {
+  constructor(private project: dataform.IProjectConfig, private version: string) {
     super();
-    this.project = project;
   }
 
   public resolveTarget(target: dataform.ITarget) {
@@ -59,11 +57,11 @@ export class RedshiftAdapter extends Adapter implements IAdapter {
         name: assertion.name
       });
     return Tasks.create()
-      .add(Task.statement(this.createOrReplaceView(target, assertion.query)))
+      .add(Task.statement(this.createOrReplaceView(target, assertion.query, true)))
       .add(Task.assertion(`select sum(1) as row_count from ${this.resolveTarget(target)}`));
   }
 
-  public createOrReplaceView(target: dataform.ITarget, query: string, bind = false) {
+  public createOrReplaceView(target: dataform.ITarget, query: string, bind: boolean) {
     const createQuery = `create or replace view ${this.resolveTarget(target)} as ${query}`;
     if (bind) {
       return createQuery;
@@ -73,19 +71,14 @@ export class RedshiftAdapter extends Adapter implements IAdapter {
 
   public createOrReplace(table: dataform.ITable) {
     if (table.type === "view") {
+      const isBindDefined = table.redshift && table.redshift.hasOwnProperty("bind");
+      const bindDefaultValue = semver.gte(this.version, "1.4.1") ? false : true;
+      const bind = isBindDefined ? table.redshift.bind : bindDefaultValue;
       return (
         Tasks.create()
           // Drop the view in case we are changing the number of column(s) (or their types).
           .add(Task.statement(this.dropIfExists(table.target, this.baseTableType(table.type))))
-          .add(
-            Task.statement(
-              this.createOrReplaceView(
-                table.target,
-                table.query,
-                table.redshift && table.redshift.bind
-              )
-            )
-          )
+          .add(Task.statement(this.createOrReplaceView(table.target, table.query, bind)))
       );
     }
     const tempTableTarget = dataform.Target.create({

--- a/core/adapters/redshift.ts
+++ b/core/adapters/redshift.ts
@@ -1,11 +1,11 @@
+import { IAdapter } from "@dataform/core/adapters";
+import { Adapter } from "@dataform/core/adapters/base";
+import { Task, Tasks } from "@dataform/core/tasks";
 import { dataform } from "@dataform/protos";
 import * as semver from "semver";
-import { Task, Tasks } from "../tasks";
-import { Adapter } from "./base";
-import { IAdapter } from "./index";
 
 export class RedshiftAdapter extends Adapter implements IAdapter {
-  constructor(private project: dataform.IProjectConfig, private version: string) {
+  constructor(private project: dataform.IProjectConfig, private dataformCoreVersion: string) {
     super();
   }
 
@@ -72,7 +72,7 @@ export class RedshiftAdapter extends Adapter implements IAdapter {
   public createOrReplace(table: dataform.ITable) {
     if (table.type === "view") {
       const isBindDefined = table.redshift && table.redshift.hasOwnProperty("bind");
-      const bindDefaultValue = semver.gte(this.version, "1.4.1") ? false : true;
+      const bindDefaultValue = semver.gte(this.dataformCoreVersion, "1.4.1") ? false : true;
       const bind = isBindDefined ? table.redshift.bind : bindDefaultValue;
       return (
         Tasks.create()

--- a/core/adapters/snowflake.ts
+++ b/core/adapters/snowflake.ts
@@ -4,11 +4,8 @@ import { Adapter } from "./base";
 import { IAdapter } from "./index";
 
 export class SnowflakeAdapter extends Adapter implements IAdapter {
-  private project: dataform.IProjectConfig;
-
-  constructor(project: dataform.IProjectConfig) {
+  constructor(private project: dataform.IProjectConfig, private version: string) {
     super();
-    this.project = project;
   }
 
   public resolveTarget(target: dataform.ITarget) {

--- a/core/adapters/snowflake.ts
+++ b/core/adapters/snowflake.ts
@@ -1,10 +1,10 @@
+import { IAdapter } from "@dataform/core/adapters";
+import { Adapter } from "@dataform/core/adapters/base";
+import { Task, Tasks } from "@dataform/core/tasks";
 import { dataform } from "@dataform/protos";
-import { Task, Tasks } from "../tasks";
-import { Adapter } from "./base";
-import { IAdapter } from "./index";
 
 export class SnowflakeAdapter extends Adapter implements IAdapter {
-  constructor(private project: dataform.IProjectConfig, private version: string) {
+  constructor(private project: dataform.IProjectConfig, private dataformCoreVersion: string) {
     super();
   }
 

--- a/core/adapters/sqldatawarehouse.ts
+++ b/core/adapters/sqldatawarehouse.ts
@@ -4,6 +4,10 @@ import { Task, Tasks } from "@dataform/core/tasks";
 import { dataform } from "@dataform/protos";
 
 export class SQLDataWarehouseAdapter extends Adapter implements IAdapter {
+  constructor(private project: dataform.IProjectConfig, private version: string) {
+    super();
+  }
+
   public resolveTarget(target: dataform.ITarget) {
     return `"${target.schema}"."${target.name}"`;
   }

--- a/core/adapters/sqldatawarehouse.ts
+++ b/core/adapters/sqldatawarehouse.ts
@@ -4,7 +4,7 @@ import { Task, Tasks } from "@dataform/core/tasks";
 import { dataform } from "@dataform/protos";
 
 export class SQLDataWarehouseAdapter extends Adapter implements IAdapter {
-  constructor(private project: dataform.IProjectConfig, private version: string) {
+  constructor(private project: dataform.IProjectConfig, private dataformCoreVersion: string) {
     super();
   }
 

--- a/core/core.package.json
+++ b/core/core.package.json
@@ -7,6 +7,7 @@
     "@dataform/protos": "$DF_VERSION",
     "@dataform/sqlx": "$DF_VERSION",
     "protobufjs": "^6.8.8",
-    "tarjan-graph": "^2.0.0"
+    "tarjan-graph": "^2.0.0",
+    "semver": "^5.6.0"
   }
 }

--- a/core/session.ts
+++ b/core/session.ts
@@ -11,7 +11,7 @@ import { Graph as TarjanGraph } from "tarjan-graph";
 import * as TarjanGraphConstructor from "tarjan-graph";
 
 // Can't use resolveJsonModule with Bazel.
-const { version } = require("@dataform/core/package.json");
+const { version: dataformCoreVersion } = require("@dataform/core/package.json");
 
 interface IActionProto {
   name?: string;
@@ -113,7 +113,7 @@ export class Session {
   }
 
   public adapter(): adapters.IAdapter {
-    return adapters.create(this.config, version);
+    return adapters.create(this.config, dataformCoreVersion);
   }
 
   public sqlxAction(actionOptions: {
@@ -351,7 +351,7 @@ export class Session {
       ),
       tests: this.compileGraphChunk(Object.values(this.tests)),
       graphErrors: this.graphErrors,
-      version
+      dataformCoreVersion
     });
 
     this.fullyQualifyDependencies(

--- a/core/session.ts
+++ b/core/session.ts
@@ -10,6 +10,9 @@ import { util } from "protobufjs";
 import { Graph as TarjanGraph } from "tarjan-graph";
 import * as TarjanGraphConstructor from "tarjan-graph";
 
+// Can't use resolveJsonModule with Bazel.
+const { version } = require("@dataform/core/package.json");
+
 interface IActionProto {
   name?: string;
   fileName?: string;
@@ -110,7 +113,7 @@ export class Session {
   }
 
   public adapter(): adapters.IAdapter {
-    return adapters.create(this.config);
+    return adapters.create(this.config, version);
   }
 
   public sqlxAction(actionOptions: {
@@ -347,7 +350,8 @@ export class Session {
         this.actions.filter(action => action instanceof Declaration)
       ),
       tests: this.compileGraphChunk(Object.values(this.tests)),
-      graphErrors: this.graphErrors
+      graphErrors: this.graphErrors,
+      version
     });
 
     this.fullyQualifyDependencies(

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@types/readline-sync": "^1.4.3",
     "@types/request": "^2.48.3",
     "@types/rimraf": "^2.0.2",
+    "@types/semver": "^6.2.0",
     "@types/stack-trace": "^0.0.29",
     "@types/yargs": "^11.1.1",
     "@zeit/next-css": "^1.0.1",

--- a/protos/core.proto
+++ b/protos/core.proto
@@ -234,6 +234,8 @@ message CompiledGraph {
 
   GraphErrors graph_errors = 7;
 
+  string version = 10;
+
   repeated ValidationError deprecated_validation_errors = 5;
   repeated CompilationError deprecated_compilation_errors = 6;
 }

--- a/protos/core.proto
+++ b/protos/core.proto
@@ -234,7 +234,7 @@ message CompiledGraph {
 
   GraphErrors graph_errors = 7;
 
-  string version = 10;
+  string dataform_core_version = 10;
 
   repeated ValidationError deprecated_validation_errors = 5;
   repeated CompilationError deprecated_compilation_errors = 6;

--- a/tests/api/api.spec.ts
+++ b/tests/api/api.spec.ts
@@ -311,6 +311,7 @@ describe("@dataform/api", () => {
     it("redshift_create", () => {
       const testGraph: dataform.ICompiledGraph = dataform.CompiledGraph.create({
         projectConfig: { warehouse: "redshift" },
+        version: "1.4.1",
         tables: [
           {
             name: "redshift_all",

--- a/tests/api/api.spec.ts
+++ b/tests/api/api.spec.ts
@@ -311,7 +311,7 @@ describe("@dataform/api", () => {
     it("redshift_create", () => {
       const testGraph: dataform.ICompiledGraph = dataform.CompiledGraph.create({
         projectConfig: { warehouse: "redshift" },
-        version: "1.4.1",
+        dataformCoreVersion: "1.4.1",
         tables: [
           {
             name: "redshift_all",

--- a/tests/api/examples.spec.ts
+++ b/tests/api/examples.spec.ts
@@ -101,10 +101,10 @@ describe("examples", () => {
           cleanSql(
             `select * from (select current_timestamp() as ts)
            where ts > (select max(ts) from \`tada-analytics.${schemaWithSuffix(
-            "df_integration_test"
-          )}.example_is_incremental\`) or (select max(ts) from \`tada-analytics.${schemaWithSuffix(
-            "df_integration_test"
-          )}.example_is_incremental\`) is null`
+             "df_integration_test"
+           )}.example_is_incremental\`) or (select max(ts) from \`tada-analytics.${schemaWithSuffix(
+              "df_integration_test"
+            )}.example_is_incremental\`) is null`
           )
         );
 
@@ -676,5 +676,14 @@ describe("examples", () => {
     } catch (e) {
       // OK
     }
+  });
+
+  it("redshift compiles", async () => {
+    const graph = await compile({
+      projectDir: "df/examples/common_v2",
+      projectConfigOverride: { warehouse: "bigquery" }
+    });
+    const { version: expectedVersion } = require("@dataform/core/package.json");
+    expect(graph.version).equals(expectedVersion);
   });
 });

--- a/tests/api/examples.spec.ts
+++ b/tests/api/examples.spec.ts
@@ -684,6 +684,6 @@ describe("examples", () => {
       projectConfigOverride: { warehouse: "bigquery" }
     });
     const { version: expectedVersion } = require("@dataform/core/package.json");
-    expect(graph.version).equals(expectedVersion);
+    expect(graph.dataformCoreVersion).equals(expectedVersion);
   });
 });

--- a/tests/api/examples.spec.ts
+++ b/tests/api/examples.spec.ts
@@ -678,7 +678,7 @@ describe("examples", () => {
     }
   });
 
-  it("redshift compiles", async () => {
+  it("version is correctly set", async () => {
     const graph = await compile({
       projectDir: "df/examples/common_v2",
       projectConfigOverride: { warehouse: "bigquery" }

--- a/tests/integration/bigquery.spec.ts
+++ b/tests/integration/bigquery.spec.ts
@@ -17,7 +17,7 @@ describe("@dataform/integration/bigquery", () => {
     expect(compiledGraph.graphErrors.compilationErrors).to.eql([]);
     expect(compiledGraph.graphErrors.validationErrors).to.eql([]);
 
-    const adapter = adapters.create(compiledGraph.projectConfig);
+    const adapter = adapters.create(compiledGraph.projectConfig, compiledGraph.version);
 
     // Drop all the tables before we do anything.
     await dropAllTables(compiledGraph, adapter, dbadapter);

--- a/tests/integration/bigquery.spec.ts
+++ b/tests/integration/bigquery.spec.ts
@@ -17,7 +17,7 @@ describe("@dataform/integration/bigquery", () => {
     expect(compiledGraph.graphErrors.compilationErrors).to.eql([]);
     expect(compiledGraph.graphErrors.validationErrors).to.eql([]);
 
-    const adapter = adapters.create(compiledGraph.projectConfig, compiledGraph.version);
+    const adapter = adapters.create(compiledGraph.projectConfig, compiledGraph.dataformCoreVersion);
 
     // Drop all the tables before we do anything.
     await dropAllTables(compiledGraph, adapter, dbadapter);

--- a/tests/integration/redshift.spec.ts
+++ b/tests/integration/redshift.spec.ts
@@ -17,7 +17,7 @@ describe("@dataform/integration/redshift", () => {
     expect(compiledGraph.graphErrors.compilationErrors).to.eql([]);
     expect(compiledGraph.graphErrors.validationErrors).to.eql([]);
 
-    const adapter = adapters.create(compiledGraph.projectConfig);
+    const adapter = adapters.create(compiledGraph.projectConfig, compiledGraph.version);
 
     // Redshift transactions are giving us headaches here. Drop tables sequentially.
     const dropFunctions = [].concat(

--- a/tests/integration/redshift.spec.ts
+++ b/tests/integration/redshift.spec.ts
@@ -17,7 +17,7 @@ describe("@dataform/integration/redshift", () => {
     expect(compiledGraph.graphErrors.compilationErrors).to.eql([]);
     expect(compiledGraph.graphErrors.validationErrors).to.eql([]);
 
-    const adapter = adapters.create(compiledGraph.projectConfig, compiledGraph.version);
+    const adapter = adapters.create(compiledGraph.projectConfig, compiledGraph.dataformCoreVersion);
 
     // Redshift transactions are giving us headaches here. Drop tables sequentially.
     const dropFunctions = [].concat(

--- a/tests/integration/snowflake.spec.ts
+++ b/tests/integration/snowflake.spec.ts
@@ -17,7 +17,7 @@ describe("@dataform/integration/snowflake", () => {
     expect(compiledGraph.graphErrors.compilationErrors).to.eql([]);
     expect(compiledGraph.graphErrors.validationErrors).to.eql([]);
 
-    const adapter = adapters.create(compiledGraph.projectConfig, compiledGraph.version);
+    const adapter = adapters.create(compiledGraph.projectConfig, compiledGraph.dataformCoreVersion);
 
     // Drop all the tables before we do anything.
     await dropAllTables(compiledGraph, adapter, dbadapter);

--- a/tests/integration/snowflake.spec.ts
+++ b/tests/integration/snowflake.spec.ts
@@ -17,7 +17,7 @@ describe("@dataform/integration/snowflake", () => {
     expect(compiledGraph.graphErrors.compilationErrors).to.eql([]);
     expect(compiledGraph.graphErrors.validationErrors).to.eql([]);
 
-    const adapter = adapters.create(compiledGraph.projectConfig);
+    const adapter = adapters.create(compiledGraph.projectConfig, compiledGraph.version);
 
     // Drop all the tables before we do anything.
     await dropAllTables(compiledGraph, adapter, dbadapter);

--- a/tests/integration/sqldatawarehouse.spec.ts
+++ b/tests/integration/sqldatawarehouse.spec.ts
@@ -20,7 +20,7 @@ describe("@dataform/integration/sqldatawarehouse", () => {
     expect(compiledGraph.graphErrors.compilationErrors).to.eql([]);
     expect(compiledGraph.graphErrors.validationErrors).to.eql([]);
 
-    const adapter = adapters.create(compiledGraph.projectConfig, compiledGraph.version);
+    const adapter = adapters.create(compiledGraph.projectConfig, compiledGraph.dataformCoreVersion);
 
     // Drop all the tables before we do anything.
     await dropAllTables(compiledGraph, adapter, dbadapter);

--- a/tests/integration/sqldatawarehouse.spec.ts
+++ b/tests/integration/sqldatawarehouse.spec.ts
@@ -20,7 +20,7 @@ describe("@dataform/integration/sqldatawarehouse", () => {
     expect(compiledGraph.graphErrors.compilationErrors).to.eql([]);
     expect(compiledGraph.graphErrors.validationErrors).to.eql([]);
 
-    const adapter = adapters.create(compiledGraph.projectConfig);
+    const adapter = adapters.create(compiledGraph.projectConfig, compiledGraph.version);
 
     // Drop all the tables before we do anything.
     await dropAllTables(compiledGraph, adapter, dbadapter);

--- a/version.bzl
+++ b/version.bzl
@@ -1,3 +1,3 @@
 # NOTE: If you change the format of this line, you must change the bash command
 # in /scripts/publish to extract the version string correctly.
-DF_VERSION = "1.4.1"
+DF_VERSION = "1.4.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1319,6 +1319,11 @@
     "@types/glob" "*"
     "@types/node" "*"
 
+"@types/semver@^6.2.0":
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-6.2.0.tgz#d688d574400d96c5b0114968705366f431831e1a"
+  integrity sha512-1OzrNb4RuAzIT7wHSsgZRlMBlNsJl+do6UblR7JMW4oB7bbR+uBEYtUh7gEc/jM84GGilh68lSOokyM/zNUlBA==
+
 "@types/serve-static@*":
   version "1.13.3"
   resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.13.3.tgz#eb7e1c41c4468272557e897e9171ded5e2ded9d1"


### PR DESCRIPTION
- bind changes correctness of some SQL, so we will only make it the default on versions from where it is supported.