### PR TITLE
Handled 404s and add robots.txt to docs site

### DIFF
--- a/docs/pages/_docs.tsx
+++ b/docs/pages/_docs.tsx
@@ -44,6 +44,11 @@ export class Docs extends React.Component<IProps> {
     const tree = await getContentTree(query.version);
     const current = tree.getChild(path);
 
+    if (!current) {
+      ctx.res.writeHead(404);
+      ctx.res.end();
+    }
+
     return { index: tree.index(), current, version: query.version };
   }
 

--- a/docs/public/robots.txt
+++ b/docs/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow:


### PR DESCRIPTION
Makes sure that when a path isn't found, it returns a 404 instead of a 500 error.
Also add an allow all robots.txt.