### PR TITLE
Clusterby length check

### DIFF
--- a/core/adapters/bigquery.ts
+++ b/core/adapters/bigquery.ts
@@ -75,7 +75,7 @@ export class BigQueryAdapter extends Adapter implements IAdapter {
         ? `partition by ${table.bigquery.partitionBy} `
         : ""
     }${
-      table.bigquery && table.bigquery.clusterBy
+      table.bigquery && table.bigquery.clusterBy && table.bigquery.clusterBy.length > 0
         ? `cluster by ${table.bigquery.clusterBy.join(", ")} `
         : ""
     }as ${table.query}`;

--- a/tests/api/api.spec.ts
+++ b/tests/api/api.spec.ts
@@ -490,7 +490,8 @@ suite("@dataform/api", () => {
             type: "table",
             query: "select 1 as test",
             bigquery: {
-              partitionBy: "DATE(test)"
+              partitionBy: "DATE(test)",
+              clusterBy: []
             }
           },
           {

--- a/tests/api/examples.spec.ts
+++ b/tests/api/examples.spec.ts
@@ -1,9 +1,9 @@
 import { Builder, compile } from "@dataform/api";
 import * as utils from "@dataform/core/utils";
 import { dataform } from "@dataform/protos";
+import { suite, test } from "@dataform/testing";
 import { fail } from "assert";
 import { expect } from "chai";
-import { suite, test } from "@dataform/testing";
 import { cleanSql } from "df/tests/utils";
 import * as path from "path";
 


### PR DESCRIPTION
Add 0 length check to `clusterBy`.

`clusterBy` wasn't set to it's default value of `[]` which is why this was missed in the tests. In order to prevent this in future nested protobufs in the API tests should be casted.

I'll look into a nice way of creating nested protobufs without having to add a huge amount of code now.