### PR TITLE
Testing library to remove dependency on mocha

### DIFF
--- a/testing/BUILD
+++ b/testing/BUILD
@@ -17,7 +17,7 @@ ts_library(
 load("//testing:index.bzl", "ts_test_suite")
 
 ts_test_suite(
-    name = "test_suite",
+    name = "tests",
     srcs = glob(["*.spec.ts"]),
     deps = [
         ":testing",

--- a/testing/BUILD
+++ b/testing/BUILD
@@ -1,0 +1,26 @@
+package(default_visibility = ["//visibility:public"])
+
+load("@npm_bazel_typescript//:index.bzl", "ts_library")
+
+ts_library(
+    name = "testing",
+    srcs = glob(
+        ["*.ts"],
+        exclude = ["*.spec.ts"],
+    ),
+    deps = [
+        "@npm//@types/node",
+        "@npm//chalk",
+    ],
+)
+
+load("//testing:index.bzl", "ts_test_suite")
+
+ts_test_suite(
+    srcs = glob(["*.spec.ts"]),
+    deps = [
+        ":testing",
+        "@npm//@types/chai",
+        "@npm//chai",
+    ],
+)

--- a/testing/BUILD
+++ b/testing/BUILD
@@ -17,6 +17,7 @@ ts_library(
 load("//testing:index.bzl", "ts_test_suite")
 
 ts_test_suite(
+    name = "test_suite",
     srcs = glob(["*.spec.ts"]),
     deps = [
         ":testing",

--- a/testing/hook.ts
+++ b/testing/hook.ts
@@ -21,7 +21,7 @@ export class Hook {
     optionsOrFn: Omit<IHookOptions, "name"> | IHookFunction,
     fn?: IHookFunction
   ) {
-    let options: IHookOptions = { name: null };
+    let options: IHookOptions = typeof nameOrOptions === "string" ? { name: nameOrOptions } : nameOrOptions;
     if (typeof nameOrOptions === "string") {
       options.name = nameOrOptions;
     } else {

--- a/testing/hook.ts
+++ b/testing/hook.ts
@@ -14,7 +14,7 @@ export type IHookHandler = (
 ) => void;
 
 export class Hook {
-  public static readonly DEFAULT_TIMEOUT = 30000;
+  public static readonly DEFAULT_TIMEOUT_MILLIS = 30000;
 
   public static create(
     nameOrOptions: IHookOptions | string,

--- a/testing/hook.ts
+++ b/testing/hook.ts
@@ -1,0 +1,69 @@
+import { IRunContext, IRunResult } from "df/testing";
+
+export type IHookFunction = () => any;
+
+export interface IHookOptions {
+  name: string;
+  timeout?: number;
+}
+
+export type IHookHandler = (
+  nameOrOptions: IHookOptions | string,
+  optionsOrFn: Omit<IHookOptions, "name"> | IHookFunction,
+  fn?: IHookFunction
+) => void;
+
+export class Hook {
+  public static readonly DEFAULT_TIMEOUT = 30000;
+
+  public static create(
+    nameOrOptions: IHookOptions | string,
+    optionsOrFn: Omit<IHookOptions, "name"> | IHookFunction,
+    fn?: IHookFunction
+  ) {
+    let options: IHookOptions = { name: null };
+    if (typeof nameOrOptions === "string") {
+      options.name = nameOrOptions;
+    } else {
+      options = { ...nameOrOptions };
+    }
+    if (typeof optionsOrFn === "function") {
+      fn = optionsOrFn;
+    } else {
+      options = { ...options, ...optionsOrFn };
+    }
+    return new Hook(options, fn);
+  }
+
+  constructor(public readonly options: IHookOptions, private readonly fn: IHookFunction) {}
+
+  public async run(ctx: IRunContext) {
+    let timer: NodeJS.Timer;
+    const timeout = this.options.timeout || Hook.DEFAULT_TIMEOUT;
+    const result: Partial<IRunResult> = {
+      path: [...ctx.path, `${this.options.name} (hook)`]
+    };
+    try {
+      await Promise.race([
+        this.fn(),
+        new Promise((_, reject) => {
+          timer = setTimeout(() => {
+            result.outcome = "timeout";
+            reject(new Error(`Timed out (${timeout}ms).`));
+          }, timeout);
+        })
+      ]);
+      result.outcome = "passed";
+    } catch (e) {
+      if (result.outcome !== "timeout") {
+        result.outcome = "failed";
+      }
+      result.err = e;
+      ctx.results.push(result as IRunResult);
+      // If hooks fail, we throw anyway.
+      throw e;
+    }
+
+    clearTimeout(timer);
+  }
+}

--- a/testing/hook.ts
+++ b/testing/hook.ts
@@ -7,11 +7,17 @@ export interface IHookOptions {
   timeout?: number;
 }
 
-export type IHookHandler = (
+export function hook(name: string | IHookOptions, fn: IHookFunction): Hook;
+export function hook(name: string, options: Omit<IHookOptions, "name">, fn: IHookFunction): Hook;
+export function hook(
   nameOrOptions: IHookOptions | string,
   optionsOrFn: Omit<IHookOptions, "name"> | IHookFunction,
   fn?: IHookFunction
-) => void;
+): Hook {
+  return Hook.create(nameOrOptions, optionsOrFn, fn);
+}
+
+export type IHookHandler = typeof Hook.create;
 
 export class Hook {
   public static readonly DEFAULT_TIMEOUT_MILLIS = 30000;
@@ -20,13 +26,9 @@ export class Hook {
     nameOrOptions: IHookOptions | string,
     optionsOrFn: Omit<IHookOptions, "name"> | IHookFunction,
     fn?: IHookFunction
-  ) {
-    let options: IHookOptions = typeof nameOrOptions === "string" ? { name: nameOrOptions } : nameOrOptions;
-    if (typeof nameOrOptions === "string") {
-      options.name = nameOrOptions;
-    } else {
-      options = { ...nameOrOptions };
-    }
+  ): Hook {
+    let options: IHookOptions =
+      typeof nameOrOptions === "string" ? { name: nameOrOptions } : nameOrOptions;
     if (typeof optionsOrFn === "function") {
       fn = optionsOrFn;
     } else {
@@ -39,9 +41,10 @@ export class Hook {
 
   public async run(ctx: IRunContext) {
     let timer: NodeJS.Timer;
-    const timeout = this.options.timeout || Hook.DEFAULT_TIMEOUT;
-    const result: Partial<IRunResult> = {
-      path: [...ctx.path, `${this.options.name} (hook)`]
+    const timeout = this.options.timeout || Hook.DEFAULT_TIMEOUT_MILLIS;
+    const result: IRunResult = {
+      path: [...ctx.path, `${this.options.name} (hook)`],
+      outcome: "failed"
     };
     try {
       await Promise.race([
@@ -54,16 +57,12 @@ export class Hook {
         })
       ]);
       result.outcome = "passed";
-    } catch (e) {
-      if (result.outcome !== "timeout") {
-        result.outcome = "failed";
-      }
-      result.err = e;
-      ctx.results.push(result as IRunResult);
+    } catch (err) {
+      ctx.results.push({ ...result, err });
       // If hooks fail, we throw anyway.
-      throw e;
+      throw err;
+    } finally {
+      clearTimeout(timer);
     }
-
-    clearTimeout(timer);
   }
 }

--- a/testing/index.bzl
+++ b/testing/index.bzl
@@ -1,0 +1,34 @@
+load("@npm_bazel_typescript//:index.bzl", "ts_library")
+load("@build_bazel_rules_nodejs//:defs.bzl", "nodejs_test")
+
+def ts_test(name, entry_point, data = [], **kwargs):
+    ts_library(
+        name = name + "_library",
+        data = data,
+        testonly = 1,
+        **kwargs
+    )
+    nodejs_test(
+        name = name,
+        data = data + [
+            ":{name}_library".format(name = name),
+        ],
+        entry_point = entry_point,
+    )
+
+def ts_test_suite(srcs, data = [], **kwargs):
+    ts_library(
+        name = "test_suite_library",
+        data = data,
+        srcs = srcs,
+        **kwargs
+    )
+    for src in srcs:
+        if (src[-8:] == ".spec.ts" or src[-8:] == "_test.ts"):
+            nodejs_test(
+                name = src[:-3],
+                data = data + [
+                    ":test_suite_library",
+                ],
+                entry_point = ":" + src,
+            )

--- a/testing/index.bzl
+++ b/testing/index.bzl
@@ -16,9 +16,9 @@ def ts_test(name, entry_point, data = [], **kwargs):
         entry_point = entry_point,
     )
 
-def ts_test_suite(srcs, data = [], **kwargs):
+def ts_test_suite(name, srcs, data = [], **kwargs):
     ts_library(
-        name = "test_suite_library",
+        name = name,
         data = data,
         srcs = srcs,
         **kwargs
@@ -28,7 +28,7 @@ def ts_test_suite(srcs, data = [], **kwargs):
             nodejs_test(
                 name = src[:-3],
                 data = data + [
-                    ":test_suite_library",
+                    ":{name}".format(name = name),
                 ],
                 entry_point = ":" + src,
             )

--- a/testing/index.spec.ts
+++ b/testing/index.spec.ts
@@ -1,5 +1,5 @@
 import { expect } from "chai";
-import { ISuiteContext, Runner, suite } from "df/testing";
+import { ISuiteContext, Runner, suite, test } from "df/testing";
 
 Runner.setNoExit(true);
 
@@ -18,7 +18,7 @@ class ExampleFixture {
 const _ = (async () => {
   try {
     let exampleFixture: ExampleFixture;
-    suite("suite", ({ test, suite }) => {
+    suite("suite", () => {
       test("passes", async () => true);
       test("fails on expectation", () => expect({ value: 1 }).deep.equals({ value: 2 }));
       test("fails on throw", () => {
@@ -32,7 +32,7 @@ const _ = (async () => {
         { timeout: 10 },
         async () => await new Promise(resolve => setTimeout(resolve, 100000))
       );
-      suite("with before and after", ({ test, beforeEach, afterEach }) => {
+      suite("with before and after", ({ beforeEach, afterEach }) => {
         let counter = 0;
         beforeEach("increment counter", () => {
           counter += 1;
@@ -58,7 +58,7 @@ const _ = (async () => {
         });
       });
 
-      suite("can execute in parallel", { parallel: true }, async ({ test }) => {
+      suite("can execute in parallel", { parallel: true }, async () => {
         let counter = 0;
         test({ name: "test1" }, async () => {
           expect(counter).equals(0);
@@ -72,7 +72,7 @@ const _ = (async () => {
         });
       });
 
-      suite("with failing before each hook", ({ beforeEach, test }) => {
+      suite("with failing before each hook", ({ beforeEach }) => {
         beforeEach("hook that fails", () => {
           throw new Error("fail-sync");
         });
@@ -80,7 +80,7 @@ const _ = (async () => {
         test("test", () => true);
       });
 
-      suite("with failing tear down hook", ({ after, test }) => {
+      suite("with failing tear down hook", ({ after }) => {
         after("hook that fails", () => {
           throw new Error("fail-sync");
         });

--- a/testing/index.spec.ts
+++ b/testing/index.spec.ts
@@ -1,0 +1,145 @@
+import { expect } from "chai";
+import { ISuiteContext, Runner, suite, test } from "df/testing";
+
+Runner.setNoExit(true);
+
+class ExampleFixture {
+  public counter = 0;
+  public constructor(ctx: ISuiteContext) {
+    ctx.setUp("reset counter", () => {
+      this.counter = 1;
+    });
+    ctx.tearDown("change counter", () => {
+      this.counter = 2;
+    });
+  }
+}
+
+const _ = (async () => {
+  let exampleFixture: ExampleFixture;
+  suite("suite", () => {
+    test("passes", async () => true);
+    test("fails on expectation", () => expect({ value: 1 }).deep.equals({ value: 2 }));
+    test("fails on throw", () => {
+      throw new Error("fail-sync");
+    });
+    test("fails on promise rejection", async () => {
+      await Promise.reject(new Error("fail-async"));
+    });
+    test(
+      "times out",
+      { timeout: 10 },
+      async () => await new Promise(resolve => setTimeout(resolve, 100000))
+    );
+    suite("with before and after", ({ beforeEach, afterEach }) => {
+      let counter = 0;
+      beforeEach("increment counter", () => {
+        counter += 1;
+      });
+      afterEach("reset counter", () => {
+        counter = 0;
+      });
+      test("passes on first test", () => {
+        expect(counter).equals(1);
+        counter = 2;
+      });
+      test("passes on second test", () => {
+        expect(counter).equals(1);
+        counter = 2;
+      });
+    });
+
+    suite("with set up and tear down", ctx => {
+      exampleFixture = new ExampleFixture(ctx);
+      test({ name: "set up is called" }, () => {
+        expect(exampleFixture.counter).equals(1);
+      });
+    });
+
+    suite("can execute in parallel", { parallel: true }, async () => {
+      let counter = 0;
+      test({ name: "test1" }, async () => {
+        expect(counter).equals(0);
+        await new Promise(resolve => setTimeout(resolve, 10));
+        counter = 1;
+      });
+      test({ name: "test2" }, async () => {
+        expect(counter).equals(0);
+        await new Promise(resolve => setTimeout(resolve, 10));
+        counter = 1;
+      });
+    });
+
+    suite("with failing before each hook", ({ beforeEach }) => {
+      beforeEach("hook that fails", () => {
+        throw new Error("fail-sync");
+      });
+
+      test("test", () => true);
+    });
+
+    suite("with failing tear down hook", ({ tearDown }) => {
+      tearDown("hook that fails", () => {
+        throw new Error("fail-sync");
+      });
+
+      test("test", () => true);
+    });
+  });
+
+  const results = await Runner.result();
+
+  // Override the test exit code behaviour.
+  process.exitCode = 0;
+
+  // Clean up the rest results.
+  const resultsClean = results.map(result => {
+    const newResult = { ...result };
+    if (result.err) {
+      newResult.err = result.err.message;
+    }
+    return newResult;
+  });
+
+  try {
+    expect(resultsClean).deep.members([
+      { path: ["suite", "passes"], outcome: "passed" },
+      {
+        path: ["suite", "fails on expectation"],
+        outcome: "failed",
+        err: "expected { value: 1 } to deeply equal { value: 2 }"
+      },
+      { path: ["suite", "fails on throw"], outcome: "failed", err: "fail-sync" },
+      { path: ["suite", "fails on promise rejection"], outcome: "failed", err: "fail-async" },
+      { path: ["suite", "times out"], outcome: "timeout", err: "Timed out (10ms)." },
+      { path: ["suite", "with before and after", "passes on first test"], outcome: "passed" },
+      { path: ["suite", "with before and after", "passes on second test"], outcome: "passed" },
+      { path: ["suite", "with set up and tear down", "set up is called"], outcome: "passed" },
+      { path: ["suite", "can execute in parallel", "test1"], outcome: "passed" },
+      { path: ["suite", "can execute in parallel", "test2"], outcome: "passed" },
+      {
+        path: ["suite", "with failing before each hook", "test", "hook that fails (hook)"],
+        outcome: "failed",
+        err: "fail-sync"
+      },
+      {
+        path: ["suite", "with failing tear down hook", "test"],
+        outcome: "passed"
+      },
+      {
+        path: ["suite", "with failing tear down hook", "hook that fails (hook)"],
+        outcome: "failed",
+        err: "fail-sync"
+      }
+    ]);
+
+    // Tear down should have been called.
+    expect(exampleFixture.counter).equals(2);
+  } catch (e) {
+    // tslint:disable-next-line: no-console
+    console.error(e);
+    console.log(`Actual: \n ${JSON.stringify(e.actual, null, 4)}`);
+    process.exit(1);
+  }
+  process.exit(0);
+})();

--- a/testing/index.spec.ts
+++ b/testing/index.spec.ts
@@ -1,107 +1,108 @@
 import { expect } from "chai";
-import { ISuiteContext, Runner, suite, test } from "df/testing";
+import { ISuiteContext, Runner, suite } from "df/testing";
 
 Runner.setNoExit(true);
 
 class ExampleFixture {
   public counter = 0;
   public constructor(ctx: ISuiteContext) {
-    ctx.setUp("reset counter", () => {
+    ctx.before("reset counter", () => {
       this.counter = 1;
     });
-    ctx.tearDown("change counter", () => {
+    ctx.after("change counter", () => {
       this.counter = 2;
     });
   }
 }
 
 const _ = (async () => {
-  let exampleFixture: ExampleFixture;
-  suite("suite", () => {
-    test("passes", async () => true);
-    test("fails on expectation", () => expect({ value: 1 }).deep.equals({ value: 2 }));
-    test("fails on throw", () => {
-      throw new Error("fail-sync");
-    });
-    test("fails on promise rejection", async () => {
-      await Promise.reject(new Error("fail-async"));
-    });
-    test(
-      "times out",
-      { timeout: 10 },
-      async () => await new Promise(resolve => setTimeout(resolve, 100000))
-    );
-    suite("with before and after", ({ beforeEach, afterEach }) => {
-      let counter = 0;
-      beforeEach("increment counter", () => {
-        counter += 1;
-      });
-      afterEach("reset counter", () => {
-        counter = 0;
-      });
-      test("passes on first test", () => {
-        expect(counter).equals(1);
-        counter = 2;
-      });
-      test("passes on second test", () => {
-        expect(counter).equals(1);
-        counter = 2;
-      });
-    });
-
-    suite("with set up and tear down", ctx => {
-      exampleFixture = new ExampleFixture(ctx);
-      test({ name: "set up is called" }, () => {
-        expect(exampleFixture.counter).equals(1);
-      });
-    });
-
-    suite("can execute in parallel", { parallel: true }, async () => {
-      let counter = 0;
-      test({ name: "test1" }, async () => {
-        expect(counter).equals(0);
-        await new Promise(resolve => setTimeout(resolve, 10));
-        counter = 1;
-      });
-      test({ name: "test2" }, async () => {
-        expect(counter).equals(0);
-        await new Promise(resolve => setTimeout(resolve, 10));
-        counter = 1;
-      });
-    });
-
-    suite("with failing before each hook", ({ beforeEach }) => {
-      beforeEach("hook that fails", () => {
-        throw new Error("fail-sync");
-      });
-
-      test("test", () => true);
-    });
-
-    suite("with failing tear down hook", ({ tearDown }) => {
-      tearDown("hook that fails", () => {
-        throw new Error("fail-sync");
-      });
-
-      test("test", () => true);
-    });
-  });
-
-  const results = await Runner.result();
-
-  // Override the test exit code behaviour.
-  process.exitCode = 0;
-
-  // Clean up the rest results.
-  const resultsClean = results.map(result => {
-    const newResult = { ...result };
-    if (result.err) {
-      newResult.err = result.err.message;
-    }
-    return newResult;
-  });
-
   try {
+    let exampleFixture: ExampleFixture;
+    suite("suite", ({ test, suite }) => {
+      test("passes", async () => true);
+      test("fails on expectation", () => expect({ value: 1 }).deep.equals({ value: 2 }));
+      test("fails on throw", () => {
+        throw new Error("fail-sync");
+      });
+      test("fails on promise rejection", async () => {
+        await Promise.reject(new Error("fail-async"));
+      });
+      test(
+        "times out",
+        { timeout: 10 },
+        async () => await new Promise(resolve => setTimeout(resolve, 100000))
+      );
+      suite("with before and after", ({ test, beforeEach, afterEach }) => {
+        let counter = 0;
+        beforeEach("increment counter", () => {
+          counter += 1;
+        });
+        afterEach("reset counter", () => {
+          counter = 0;
+        });
+        test("passes on first test", () => {
+          expect(counter).equals(1);
+          counter = 2;
+        });
+        test("passes on second test", () => {
+          expect(counter).equals(1);
+          counter = 2;
+        });
+      });
+
+      suite("with set up and tear down", ctx => {
+        const { test } = ctx;
+        exampleFixture = new ExampleFixture(ctx);
+        test({ name: "set up is called" }, () => {
+          expect(exampleFixture.counter).equals(1);
+        });
+      });
+
+      suite("can execute in parallel", { parallel: true }, async ({ test }) => {
+        let counter = 0;
+        test({ name: "test1" }, async () => {
+          expect(counter).equals(0);
+          await new Promise(resolve => setTimeout(resolve, 10));
+          counter = 1;
+        });
+        test({ name: "test2" }, async () => {
+          expect(counter).equals(0);
+          await new Promise(resolve => setTimeout(resolve, 10));
+          counter = 1;
+        });
+      });
+
+      suite("with failing before each hook", ({ beforeEach, test }) => {
+        beforeEach("hook that fails", () => {
+          throw new Error("fail-sync");
+        });
+
+        test("test", () => true);
+      });
+
+      suite("with failing tear down hook", ({ after, test }) => {
+        after("hook that fails", () => {
+          throw new Error("fail-sync");
+        });
+
+        test("test", () => true);
+      });
+    });
+
+    const results = await Runner.result();
+
+    // Override the test exit code behaviour.
+    process.exitCode = 0;
+
+    // Clean up the rest results.
+    const resultsClean = results.map(result => {
+      const newResult = { ...result };
+      if (result.err) {
+        newResult.err = result.err.message;
+      }
+      return newResult;
+    });
+
     expect(resultsClean).deep.members([
       { path: ["suite", "passes"], outcome: "passed" },
       {

--- a/testing/index.ts
+++ b/testing/index.ts
@@ -1,0 +1,4 @@
+export * from "df/testing/hook";
+export * from "df/testing/suite";
+export * from "df/testing/test";
+export * from "df/testing/runner";

--- a/testing/runner.ts
+++ b/testing/runner.ts
@@ -1,0 +1,114 @@
+import chalk from "chalk";
+import { Suite } from "df/testing";
+import { promisify } from "util";
+
+export interface IRunResult {
+  path: string[];
+  err: any;
+  outcome: "passed" | "timeout" | "failed";
+}
+
+export interface IRunContext {
+  path: string[];
+  results: IRunResult[];
+}
+
+export class Runner {
+  public static setNoExit(noExit: boolean) {
+    Runner.noExit = noExit;
+  }
+  public static queueRunAndExit() {
+    if (!Runner.resultPromise) {
+      Runner.resultPromise = Runner.run();
+    }
+  }
+
+  // tslint:disable: no-console
+  public static async run() {
+    // We tell the runner to start running at the end of current block of
+    // synchronously executed code. This will typically be after all the
+    // suite definitions are evaluated.
+    await promisify(process.nextTick)();
+    const ctx: IRunContext = {
+      path: [],
+      results: []
+    };
+
+    await Suite.globalStack[0].run(ctx);
+
+    if (ctx.results.length === 0) {
+      ctx.results.push({
+        path: [],
+        err: new Error("No tests found in top level test suite."),
+        outcome: "failed"
+      });
+    }
+    const indent = (value: string, levels = 4) =>
+      value
+        .split("\n")
+        .map(line => `${new Array(levels).fill(" ").join("")}${line}`)
+        .join("\n");
+
+    for (const result of ctx.results) {
+      const outcomeString = (result.outcome || "unknown").toUpperCase();
+      const pathString = result.path.join(" > ");
+
+      const colorFn =
+        result.outcome === "failed" || result.outcome === "timeout"
+          ? chalk.red
+          : result.outcome === "passed"
+          ? chalk.green
+          : chalk.yellow;
+      if (pathString.length + outcomeString.length + 1 <= 80) {
+        console.info(
+          `${pathString}${new Array(80 - pathString.length - outcomeString.length - 1)
+            .fill(" ")
+            .join("")}${colorFn(outcomeString)}`
+        );
+      } else {
+        console.info(pathString);
+        console.info(
+          `${new Array(80 - outcomeString.length - 1).fill(" ").join("")}${colorFn(outcomeString)}`
+        );
+      }
+
+      if (result.err) {
+        const errString = result.err.stack
+          ? result.err.stack && indent(result.err.stack as string)
+          : `    ${JSON.stringify(result.err, null, 4)}`;
+
+        console.error(`\n${errString}\n`);
+        if (result.err.showDiff) {
+          console.error(`    Expected:\n`);
+          console.error(indent(JSON.stringify(result.err.expected, null, 4), 8));
+          console.error(`\n    Actual:\n`);
+          console.error(indent(JSON.stringify(result.err.actual, null, 4), 8));
+          console.error("\n");
+        }
+      }
+    }
+
+    const hasErrors = ctx.results.some(result => result.outcome !== "passed");
+
+    if (hasErrors) {
+      console.log(`\nTests failed.`);
+    } else {
+      console.log(`\nTests passed.`);
+    }
+
+    process.exitCode = hasErrors ? 1 : 0;
+
+    if (!Runner.noExit) {
+      process.exit();
+    }
+
+    return ctx.results;
+  }
+
+  public static async result() {
+    return await Runner.resultPromise;
+  }
+  private static noExit = false;
+
+  private static resultPromise: Promise<IRunResult[]>;
+}

--- a/testing/runner.ts
+++ b/testing/runner.ts
@@ -46,7 +46,7 @@ export class Runner {
     const indent = (value: string, levels = 4) =>
       value
         .split("\n")
-        .map(line => `${new Array(levels).fill(" ").join("")}${line}`)
+        .map(line => `${" ".repeat(4).join("")}${line}`)
         .join("\n");
 
     for (const result of ctx.results) {

--- a/testing/runner.ts
+++ b/testing/runner.ts
@@ -16,7 +16,7 @@ export interface IRunContext {
 export class Runner {
   public static readonly topLevelSuites: Set<Suite> = new Set();
 
-  public static register(suite: Suite) {
+  public static registerTopLevelSuite(suite: Suite) {
     Runner.topLevelSuites.add(suite);
     Runner.queueRun();
   }

--- a/testing/runner.ts
+++ b/testing/runner.ts
@@ -4,8 +4,8 @@ import { promisify } from "util";
 
 export interface IRunResult {
   path: string[];
-  err: any;
   outcome: "passed" | "timeout" | "failed";
+  err?: any;
 }
 
 export interface IRunContext {
@@ -14,10 +14,17 @@ export interface IRunContext {
 }
 
 export class Runner {
+  public static readonly topLevelSuites: Set<Suite> = new Set();
+
+  public static register(suite: Suite) {
+    Runner.topLevelSuites.add(suite);
+    Runner.queueRun();
+  }
+
   public static setNoExit(noExit: boolean) {
     Runner.noExit = noExit;
   }
-  public static queueRunAndExit() {
+  public static queueRun() {
     if (!Runner.resultPromise) {
       Runner.resultPromise = Runner.run();
     }
@@ -27,14 +34,14 @@ export class Runner {
   public static async run() {
     // We tell the runner to start running at the end of current block of
     // synchronously executed code. This will typically be after all the
-    // suite definitions are evaluated.
+    // suite definitions are evaluated. This is equivelant to setTimeout(..., 0).
     await promisify(process.nextTick)();
     const ctx: IRunContext = {
       path: [],
       results: []
     };
 
-    await Suite.globalStack[0].run(ctx);
+    await Promise.all([...this.topLevelSuites].map(suite => suite.run(ctx)));
 
     if (ctx.results.length === 0) {
       ctx.results.push({
@@ -46,7 +53,7 @@ export class Runner {
     const indent = (value: string, levels = 4) =>
       value
         .split("\n")
-        .map(line => `${" ".repeat(4).join("")}${line}`)
+        .map(line => `${" ".repeat(4)}${line}`)
         .join("\n");
 
     for (const result of ctx.results) {

--- a/testing/suite.ts
+++ b/testing/suite.ts
@@ -1,0 +1,153 @@
+import { Hook, IHookHandler, IRunContext, Runner, test, Test } from "df/testing";
+
+export interface ISuiteOptions {
+  name: string;
+  parallel?: boolean;
+}
+
+export interface ISuiteContext {
+  suite: typeof suite;
+  test: typeof test;
+  beforeEach: IHookHandler;
+  afterEach: IHookHandler;
+  setUp: IHookHandler;
+  tearDown: IHookHandler;
+}
+
+export function suite(
+  nameOrOptions: ISuiteOptions | string,
+  optionsOrFn: Omit<ISuiteOptions, "name"> | ((ctx?: ISuiteContext) => void),
+  fn?: (ctx?: ISuiteContext) => void
+): void {
+  Suite.globalStack.slice(-1)[0].addSuite(Suite.create(nameOrOptions, optionsOrFn, fn));
+  Runner.queueRunAndExit();
+}
+
+export class Suite {
+  public static readonly globalStack: Suite[] = [new Suite({ name: undefined }, () => null)];
+
+  public static create(
+    nameOrOptions: ISuiteOptions | string,
+    optionsOrFn: Omit<ISuiteOptions, "name"> | ((ctx?: ISuiteContext) => void),
+    fn?: (ctx?: ISuiteContext) => void
+  ) {
+    let options: ISuiteOptions = { name: null };
+    if (typeof nameOrOptions === "string") {
+      options.name = nameOrOptions;
+    } else {
+      options = { ...nameOrOptions };
+    }
+    if (typeof optionsOrFn === "function") {
+      fn = optionsOrFn;
+    } else {
+      options = { ...options, ...optionsOrFn };
+    }
+    return new Suite(options, fn);
+  }
+
+  private suites: Suite[] = [];
+  private tests: Test[] = [];
+
+  private setUps: Hook[] = [];
+  private tearDowns: Hook[] = [];
+  private beforeEaches: Hook[] = [];
+  private afterEaches: Hook[] = [];
+
+  private runStarted: boolean;
+
+  constructor(public readonly options: ISuiteOptions, fn: (ctx?: ISuiteContext) => void) {
+    if (Suite.globalStack) {
+      Suite.globalStack.push(this);
+    }
+    fn(this.context());
+    if (Suite.globalStack) {
+      Suite.globalStack.pop();
+    }
+  }
+
+  public async run(ctx: IRunContext) {
+    const testsAndSuites = [...this.suites, ...this.tests];
+    const path = this.options.name === undefined ? ctx.path : [...ctx.path, this.options.name];
+    const runTestOrSuite = async (testOrSuite: Suite | Test) => {
+      const testCtx = {
+        ...ctx,
+        path: [...path, testOrSuite.options.name]
+      };
+      try {
+        for (const beforeEach of this.beforeEaches) {
+          await beforeEach.run(testCtx);
+        }
+        await testOrSuite.run({ ...ctx, path });
+      } catch (e) {
+        // If a before each fails, we should still run the after eaches.
+      }
+      try {
+        for (const afterEach of this.afterEaches) {
+          await afterEach.run(testCtx);
+        }
+      } catch (e) {
+        // If an after each fails, carry on.
+      }
+    };
+
+    try {
+      for (const setUp of this.setUps) {
+        await setUp.run({ ...ctx, path });
+      }
+
+      if (this.options.parallel) {
+        await Promise.all(testsAndSuites.map(testOrSuite => runTestOrSuite(testOrSuite)));
+      } else {
+        for (const testOrSuite of testsAndSuites) {
+          await runTestOrSuite(testOrSuite);
+        }
+      }
+    } catch (e) {
+      // If a set up fails, still run the tear downs.
+    }
+    try {
+      for (const tearDown of this.tearDowns) {
+        await tearDown.run({ ...ctx, path });
+      }
+    } catch (e) {
+      // If an tear down fails, carry on.
+    }
+  }
+
+  public addSuite(suite: Suite) {
+    this.checkMutation();
+    this.suites.push(suite);
+  }
+
+  public addTest(test: Test) {
+    this.checkMutation();
+    this.tests.push(test);
+  }
+
+  private addHook(hookList: Hook[], hook: Hook) {
+    this.checkMutation();
+    hookList.push(hook);
+  }
+
+  private checkMutation() {
+    if (this.runStarted) {
+      throw new Error("Cannot mutate a suite that has already started running.");
+    }
+    if (Suite.globalStack.slice(-1)[0] !== this) {
+      throw new Error(
+        "Cannot mutate a suite that is not currently in scope (suite configuration must be synchronous)."
+      );
+    }
+  }
+
+  private context(): ISuiteContext {
+    return {
+      suite: (...args) => this.addSuite(Suite.create(...args)),
+      test: (...args) => this.addTest(Test.create(...args)),
+      beforeEach: (...args) => this.addHook(this.beforeEaches, Hook.create(...args)),
+      afterEach: (...args) => this.addHook(this.afterEaches, Hook.create(...args)),
+      setUp: (...args) => this.addHook(this.setUps, Hook.create(...args)),
+      tearDown: (...args) => this.addHook(this.tearDowns, Hook.create(...args))
+    };
+  }
+}

--- a/testing/suite.ts
+++ b/testing/suite.ts
@@ -1,4 +1,4 @@
-import { Hook, IHookHandler, IRunContext, Runner, test, Test } from "df/testing";
+import { Hook, hook, IRunContext, Runner, test, Test } from "df/testing";
 
 export interface ISuiteOptions {
   name: string;
@@ -8,35 +8,39 @@ export interface ISuiteOptions {
 export interface ISuiteContext {
   suite: typeof suite;
   test: typeof test;
-  beforeEach: IHookHandler;
-  afterEach: IHookHandler;
-  setUp: IHookHandler;
-  tearDown: IHookHandler;
+  beforeEach: typeof hook;
+  afterEach: typeof hook;
+  before: typeof hook;
+  after: typeof hook;
 }
 
+export function suite(name: string | ISuiteOptions, fn: (ctx?: ISuiteContext) => void): void;
+export function suite(
+  name: string,
+  options: Omit<ISuiteOptions, "name">,
+  fn: (ctx?: ISuiteContext) => void
+): void;
 export function suite(
   nameOrOptions: ISuiteOptions | string,
   optionsOrFn: Omit<ISuiteOptions, "name"> | ((ctx?: ISuiteContext) => void),
   fn?: (ctx?: ISuiteContext) => void
-): void {
-  Suite.globalStack.slice(-1)[0].addSuite(Suite.create(nameOrOptions, optionsOrFn, fn));
-  Runner.queueRunAndExit();
+) {
+  if (Suite.globalStack.length > 0) {
+    throw new Error("Cannot create a top level suite inside a suite. Call ctx.suite instead.");
+  }
+  Runner.register(Suite.create(nameOrOptions, optionsOrFn, fn));
 }
 
 export class Suite {
-  public static readonly globalStack: Suite[] = [new Suite({ name: undefined }, () => null)];
+  public static readonly globalStack: Suite[] = [];
 
   public static create(
     nameOrOptions: ISuiteOptions | string,
     optionsOrFn: Omit<ISuiteOptions, "name"> | ((ctx?: ISuiteContext) => void),
     fn?: (ctx?: ISuiteContext) => void
-  ) {
-    let options: ISuiteOptions = { name: null };
-    if (typeof nameOrOptions === "string") {
-      options.name = nameOrOptions;
-    } else {
-      options = { ...nameOrOptions };
-    }
+  ): Suite {
+    let options: ISuiteOptions =
+      typeof nameOrOptions === "string" ? { name: nameOrOptions } : { ...nameOrOptions };
     if (typeof optionsOrFn === "function") {
       fn = optionsOrFn;
     } else {
@@ -131,23 +135,28 @@ export class Suite {
 
   private checkMutation() {
     if (this.runStarted) {
-      throw new Error("Cannot mutate a suite that has already started running.");
+      throw new Error("Cannot add to a suite that has already started running.");
     }
     if (Suite.globalStack.slice(-1)[0] !== this) {
       throw new Error(
-        "Cannot mutate a suite that is not currently in scope (suite configuration must be synchronous)."
+        "Cannot add to a suite that is not currently in scope. Call ctx.suite, ctx.test, ctx.before/after instead."
       );
     }
   }
 
   private context(): ISuiteContext {
+    // The any types here are required due to method overloads.
     return {
-      suite: (...args) => this.addSuite(Suite.create(...args)),
-      test: (...args) => this.addTest(Test.create(...args)),
-      beforeEach: (...args) => this.addHook(this.beforeEaches, Hook.create(...args)),
-      afterEach: (...args) => this.addHook(this.afterEaches, Hook.create(...args)),
-      setUp: (...args) => this.addHook(this.setUps, Hook.create(...args)),
-      tearDown: (...args) => this.addHook(this.tearDowns, Hook.create(...args))
+      suite: ((...args: [any, any, any]) => this.addSuite(Suite.create(...args))) as typeof suite,
+      test: ((...args: [any, any, any]) => this.addTest(Test.create(...args))) as typeof test,
+      beforeEach: ((...args: [any, any, any]) =>
+        this.addHook(this.beforeEaches, Hook.create(...args))) as typeof hook,
+      afterEach: ((...args: [any, any, any]) =>
+        this.addHook(this.afterEaches, Hook.create(...args))) as typeof hook,
+      before: ((...args: [any, any, any]) =>
+        this.addHook(this.setUps, Hook.create(...args))) as typeof hook,
+      after: ((...args: [any, any, any]) =>
+        this.addHook(this.tearDowns, Hook.create(...args))) as typeof hook
     };
   }
 }

--- a/testing/suite.ts
+++ b/testing/suite.ts
@@ -25,10 +25,12 @@ export function suite(
   optionsOrFn: Omit<ISuiteOptions, "name"> | ((ctx?: ISuiteContext) => void),
   fn?: (ctx?: ISuiteContext) => void
 ) {
+  const suite = Suite.create(nameOrOptions, optionsOrFn, fn);
   if (Suite.globalStack.length > 0) {
-    throw new Error("Cannot create a top level suite inside a suite. Call ctx.suite instead.");
+    Suite.globalStack.slice(-1)[0].addSuite(suite);
+  } else {
+    Runner.registerTopLevelSuite(suite);
   }
-  Runner.register(Suite.create(nameOrOptions, optionsOrFn, fn));
 }
 
 export class Suite {

--- a/testing/test.ts
+++ b/testing/test.ts
@@ -1,0 +1,69 @@
+import { IRunContext, IRunResult, Runner, Suite } from "df/testing";
+
+interface ITestOptions {
+  name: string;
+  timeout?: number;
+}
+
+export function test(
+  nameOrOptions: ITestOptions | string,
+  optionsOrFn: Omit<ITestOptions, "name"> | (() => void),
+  fn?: () => void
+): void {
+  Suite.globalStack.slice(-1)[0].addTest(Test.create(nameOrOptions, optionsOrFn, fn));
+  Runner.queueRunAndExit();
+}
+
+export class Test {
+  public static readonly DEFAULT_TIMEOUT = 30000;
+
+  public static create(
+    nameOrOptions: ITestOptions | string,
+    optionsOrFn: Omit<ITestOptions, "name"> | (() => void),
+    fn?: () => void
+  ) {
+    let options: ITestOptions = { name: null };
+    if (typeof nameOrOptions === "string") {
+      options.name = nameOrOptions;
+    } else {
+      options = { ...nameOrOptions };
+    }
+    if (typeof optionsOrFn === "function") {
+      fn = optionsOrFn;
+    } else {
+      options = { ...options, ...optionsOrFn };
+    }
+    return new Test(options, fn);
+  }
+
+  constructor(public readonly options: ITestOptions, private readonly fn: () => any) {}
+
+  public async run(ctx: IRunContext) {
+    let timer: NodeJS.Timer;
+    const timeout = this.options.timeout || Test.DEFAULT_TIMEOUT;
+    const result: Partial<IRunResult> = {
+      path: [...ctx.path, this.options.name]
+    };
+    try {
+      await Promise.race([
+        this.fn(),
+        new Promise((_, reject) => {
+          timer = setTimeout(() => {
+            result.outcome = "timeout";
+            reject(new Error(`Timed out (${timeout}ms).`));
+          }, timeout);
+        })
+      ]);
+      result.outcome = "passed";
+    } catch (e) {
+      if (result.outcome !== "timeout") {
+        result.outcome = "failed";
+      }
+      result.err = e;
+    }
+
+    clearTimeout(timer);
+
+    ctx.results.push(result as IRunResult);
+  }
+}

--- a/testing/test.ts
+++ b/testing/test.ts
@@ -16,7 +16,12 @@ export function test(
   optionsOrFn: Omit<ITestOptions, "name"> | (() => void),
   fn?: () => void
 ): void {
-  throw new Error("Cannot create a top level test, must be created in a suite.");
+  const test = Test.create(nameOrOptions, optionsOrFn, fn);
+  if (Suite.globalStack.length > 0) {
+    Suite.globalStack.slice(-1)[0].addTest(test);
+  } else {
+    throw new Error("Cannot create a top level test, must be created in a suite.");
+  }
 }
 
 export class Test {

--- a/testing/test.ts
+++ b/testing/test.ts
@@ -15,7 +15,7 @@ export function test(
 }
 
 export class Test {
-  public static readonly DEFAULT_TIMEOUT = 30000;
+  public static readonly DEFAULT_TIMEOUT_MILLIS = 30000;
 
   public static create(
     nameOrOptions: ITestOptions | string,


### PR DESCRIPTION
Mocha causes us a few issues, as it needs to be run through the CLI, we have complex bazel rules to deal with this. It has annoyingly globally scoped types and does a lot more than we need it to.

This PR introduces a simple testing library that can be used without a CLI, where each test is simply considered a binary with a exit set according to whether it passes or not. It also adds rules `ts_test` and `ts_test_suite` for making writing bazel rules easier.

The library itself is otherwise very similar to `mocha`, without the globals, CLI, and slightly more strict usage patterns.

Features:
- Parallel test suites
- Timeouts
- Sub suites
- Hooks: beforeEach, afterEach, setUp, tearDown
- Deep diffing on log output
- Log format that matches bazel

In the future, we should I think be able to use `bazel` for coverage metrics without any additional effort with this set up after this work is finished: https://github.com/bazelbuild/rules_nodejs/pull/1135