### PR TITLE
Throw validation error for partitionBy if BigQuery view

### DIFF
--- a/core/utils.ts
+++ b/core/utils.ts
@@ -187,6 +187,17 @@ export function validate(compiledGraph: dataform.ICompiledGraph): dataform.IGrap
       }
     }
 
+    // BigQuery config
+    if (!!action.bigquery) {
+      if (action.bigquery.partitionBy && action.type === "view") {
+        const error = dataform.ValidationError.create({
+          message: `partitionBy is not valid for BigQuery views; it is only valid for tables`,
+          actionName
+        });
+        validationErrors.push(error);
+      }
+    }
+
     // ignored properties in tables
     if (!!ignoredProps[action.type]) {
       ignoredProps[action.type].forEach(ignoredProp => {

--- a/scripts/run
+++ b/scripts/run
@@ -2,4 +2,4 @@
 set -e
 
 bazel build //cli:bin
-./bazel-bin/cli/bin "$@"
+./bazel-bin/cli/bin.sh "$@"


### PR DESCRIPTION
Fixes #421 

* Added a validation error for if a user tries to specify a `partitionBy` while the action is for `bigquery` of type `view` (BigQuery only allows `partitionBy` for type `table`).

* Added a test, similar to the existing redhshift tests, that tests that the validation error is indeed ✋💨🥎 as expected.

* Changed the `TEST_CONFIG` environment variable in tests as there are currently 3 and likely to be more in the future. See comment below.
