### PR TITLE
Added exit codes to CLI, where non-zero indicates failure

### DIFF
--- a/cli/index.ts
+++ b/cli/index.ts
@@ -338,7 +338,12 @@ const builtYargs = createYargsCli({
           // Add event listeners.
           watcher
             .on("ready", printReady)
-            .on("error", error => printError(`Error: ${error}`))
+            .on("error", error => {
+              // This error is caught not if there is a compilation error, but
+              // if the watcher fails; this indicates an failure on our side.
+              printError(`Error: ${error}`);
+              process.exit(1);
+            })
             .on("all", () => {
               if (timeoutID || isCompiling) {
                 // don't recompile many times if we changed a lot of files
@@ -359,11 +364,13 @@ const builtYargs = createYargsCli({
           process.on("SIGINT", () => {
             watcher.close();
             watching = false;
+            process.exit(1);
           });
           while (watching) {
             await new Promise((resolve, reject) => setTimeout(() => resolve(), 100));
           }
         }
+        process.exit(0);
       }
     },
     {
@@ -379,7 +386,7 @@ const builtYargs = createYargsCli({
         });
         if (compiledGraphHasErrors(compiledGraph)) {
           printCompiledGraphErrors(compiledGraph.graphErrors);
-          return;
+          return 1;
         }
         printSuccess("Compiled successfully.\n");
         const readCredentials = credentials.read(
@@ -389,7 +396,7 @@ const builtYargs = createYargsCli({
 
         if (!compiledGraph.tests.length) {
           printError("No unit tests found.");
-          return;
+          return 1;
         }
 
         print(`Running ${compiledGraph.tests.length} unit tests...\n`);
@@ -399,6 +406,7 @@ const builtYargs = createYargsCli({
           compiledGraph.tests
         );
         testResults.forEach(testResult => printTestResult(testResult));
+        return 0;
       }
     },
     {
@@ -438,7 +446,7 @@ const builtYargs = createYargsCli({
         });
         if (compiledGraphHasErrors(compiledGraph)) {
           printCompiledGraphErrors(compiledGraph.graphErrors);
-          return;
+          return 1;
         }
         printSuccess("Compiled successfully.\n");
         const readCredentials = credentials.read(
@@ -461,7 +469,7 @@ const builtYargs = createYargsCli({
             "Dry run (--dry-run) mode is turned on; not running the following actions against your warehouse:\n"
           );
           printExecutionGraph(executionGraph, argv.verbose);
-          return;
+          return 0;
         }
 
         if (argv["run-tests"]) {
@@ -474,7 +482,7 @@ const builtYargs = createYargsCli({
           testResults.forEach(testResult => printTestResult(testResult));
           if (testResults.some(testResult => !testResult.successful)) {
             printError("\nUnit tests did not pass; aborting run.");
-            return;
+            return 1;
           }
           printSuccess("Unit tests completed successfully.\n");
         }
@@ -487,7 +495,7 @@ const builtYargs = createYargsCli({
               WarehouseType[compiledGraph.projectConfig.warehouse as keyof typeof WarehouseType]
             )
           ) {
-            process.exit();
+            process.exit(1);
           }
           runner.cancel();
         });
@@ -511,7 +519,9 @@ const builtYargs = createYargsCli({
         };
 
         runner.onChange(printExecutedGraph);
-        printExecutedGraph(await runner.resultPromise());
+        const runResult = await runner.resultPromise()
+        printExecutedGraph(runResult);
+        return ((runResult.status === dataform.RunResult.ExecutionStatus.FAILED) ? 1 : 0);
       }
     },
     {

--- a/cli/yargswrapper.ts
+++ b/cli/yargswrapper.ts
@@ -9,7 +9,7 @@ export interface ICommand {
   description: string;
   positionalOptions: Array<INamedOption<yargs.PositionalOptions>>;
   options: Array<INamedOption<yargs.Options>>;
-  processFn: (argv: { [argumentName: string]: any }) => any;
+  processFn: (argv: { [argumentName: string]: any }) => Promise<number>;
 }
 
 export interface INamedOption<T> {
@@ -26,8 +26,8 @@ export function createYargsCli(cli: ICli) {
       command.description,
       (yargsChainer: yargs.Argv) => createOptionsChain(yargsChainer, command),
       async (argv: { [argumentName: string]: any }) => {
-        await command.processFn(argv);
-        process.exit();
+        const result = await command.processFn(argv);
+        process.exit(result);
       }
     );
   }

--- a/cli/yargswrapper.ts
+++ b/cli/yargswrapper.ts
@@ -26,8 +26,8 @@ export function createYargsCli(cli: ICli) {
       command.description,
       (yargsChainer: yargs.Argv) => createOptionsChain(yargsChainer, command),
       async (argv: { [argumentName: string]: any }) => {
-        const result = await command.processFn(argv);
-        process.exit(result);
+        const exitCode = await command.processFn(argv);
+        process.exit(exitCode);
       }
     );
   }


### PR DESCRIPTION
Fixes #394 

I also added an additional `process.exit()` for watcher SIGINT to conform with others.

Also unsure whether `process.exit()` could be substituted for `return` - CLI tests might be useful for.