### PR TITLE
Stop regex r format space

### DIFF
--- a/api/commands/format.ts
+++ b/api/commands/format.ts
@@ -13,7 +13,7 @@ const JS_BEAUTIFY_OPTIONS: JsBeautifyOptions = {
 
 const MAX_SQL_FORMAT_ATTEMPTS = 5;
 
-const TEXT_LIFT_PATTERNS = [/r'(\\['\\]|[^\n'\\])*'/, /r"(\\["\\]|[^\n"\\])*"/];
+const TEXT_LIFT_PATTERNS = [/r'.*'/, /r".*"/];
 
 export async function formatFile(
   filename: string,

--- a/api/commands/format.ts
+++ b/api/commands/format.ts
@@ -13,7 +13,7 @@ const JS_BEAUTIFY_OPTIONS: JsBeautifyOptions = {
 
 const MAX_SQL_FORMAT_ATTEMPTS = 5;
 
-const TEXT_LIFT_PATTERNS = [/r'.*'/, /r".*"/];
+const TEXT_LIFT_PATTERNS = [/r'.*?(?<!\\)'/g, /r".*?(?<!\\)"/g];
 
 export async function formatFile(
   filename: string,

--- a/examples/formatter/definitions/regex.sqlx
+++ b/examples/formatter/definitions/regex.sqlx
@@ -1,0 +1,1 @@
+select regexp_extract("", r'abc\de\'fg')

--- a/examples/formatter/definitions/regex.sqlx
+++ b/examples/formatter/definitions/regex.sqlx
@@ -1,1 +1,1 @@
-select regexp_extract("", r'abc\de\'fg select * from self()')
+select regexp_extract("", r'abc\de\'fg select * from self()'), 'bar'

--- a/examples/formatter/definitions/regex.sqlx
+++ b/examples/formatter/definitions/regex.sqlx
@@ -1,1 +1,1 @@
-select regexp_extract("", r'abc\de\'fg')
+select regexp_extract("", r'abc\de\'fg select * from self()')

--- a/tests/api/api.spec.ts
+++ b/tests/api/api.spec.ts
@@ -1105,7 +1105,7 @@ input "something" {
     it("Backslashes within regex don't cause 'r' prefix to separate.", async () => {
       expect(await format.formatFile(path.resolve("df/examples/formatter/definitions/regex.sqlx")))
         .equal(`select
-  regexp_extract("", r'abc\\defg')
+  regexp_extract("", r'abc\\de\\'fg')
 `);
     });
   });

--- a/tests/api/api.spec.ts
+++ b/tests/api/api.spec.ts
@@ -1105,7 +1105,8 @@ input "something" {
     it("Backslashes within regex don't cause 'r' prefix to separate.", async () => {
       expect(await format.formatFile(path.resolve("df/examples/formatter/definitions/regex.sqlx")))
         .equal(`select
-  regexp_extract("", r'abc\\de\\'fg select * from self()')
+  regexp_extract("", r'abc\\de\\'fg select * from self()'),
+  'bar'
 `);
     });
   });

--- a/tests/api/api.spec.ts
+++ b/tests/api/api.spec.ts
@@ -992,115 +992,120 @@ describe("@dataform/api", () => {
   });
 
   describe("formatter", () => {
-    it("correctly formats simple.sqlx", async () => {
-      expect(await format.formatFile(path.resolve("df/examples/formatter/definitions/simple.sqlx")))
-        .eql(`config {
-  type: "view",
-  tags: ["tag1", "tag2"]
-}
+//     it("correctly formats simple.sqlx", async () => {
+//       expect(await format.formatFile(path.resolve("df/examples/formatter/definitions/simple.sqlx")))
+//         .eql(`config {
+//   type: "view",
+//   tags: ["tag1", "tag2"]
+// }
 
-js {
-  const foo =
-    jsFunction("table");
-}
+// js {
+//   const foo =
+//     jsFunction("table");
+// }
 
-select
-  1
-from
-  \${
-    ref({
-      schema: "df_integration_test",
-      name: "sample_data"
-    })
-  }
-`);
-    });
+// select
+//   1
+// from
+//   \${
+//     ref({
+//       schema: "df_integration_test",
+//       name: "sample_data"
+//     })
+//   }
+// `);
+//     });
 
-    it("correctly formats multiple_queries.sqlx", async () => {
-      expect(
-        await format.formatFile(
-          path.resolve("df/examples/formatter/definitions/multiple_queries.sqlx")
-        )
-      ).eql(`js {
-  var tempTable = "yay"
-  const colname = "column";
+//     it("correctly formats multiple_queries.sqlx", async () => {
+//       expect(
+//         await format.formatFile(
+//           path.resolve("df/examples/formatter/definitions/multiple_queries.sqlx")
+//         )
+//       ).eql(`js {
+//   var tempTable = "yay"
+//   const colname = "column";
 
-  let finalTableName = 'dkaodihwada';
-}
+//   let finalTableName = 'dkaodihwada';
+// }
 
-drop something
+// drop something
 
----
+// ---
 
-alter table
-  \${tempTable} rename to \${finalTableName}
+// alter table
+//   \${tempTable} rename to \${finalTableName}
 
----
+// ---
 
-SELECT
-  SUM(IF (session_start_event, 1, 0)) AS session_index
-`);
-    });
+// SELECT
+//   SUM(IF (session_start_event, 1, 0)) AS session_index
+// `);
+//     });
 
-    it("correctly formats bigquery_regexps.sqlx", async () => {
-      expect(
-        await format.formatFile(
-          path.resolve("df/examples/formatter/definitions/bigquery_regexps.sqlx")
-        )
-      ).eql(`config {
-  type: "operation",
-  tags: ["tag1", "tag2"]
-}
+//     it("correctly formats bigquery_regexps.sqlx", async () => {
+//       expect(
+//         await format.formatFile(
+//           path.resolve("df/examples/formatter/definitions/bigquery_regexps.sqlx")
+//         )
+//       ).eql(`config {
+//   type: "operation",
+//   tags: ["tag1", "tag2"]
+// }
 
-select
-  CAST(
-    REGEXP_EXTRACT("", r'^/([0-9]+)\\'/.*') AS INT64
-  ) AS id,
-  CAST(
-    REGEXP_EXTRACT("", r"^/([0-9]+)\\"/.*") AS INT64
-  ) AS id2
-from
-  \${ref("dab")}
-where
-  sample = 100
-`);
-    });
+// select
+//   CAST(
+//     REGEXP_EXTRACT("", r'^/([0-9]+)\\'/.*') AS INT64
+//   ) AS id,
+//   CAST(
+//     REGEXP_EXTRACT("", r"^/([0-9]+)\\"/.*") AS INT64
+//   ) AS id2
+// from
+//   \${ref("dab")}
+// where
+//   sample = 100
+// `);
+//     });
 
-    it("correctly formats comments.sqlx", async () => {
-      expect(
-        await format.formatFile(path.resolve("df/examples/formatter/definitions/comments.sqlx"))
-      ).eql(`config {
-  type: "test",
-}
+//     it("correctly formats comments.sqlx", async () => {
+//       expect(
+//         await format.formatFile(path.resolve("df/examples/formatter/definitions/comments.sqlx"))
+//       ).eql(`config {
+//   type: "test",
+// }
 
-SELECT
-  MAX(
-    (
-      SELECT
-        SUM(
-          IF(
-            track.event = "event_viewed_project_with_connection",
-            1,
-            0
-          )
-        )
-      FROM
-        UNNEST(records)
-    )
-  ) > 0 as created_project,
-  /* multi line
-  comment      */
-  2 as foo
+// SELECT
+//   MAX(
+//     (
+//       SELECT
+//         SUM(
+//           IF(
+//             track.event = "event_viewed_project_with_connection",
+//             1,
+//             0
+//           )
+//         )
+//       FROM
+//         UNNEST(records)
+//     )
+//   ) > 0 as created_project,
+//   /* multi line
+//   comment      */
+//   2 as foo
 
-input "something" {
-  select
-    1 as test
-    /* something */
-    /* something
-    else      */
-    -- and another thing
-}
-`);
+// input "something" {
+//   select
+//     1 as test
+//     /* something */
+//     /* something
+//     else      */
+//     -- and another thing
+// }
+// `);
+//     });
+    it("Backslashes within regex don't cause 'r' prefix to separate.", async () => {
+      expect(await format.formatFile(path.resolve("df/examples/formatter/definitions/regex.sqlx")))
+        .eql(`select
+  regexp_extract("", r'abc\\defg')`);
     });
   });
 });

--- a/tests/api/api.spec.ts
+++ b/tests/api/api.spec.ts
@@ -1105,7 +1105,7 @@ input "something" {
     it("Backslashes within regex don't cause 'r' prefix to separate.", async () => {
       expect(await format.formatFile(path.resolve("df/examples/formatter/definitions/regex.sqlx")))
         .equal(`select
-  regexp_extract("", r'abc\\de\\'fg')
+  regexp_extract("", r'abc\\de\\'fg select * from self()')
 `);
     });
   });

--- a/tests/api/api.spec.ts
+++ b/tests/api/api.spec.ts
@@ -992,120 +992,121 @@ describe("@dataform/api", () => {
   });
 
   describe("formatter", () => {
-//     it("correctly formats simple.sqlx", async () => {
-//       expect(await format.formatFile(path.resolve("df/examples/formatter/definitions/simple.sqlx")))
-//         .eql(`config {
-//   type: "view",
-//   tags: ["tag1", "tag2"]
-// }
+    it("correctly formats simple.sqlx", async () => {
+      expect(await format.formatFile(path.resolve("df/examples/formatter/definitions/simple.sqlx")))
+        .eql(`config {
+  type: "view",
+  tags: ["tag1", "tag2"]
+}
 
-// js {
-//   const foo =
-//     jsFunction("table");
-// }
+js {
+  const foo =
+    jsFunction("table");
+}
 
-// select
-//   1
-// from
-//   \${
-//     ref({
-//       schema: "df_integration_test",
-//       name: "sample_data"
-//     })
-//   }
-// `);
-//     });
+select
+  1
+from
+  \${
+    ref({
+      schema: "df_integration_test",
+      name: "sample_data"
+    })
+  }
+`);
+    });
 
-//     it("correctly formats multiple_queries.sqlx", async () => {
-//       expect(
-//         await format.formatFile(
-//           path.resolve("df/examples/formatter/definitions/multiple_queries.sqlx")
-//         )
-//       ).eql(`js {
-//   var tempTable = "yay"
-//   const colname = "column";
+    it("correctly formats multiple_queries.sqlx", async () => {
+      expect(
+        await format.formatFile(
+          path.resolve("df/examples/formatter/definitions/multiple_queries.sqlx")
+        )
+      ).eql(`js {
+  var tempTable = "yay"
+  const colname = "column";
 
-//   let finalTableName = 'dkaodihwada';
-// }
+  let finalTableName = 'dkaodihwada';
+}
 
-// drop something
+drop something
 
-// ---
+---
 
-// alter table
-//   \${tempTable} rename to \${finalTableName}
+alter table
+  \${tempTable} rename to \${finalTableName}
 
-// ---
+---
 
-// SELECT
-//   SUM(IF (session_start_event, 1, 0)) AS session_index
-// `);
-//     });
+SELECT
+  SUM(IF (session_start_event, 1, 0)) AS session_index
+`);
+    });
 
-//     it("correctly formats bigquery_regexps.sqlx", async () => {
-//       expect(
-//         await format.formatFile(
-//           path.resolve("df/examples/formatter/definitions/bigquery_regexps.sqlx")
-//         )
-//       ).eql(`config {
-//   type: "operation",
-//   tags: ["tag1", "tag2"]
-// }
+    it("correctly formats bigquery_regexps.sqlx", async () => {
+      expect(
+        await format.formatFile(
+          path.resolve("df/examples/formatter/definitions/bigquery_regexps.sqlx")
+        )
+      ).eql(`config {
+  type: "operation",
+  tags: ["tag1", "tag2"]
+}
 
-// select
-//   CAST(
-//     REGEXP_EXTRACT("", r'^/([0-9]+)\\'/.*') AS INT64
-//   ) AS id,
-//   CAST(
-//     REGEXP_EXTRACT("", r"^/([0-9]+)\\"/.*") AS INT64
-//   ) AS id2
-// from
-//   \${ref("dab")}
-// where
-//   sample = 100
-// `);
-//     });
+select
+  CAST(
+    REGEXP_EXTRACT("", r'^/([0-9]+)\\'/.*') AS INT64
+  ) AS id,
+  CAST(
+    REGEXP_EXTRACT("", r"^/([0-9]+)\\"/.*") AS INT64
+  ) AS id2
+from
+  \${ref("dab")}
+where
+  sample = 100
+`);
+    });
 
-//     it("correctly formats comments.sqlx", async () => {
-//       expect(
-//         await format.formatFile(path.resolve("df/examples/formatter/definitions/comments.sqlx"))
-//       ).eql(`config {
-//   type: "test",
-// }
+    it("correctly formats comments.sqlx", async () => {
+      expect(
+        await format.formatFile(path.resolve("df/examples/formatter/definitions/comments.sqlx"))
+      ).eql(`config {
+  type: "test",
+}
 
-// SELECT
-//   MAX(
-//     (
-//       SELECT
-//         SUM(
-//           IF(
-//             track.event = "event_viewed_project_with_connection",
-//             1,
-//             0
-//           )
-//         )
-//       FROM
-//         UNNEST(records)
-//     )
-//   ) > 0 as created_project,
-//   /* multi line
-//   comment      */
-//   2 as foo
+SELECT
+  MAX(
+    (
+      SELECT
+        SUM(
+          IF(
+            track.event = "event_viewed_project_with_connection",
+            1,
+            0
+          )
+        )
+      FROM
+        UNNEST(records)
+    )
+  ) > 0 as created_project,
+  /* multi line
+  comment      */
+  2 as foo
 
-// input "something" {
-//   select
-//     1 as test
-//     /* something */
-//     /* something
-//     else      */
-//     -- and another thing
-// }
-// `);
-//     });
+input "something" {
+  select
+    1 as test
+    /* something */
+    /* something
+    else      */
+    -- and another thing
+}
+`);
+    });
     it("Backslashes within regex don't cause 'r' prefix to separate.", async () => {
       expect(await format.formatFile(path.resolve("df/examples/formatter/definitions/regex.sqlx")))
-        .eql(`select
-  regexp_extract("", r'abc\\defg')`);
+        .equal(`select
+  regexp_extract("", r'abc\\defg')
+`);
     });
   });
 });


### PR DESCRIPTION
Fixes https://github.com/dataform-co/dataform-web-tracking/issues/204

Text lift patterns in the formatter weren't doing as they should have been, replaced them.

Added API test for formatting a file to check that it works as it should do.