### PR TITLE
Fixed missing file field on function call (#525)

### DIFF
--- a/content/docs/guides/includes.md
+++ b/content/docs/guides/includes.md
@@ -122,7 +122,7 @@ SELECT field1,
        field5,
        SUM(revenue) AS revenue
 FROM my_schema.my_table
-${groupBy(5)}
+${utils.groupBy(5)}
 ```
 
 The query will be compiled into the following SQL before it is run:


### PR DESCRIPTION
When a function is called, it should have the file name specified