### PR TITLE
Fix regex hash injections and testing module improvements

### DIFF
--- a/api/commands/format.ts
+++ b/api/commands/format.ts
@@ -13,7 +13,10 @@ const JS_BEAUTIFY_OPTIONS: JsBeautifyOptions = {
 
 const MAX_SQL_FORMAT_ATTEMPTS = 5;
 
-const TEXT_LIFT_PATTERNS = [/r'.*?(?<!\\)'/g, /r".*?(?<!\\)"/g];
+// TODO: currently r'...' are only lifted if there is a whitespace beforehand due to
+// the positive lookbehind. Instead the regex should be matched regardless of a prior
+// whitespace. Does this require matching a reversed string? @ekrekr.
+const TEXT_LIFT_PATTERNS = [/(?<=[ ])r'.*?(?<!\\)'/, /(?<=[ ])r".*?(?<!\\)"/];
 
 export async function formatFile(
   filename: string,

--- a/examples/formatter/definitions/bigquery_regexps.sqlx
+++ b/examples/formatter/definitions/bigquery_regexps.sqlx
@@ -3,5 +3,11 @@ config { type: "operation",
 }
 
 select CAST(REGEXP_EXTRACT("", r'^/([0-9]+)\'/.*') AS INT64) AS id,
-       CAST(REGEXP_EXTRACT("", r"^/([0-9]+)\"/.*") AS INT64) AS id2 from ${ref("dab")} 
+       CAST(REGEXP_EXTRACT("", r"^/([0-9]+)\"/.*") AS INT64) AS id2,
+       IFNULL (
+         regexp_extract('', r'\a?query=([^&]+)&*'),
+         regexp_extract('', r'\a?q=([^&]+)&*')
+       ) AS id3,
+       regexp_extract('bar', r'bar') as ID4 from ${ref("dab")}
+
 where sample = 100

--- a/examples/formatter/definitions/bigquery_regexps.sqlx
+++ b/examples/formatter/definitions/bigquery_regexps.sqlx
@@ -2,8 +2,8 @@ config { type: "operation",
                       tags: ["tag1", "tag2"]
 }
 
-select CAST(REGEXP_EXTRACT("", r'^/([0-9]+)\'/.*') AS INT64) AS id,
-       CAST(REGEXP_EXTRACT("", r"^/([0-9]+)\"/.*") AS INT64) AS id2,
+select CAST(REGEXP_EXTRACT("", r'^/([0-9]+)\'\"/.*') AS INT64) AS id,
+       CAST(REGEXP_EXTRACT("", r"^/([0-9]+)\"\'/.*") AS INT64) AS id2,
        IFNULL (
          regexp_extract('', r'\a?query=([^&]+)&*'),
          regexp_extract('', r'\a?q=([^&]+)&*')

--- a/testing/runner.ts
+++ b/testing/runner.ts
@@ -94,9 +94,9 @@ export class Runner {
       const hasErrors = ctx.results.some(result => result.outcome !== "passed");
 
       if (hasErrors) {
-        console.log(`\nTests failed.`);
+        console.info(chalk.green(`\nTests failed.`));
       } else {
-        console.log(`\nTests passed.`);
+        console.info(chalk.red(`\nTests passed.`));
       }
 
       process.exitCode = hasErrors ? 1 : 0;
@@ -152,7 +152,7 @@ export class Runner {
         : Diff.diffLines(expected, actual);
       if (diffs.length === 1 && !diffs[0].added && !diffs[0].removed) {
         console.error(
-          `\n    ${chalk.green(
+          `\n    ${chalk.yellow(
             "Objects appear identical! Are you comparing objects with functions?"
           )}`
         );
@@ -165,7 +165,7 @@ export class Runner {
           // This diff won't show well for users with either default green or red text.
           const colorFn = diff.added ? chalk.red : diff.removed ? chalk.green : chalk.reset;
           const indentMarker = `${diff.added ? "+" : diff.removed ? "-" : " "}${
-            comparingObjects ? " " : "|"
+            comparingObjects ? "   " : "|"
           }`;
           toLog += diff.value
             .split("\n")

--- a/tests/api/api.spec.ts
+++ b/tests/api/api.spec.ts
@@ -1230,6 +1230,11 @@ from
 where
   sample = 100
 `);
+
+      // expect({ asd: 143, def: { 123: 910, 564: 123 } }).to.equal({
+      //   asd: 123,
+      //   def: { 123: 810, 564: 456 }
+      // });
     });
 
     test("correctly formats comments.sqlx", async () => {

--- a/tests/api/api.spec.ts
+++ b/tests/api/api.spec.ts
@@ -1219,7 +1219,12 @@ select
   ) AS id,
   CAST(
     REGEXP_EXTRACT("", r"^/([0-9]+)\\"/.*") AS INT64
-  ) AS id2
+  ) AS id2,
+  IFNULL (
+    regexp_extract('', r'\\a?query=([^&]+)&*'),
+    regexp_extract('', r'\\a?q=([^&]+)&*')
+  ) AS id3,
+  regexp_extract('bar', r'bar') as ID4
 from
   \${ref("dab")}
 where

--- a/tests/api/api.spec.ts
+++ b/tests/api/api.spec.ts
@@ -1215,10 +1215,10 @@ SELECT
 
 select
   CAST(
-    REGEXP_EXTRACT("", r'^/([0-9]+)\\'/.*') AS INT64
+    REGEXP_EXTRACT("", r'^/([0-9]+)\\'\\"/.*') AS INT64
   ) AS id,
   CAST(
-    REGEXP_EXTRACT("", r"^/([0-9]+)\\"/.*") AS INT64
+    REGEXP_EXTRACT("", r"^/([0-9]+)\\"\\'/.*") AS INT64
   ) AS id2,
   IFNULL (
     regexp_extract('', r'\\a?query=([^&]+)&*'),
@@ -1230,11 +1230,6 @@ from
 where
   sample = 100
 `);
-
-      // expect({ asd: 143, def: { 123: 910, 564: 123 } }).to.equal({
-      //   asd: 123,
-      //   def: { 123: 810, 564: 456 }
-      // });
     });
 
     test("correctly formats comments.sqlx", async () => {


### PR DESCRIPTION
Fixes https://github.com/dataform-co/dataform-web-tracking/issues/218

Could probably have been 2 PRs.

Issue was caused by:

* Text being lifted and converted to hashes was globally matched, so each match was being given an identical hash.

* Regex is greedy and so would match regexes that finished in `r'`, e.g. 

```console
$ node
> "regexp_extract('bar', r'bar') as ID4 from".match(/r'.*?(?<!\\)'/g)
[ "r', r'" ]
```

whereas it should be `[ "r'bar'" ]`.

The fix I added will only accept `r'` if it has a space beforehand. This is not perfect, but I can't find the perfect solution, and this will solve for the majority of users.

* Added text for these situations.

* Differences in strings weren't showing well so I updated the testing module to show them nicer, including adding `+` and `-` symbols to lines with colors, and migrating to using the chalk package rather than printing raw color characters.

![Screenshot 2020-02-18 at 15 28 46](https://user-images.githubusercontent.com/13434377/74750297-6ea88800-5263-11ea-998f-46b16d283f57.png)
