### PR TITLE
Grpc web proxy http1 support

### DIFF
--- a/tools/grpc-web-proxy/cli.ts
+++ b/tools/grpc-web-proxy/cli.ts
@@ -22,8 +22,10 @@ if (argv.secure === "insecure") {
     key: fs.readFileSync(argv["ssl-key-path"], "utf8"),
     cert: fs.readFileSync(argv["ssl-cert-path"], "utf8")
   };
-} else {
+} else if (argv.secure === "fake-https") {
   options.secure = "fake-https";
+} else {
+  options.secure = "http1";
 }
 
 const _ = new GrpcWebProxy(options);

--- a/tools/grpc-web-proxy/cli.ts
+++ b/tools/grpc-web-proxy/cli.ts
@@ -1,12 +1,15 @@
 #!/usr/bin/env node
-import { GrpcWebProxy, IGrpcWebProxyOptions } from "@dataform/grpc-web-proxy";
+import { GrpcWebProxy, IGrpcWebProxyOptions, Mode } from "@dataform/grpc-web-proxy";
 import * as fs from "fs";
 import * as yargs from "yargs";
 
 const argv = yargs
-  .option("backend", { type: "string" })
+  .option("backend", {
+    type: "string",
+    describe: "URL to the backend such as http://localhost:8000"
+  })
   .option("port", { type: "number" })
-  .option("secure", { type: "string" })
+  .option("mode", { type: "string", choices: [...Mode] })
   .option("ssl-key-path", { type: "string" })
   .option("ssl-cert-path", { type: "string" }).argv;
 
@@ -15,17 +18,13 @@ const options: IGrpcWebProxyOptions = {
   port: argv.port
 };
 
-if (argv.secure === "insecure") {
-  options.secure = "insecure";
-} else if (argv["ssl-key-path"]) {
-  options.secure = {
-    key: fs.readFileSync(argv["ssl-key-path"], "utf8"),
-    cert: fs.readFileSync(argv["ssl-cert-path"], "utf8")
-  };
-} else if (argv.secure === "fake-https") {
-  options.secure = "fake-https";
-} else {
-  options.secure = "http1";
+if (argv.mode) {
+  options.mode = argv.mode;
+}
+
+if (argv["ssl-key-path"]) {
+  options.key = fs.readFileSync(argv["ssl-key-path"], "utf8");
+  options.cert = fs.readFileSync(argv["ssl-cert-path"], "utf8");
 }
 
 const _ = new GrpcWebProxy(options);

--- a/tools/grpc-web-proxy/grpc-web-proxy.package.json
+++ b/tools/grpc-web-proxy/grpc-web-proxy.package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dataform/grpc-web-proxy",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "description": "A simple HTTP2 grpc-web-proxy for Node.",
   "homepage": "https://github.com/dataform-co/dataform/tools/grpc-web-proxy",
   "license": "MIT",

--- a/tools/grpc-web-proxy/readme.md
+++ b/tools/grpc-web-proxy/readme.md
@@ -24,18 +24,18 @@ To start the proxy, you must set a backend address (the gRPC service you want to
 npx grpc-web-proxy --backend http://localhost:1234 --port 8000
 ```
 
-By default this will run an HTTPS server using fake credentials, as most browsers require HTTPS for HTTP2.
+By default this will run an insecure HTTP/1 server.
 
-To run a normal http server anyway:
+To run an insecure HTTP2 server:
 
 ```bash
-npx grpc-web-proxy --backend http://localhost:1234 --port 8000 --secure insecure
+npx grpc-web-proxy --backend http://localhost:1234 --port 8000 --mode http2-insecure
 ```
 
-To provide your own certs:
+To provide your own certs for a HTTP/2 server:
 
 ```bash
-npx grpc-web-proxy --backend http://localhost:1234 --port 8000 --ssl-key-path somekey.key --ssl-cert-path somecert.crt
+npx grpc-web-proxy --backend http://localhost:1234 --port 8000 --mode http2-secure --ssl-key-path somekey.key --ssl-cert-path somecert.crt
 ```
 
 ## Usage (Code)
@@ -45,27 +45,33 @@ If you want to run the proxy inside an existing node server, you can do the foll
 ```js
 import { GrpcWebProxy } from "@dataform/grpc-web-proxy";
 
-// Fake HTTPS.
+// Insecure HTTP/1.
 new GrpcWebProxy({
     backend: "http://localhost:1234",
     port: 8000
 });
 
-// Secure.
+// Fake HTTPS/2.
 new GrpcWebProxy({
     backend: "http://localhost:1234",
     port: 8000,
-    secure: {
-        key: ...,
-        cert: ...
-    }
+    mode: "http2-fake-https"
 });
 
-// Insecure.
+// Secure HTTPS/2.
 new GrpcWebProxy({
     backend: "http://localhost:1234",
     port: 8000,
-    secure: "insecure"
+    mode: "http2-secure",
+    key: ...,
+    cert: ...
+});
+
+// Insecure HTTPS/2.
+new GrpcWebProxy({
+    backend: "http://localhost:1234",
+    port: 8000,
+    mode: "http2-insecure"
 });
 ```
 


### PR DESCRIPTION
Because HTTP2 caused us a load of issues with certs running locally.