### PR TITLE
Keep a cache of protobuf type Properties.

### DIFF
--- a/protomongo/protomongo.go
+++ b/protomongo/protomongo.go
@@ -45,7 +45,7 @@ func (pc *protobufCodec) EncodeValue(ectx bsoncodec.EncodeContext, vw bsonrw.Val
 	for _, prop := range ph.oneofFieldWrapperProps {
 		fVal := val.FieldByName(prop.Name)
 		if !fVal.IsZero() {
-			// If this field is a oneof, we need to get the single Go value stored inside its oneof struct,
+			// Since this field is a oneof, we need to get the single Go value stored inside its oneof wrapper struct,
 			// instead of simply using the value as-is.
 			oneof := fVal.Elem().Elem()
 			singleProp := proto.GetProperties(oneof.Type()).Prop[0]

--- a/protomongo/protomongo_test.go
+++ b/protomongo/protomongo_test.go
@@ -103,7 +103,7 @@ var (
 
 func TestMarshalUnmarshal(t *testing.T) {
 	rb := bson.NewRegistryBuilder()
-	rb.RegisterCodec(reflect.TypeOf((*proto.Message)(nil)).Elem(), &ProtobufCodec{})
+	rb.RegisterCodec(reflect.TypeOf((*proto.Message)(nil)).Elem(), NewProtobufCodec())
 	reg := rb.Build()
 
 	for _, testCase := range tests {
@@ -123,7 +123,7 @@ func TestMarshalUnmarshal(t *testing.T) {
 
 func TestMarshalUnmarshalWithPointers(t *testing.T) {
 	rb := bson.NewRegistryBuilder()
-	rb.RegisterCodec(reflect.TypeOf((*proto.Message)(nil)).Elem(), &ProtobufCodec{})
+	rb.RegisterCodec(reflect.TypeOf((*proto.Message)(nil)).Elem(), NewProtobufCodec())
 	reg := rb.Build()
 
 	for _, testCase := range tests {


### PR DESCRIPTION
Each time we encode or decode a single instance of a protobuf, we do a bunch of work involving protobuf descriptors & reflection. This PR stores the results of that work in a cache keyed by protobuf name, so that we shouldn't ever need to re-do it after computing it once.