### PR TITLE
Open source contribution extension

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -1,7 +1,7 @@
 # Contributing
 
 Dataform is a TypeScript project, and is fairly easy to build and run locally.
-For help making changes, join our `#development` channel in [Slack](https://slack.dataform.co), or [email us](mailto:opensource@dataform.co) directly.
+For help making changes, join our `#development` channel in [Slack](https://slack.dataform.co), or [email us](mailto:team@dataform.co) directly.
 
 ## Requirements
 
@@ -67,6 +67,6 @@ You can view the documentation site at [localhost:3001](http://localhost:3001).
 
 A good place to start is by solving [Issues](https://github.com/dataform-co/dataform/issues), with the aim of understanding the code base well enough to create new features.
 
-We also regularly run hackathons, but you'll have to [ask us directly](mailto:opensource@dataform.co) if you would like to participate.
+We also regularly run hackathons, but you'll have to [ask us directly](mailto:team@dataform.co) if you would like to participate.
 
-Come meet us at [one of our events](https://www.google.com/search?q=dataform+events)!
+Come meet us at [one of our events](https://www.meetup.com/Data-First-London/)!

--- a/contributors.md
+++ b/contributors.md
@@ -9,7 +9,7 @@ For help making changes, join our `#development` channel in [Slack](https://slac
 
 ## Getting Started
 
-First clone this repository, and navigate within.
+First :fork_and_knife: [fork this repository](https://github.com/dataform-co/dataform/fork), clone it to your desktop, and navigate within.
 
 ### Run the CLI
 
@@ -19,7 +19,7 @@ Print out the default help information:
 ./scripts/run help
 ```
 
-Create a new `redshift` project in a temp directory:
+Create a new `redshift` toy project:
 
 ```bash
 mkdir /tmp/test_project
@@ -30,7 +30,7 @@ More commands can be found by substituting `dataform` with `./scripts/run` in th
 
 ### Test
 
-To test the project, run the following command:
+To test the Dataform project, run the following command:
 
 ```bash
 bazel test -- tests/... -tests/integration/...
@@ -38,7 +38,7 @@ bazel test -- tests/... -tests/integration/...
 
 This runs all tests excluding the integration tests. If you need to run integration tests, please [get in touch](mailto:opensource@dataform.co) with the team.
 
-_Note: A `java failed` error suggests that java needs to be installed._
+_Note: A `java failed` error suggests that Java needs to be installed._
 
 ### Building
 
@@ -61,3 +61,11 @@ bazel run docs
 ```
 
 You can view the documentation site at [localhost:3001](http://localhost:3001).
+
+## Deciding what to contribute
+
+A good place to start is by solving [Issues](https://github.com/dataform-co/dataform/issues), with the aim of understanding the code base well enough to create new features.
+
+We also regularly run hackathons, but you'll have to [ask us directly](mailto:opensource@dataform.co) if you would like to participate.
+
+Come meet us at [one of our events](https://www.google.com/search?q=dataform+events)!

--- a/contributors.md
+++ b/contributors.md
@@ -1,31 +1,15 @@
 # Contributing
 
 Dataform is a TypeScript project, and is fairly easy to build and run locally.
-For help making changes, join our `#development` channel in [Slack](https://slack.dataform.co).
+For help making changes, join our `#development` channel in [Slack](https://slack.dataform.co), or [email us](mailto:opensource@dataform.co) directly.
 
 ## Requirements
 
 [Bazel](https://bazel.build) - Bazel is a build system, and this is the only dependency you need to build and run the entire project.
 
-### Building
+## Getting Started
 
-To check the project builds succesfully, run the following command:
-
-```bash
-bazel build ...
-```
-
-_Note: If you are running Bazel on a **Mac**, `bazel build ...` may fail with a `Too many open files in system` error. This is [due to a limitation](https://github.com/angular/angular-bazel-example/issues/178) on the default maximum open file descriptors. You can increase the limit by running `sudo sysctl -w kern.maxfiles=<LARGE_NUMBER>` (we use `65536`)._
-
-### Test
-
-To test the project, run the following command:
-
-```bash
-bazel test ...
-```
-
-_Note: Some integration tests may fail due to missing credentials. If you need to run these tests, reach out to the team on [Slack](https://slack.dataform.co)._
+First clone this repository, and navigate within.
 
 ### Run the CLI
 
@@ -38,12 +22,37 @@ Print out the default help information:
 Create a new `redshift` project in a temp directory:
 
 ```bash
+mkdir /tmp/test_project
 ./scripts/run init redshift /tmp/test_project
 ```
 
-See the [CLI documentation](https://docs.dataform.co/guides/command-line-interface/) for more commands.
+More commands can be found by substituting `dataform` with `./scripts/run` in the [CLI documentation](https://docs.dataform.co/guides/command-line-interface).
 
-## Run the documentation site
+### Test
+
+To test the project, run the following command:
+
+```bash
+bazel test -- tests/... -tests/integration/...
+```
+
+This runs all tests excluding the integration tests. If you need to run integration tests, please [get in touch](mailto:opensource@dataform.co) with the team.
+
+_Note: A `java failed` error suggests that java needs to be installed._
+
+### Building
+
+Running the CLI will build the required components. To build other components, for example the api, use:
+
+```bash
+bazel build api
+```
+
+_Note: Building the entire project with `Bazel build ...` will not work unless you have credentials provided by the team. A workaround to this is to create an empty `tools/stackdriver-github-bridge/env.yaml` file._
+
+_Note: If you are running Bazel on a **Mac**, `bazel build ...` may fail with a `Too many open files in system` error. This is [due to a limitation](https://github.com/angular/angular-bazel-example/issues/178) on the default maximum open file descriptors. You can increase the limit by running `sudo sysctl -w kern.maxfiles=<LARGE_NUMBER>` (we use `65536`)._
+
+### Run the documentation site
 
 This will run the documentation site in development mode with live reload.
 

--- a/contributors.md
+++ b/contributors.md
@@ -13,20 +13,17 @@ First :fork_and_knife: [fork this repository](https://github.com/dataform-co/dat
 
 ### Run the CLI
 
-Print out the default help information:
+You can run the project as you would the `npm` installation of `@dataform/cli`, but replace `dataform` with `./scripts/run`.
+
+For example, to print out the default help information:
 
 ```bash
 ./scripts/run help
 ```
 
-Create a new `redshift` toy project:
+Check the [docs](https://docs.dataform.co/guides/command-line-interface/) for more examples.
 
-```bash
-mkdir /tmp/test_project
-./scripts/run init redshift /tmp/test_project
-```
-
-More commands can be found by substituting `dataform` with `./scripts/run` in the [CLI documentation](https://docs.dataform.co/guides/command-line-interface).
+_Note: If you are running Bazel on a **Mac**, this or any step that requires building may fail with a `Too many open files in system` error. This is [due to a limitation](https://github.com/angular/angular-bazel-example/issues/178) on the default maximum open file descriptors. You can increase the limit by running `sudo sysctl -w kern.maxfiles=<LARGE_NUMBER>` (we use `65536`)._
 
 ### Test
 
@@ -42,15 +39,19 @@ _Note: A `java failed` error suggests that Java needs to be installed._
 
 ### Building
 
-Running the CLI will build the required components. To build other components, for example the api, use:
+Running the CLI will build the required components. To build all other components, use:
 
 ```bash
-bazel build api
+bazel build -- ... -tools/...
 ```
 
-_Note: Building the entire project with `Bazel build ...` will not work unless you have credentials provided by the team. A workaround to this is to create an empty `tools/stackdriver-github-bridge/env.yaml` file._
+or if you're using `zsh`, then
 
-_Note: If you are running Bazel on a **Mac**, `bazel build ...` may fail with a `Too many open files in system` error. This is [due to a limitation](https://github.com/angular/angular-bazel-example/issues/178) on the default maximum open file descriptors. You can increase the limit by running `sudo sysctl -w kern.maxfiles=<LARGE_NUMBER>` (we use `65536`)._
+```bash
+bazel build -- "..." -tools/...
+```
+
+The projects folder here is not built as it requires an environment file, which can be provided from the team.
 
 ### Run the documentation site
 

--- a/readme.md
+++ b/readme.md
@@ -59,4 +59,4 @@ Open an issue or email us at opensource@dataform.co
 
 # Want to contribute?
 
-Check out our [contributors guide](https://github.com/dataform-co/dataform/blob/master/contributors.md) to get started with setting up the repo.
+Check out our [contributors guide](https://github.com/dataform-co/dataform/blob/master/contributing.md) to get started with setting up the repo.


### PR DESCRIPTION
Instructions should work out the box (at least for now), preventing confusion about the `env.yaml` file if they try to build the entire solution.

I also added some info on events and such, which I think is nice.