### PR TITLE
Make protomongo codec treat repeated/non-repeated fields as interoperable.

### DIFF
--- a/protomongo/protomongo.go
+++ b/protomongo/protomongo.go
@@ -90,11 +90,11 @@ func (pc *protobufCodec) DecodeValue(ectx bsoncodec.DecodeContext, vr bsonrw.Val
 		}
 
 		tag := elementNameToTag(f)
-		prop, isProp := ph.normalPropsByTag[tag]
+		prop, isNotOneOf := ph.normalPropsByTag[tag]
 		oneof, isOneof := ph.oneofPropsByTag[tag]
 
 		// Skip any field that we don't recognize.
-		if !isProp && !isOneof {
+		if !isNotOneOf && !isOneof {
 			if err = vr.Skip(); err != nil {
 				return err
 			}
@@ -103,7 +103,7 @@ func (pc *protobufCodec) DecodeValue(ectx bsoncodec.DecodeContext, vr bsonrw.Val
 
 		// Figure out what field we need to decode into.
 		var fVal reflect.Value
-		if isProp {
+		if isNotOneOf {
 			fVal = val.FieldByName(prop.Name)
 		} else if isOneof {
 			oneofVal := reflect.New(oneof.Type.Elem())
@@ -112,16 +112,45 @@ func (pc *protobufCodec) DecodeValue(ectx bsoncodec.DecodeContext, vr bsonrw.Val
 		}
 
 		// Actually decode the value.
-		enc, err := ectx.LookupDecoder(fVal.Type())
-		if err != nil {
-			return err
-		}
-		if err = enc.DecodeValue(ectx, fvr, fVal); err != nil {
-			return err
+		if err = lookupDecoderAndDecode(ectx, fvr, fVal); err != nil && isNotOneOf {
+			// It's possible that this value was encoded as a repeated field and is now being decoded as non-repeated field,
+			// or vice-versa. Since this would count as a valid protobuf change, we try to decode as the opposite type.
+			// If this decoding attempt fails, we return the original decode error.
+			if prop.Repeated {
+				singleVal := reflect.New(fVal.Type().Elem()).Elem()
+				if backupDecodeErr := lookupDecoderAndDecode(ectx, fvr, singleVal); backupDecodeErr != nil {
+					return err
+				}
+				fVal.Set(reflect.Append(fVal, singleVal))
+			} else {
+				repeatedVal := reflect.New(reflect.SliceOf(fVal.Type())).Elem()
+				if backupDecodeErr := lookupDecoderAndDecode(ectx, fvr, repeatedVal); backupDecodeErr != nil {
+					return err
+				}
+
+				for i := 0; i < repeatedVal.Len(); i++ {
+					singleVal := repeatedVal.Index(i)
+					// Following the rules here at https://developers.google.com/protocol-buffers/docs/proto#updating,
+					// repeated Message values must be merged into a single value.
+					if _, fieldIsMessage := fVal.Interface().(proto.Message); fieldIsMessage {
+						proto.Merge(fVal.Interface().(proto.Message), singleVal.Interface().(proto.Message))
+					} else {
+						fVal.Set(singleVal)
+					}
+				}
+			}
 		}
 	}
 
 	return nil
+}
+
+func lookupDecoderAndDecode(ectx bsoncodec.DecodeContext, vr bsonrw.ValueReader, val reflect.Value) error {
+	enc, err := ectx.LookupDecoder(val.Type())
+	if err != nil {
+		return err
+	}
+	return enc.DecodeValue(ectx, vr, val)
 }
 
 type protoHelper struct {

--- a/protomongo/protomongo_test.go
+++ b/protomongo/protomongo_test.go
@@ -11,9 +11,9 @@ import (
 
 var (
 	tests = []struct {
-		name string
-		pb   proto.Message
-		new  func() proto.Message
+		name          string
+		pb            proto.Message
+		equivalentPbs []proto.Message
 	}{
 		{
 			name: "simple message",
@@ -26,8 +26,16 @@ var (
 				BoolField:   true,
 				EnumField:   pb.Enum_VAL_2,
 			},
-			new: func() proto.Message {
-				return new(pb.SimpleMessage)
+			equivalentPbs: []proto.Message{
+				&pb.RepeatedFieldMessage{
+					StringField: []string{"foo"},
+					Int32Field:  []int32{32525},
+					Int64Field:  []int64{1531541553141312315},
+					FloatField:  []float32{21541.3242},
+					DoubleField: []float64{21535215136361617136.543858},
+					BoolField:   []bool{true},
+					EnumField:   []pb.Enum{pb.Enum_VAL_2},
+				},
 			},
 		},
 		{
@@ -41,8 +49,16 @@ var (
 				BoolField:   []bool{true, false, true, true},
 				EnumField:   []pb.Enum{pb.Enum_VAL_2, pb.Enum_VAL_1},
 			},
-			new: func() proto.Message {
-				return new(pb.RepeatedFieldMessage)
+			equivalentPbs: []proto.Message{
+				&pb.SimpleMessage{
+					StringField: "bar",
+					Int32Field:  435,
+					Int64Field:  13512516266,
+					FloatField:  3435.322,
+					DoubleField: 213143343.76767,
+					BoolField:   true,
+					EnumField:   pb.Enum_VAL_1,
+				},
 			},
 		},
 		{
@@ -59,8 +75,21 @@ var (
 					EnumField:   pb.Enum_VAL_2,
 				},
 			},
-			new: func() proto.Message {
-				return new(pb.MessageWithSubMessage)
+			equivalentPbs: []proto.Message{
+				&pb.MessageWithRepeatedSubMessage{
+					StringField: "baz",
+					SimpleMessage: []*pb.SimpleMessage{
+						&pb.SimpleMessage{
+							StringField: "foo",
+							Int32Field:  32525,
+							Int64Field:  1531541553141312315,
+							FloatField:  21541.3242,
+							DoubleField: 21535215136361617136.543858,
+							BoolField:   true,
+							EnumField:   pb.Enum_VAL_2,
+						},
+					},
+				},
 			},
 		},
 		{
@@ -84,8 +113,24 @@ var (
 					},
 				},
 			},
-			new: func() proto.Message {
-				return new(pb.MessageWithRepeatedSubMessage)
+			equivalentPbs: []proto.Message{
+				&pb.MessageWithSubMessage{
+					StringField: "baz",
+					SimpleMessage: &pb.SimpleMessage{
+						StringField: "qux",
+						Int32Field:  22,
+						Int64Field:  1531541553141312315,
+						FloatField:  21541.3242,
+						DoubleField: 21535215136361617136.543858,
+						// It might be expected that because the last element of the 'SimpleMessage' slice in 'pb' explicitly sets 'BoolField' to false,
+						// this field should also be false, because the elements of the 'SimpleMessage' slice should be merged in order.
+						// However, by the rules of proto3, default field values are never serialized. Thus when the second element
+						// of the 'SimpleMessage' slice is deserialized, that deserialized value contains no value for 'BoolField', and thus
+						// this field retains the value that was set in the first element of that slice.
+						BoolField: true,
+						EnumField: pb.Enum_VAL_2,
+					},
+				},
 			},
 		},
 		{
@@ -94,9 +139,7 @@ var (
 				StringField: "baz",
 				OneofField:  &pb.MessageWithOneof_Int32OneofField{3132},
 			},
-			new: func() proto.Message {
-				return new(pb.MessageWithOneof)
-			},
+			equivalentPbs: []proto.Message{},
 		},
 	}
 )
@@ -111,12 +154,15 @@ func TestMarshalUnmarshal(t *testing.T) {
 		if err != nil {
 			t.Errorf("bson.MarshalWithRegistry error = %v", err)
 		}
-		out := testCase.new()
-		if err = bson.UnmarshalWithRegistry(reg, b, &out); err != nil {
-			t.Errorf("bson.UnmarshalWithRegistry error = %v", err)
-		}
-		if !proto.Equal(testCase.pb, out) {
-			t.Errorf("failed: in=%#v, out=%#v", testCase.pb, out)
+
+		for _, equivalentPb := range append(testCase.equivalentPbs, testCase.pb) {
+			out := reflect.New(reflect.TypeOf(equivalentPb).Elem()).Interface().(proto.Message)
+			if err = bson.UnmarshalWithRegistry(reg, b, &out); err != nil {
+				t.Errorf("bson.UnmarshalWithRegistry error = %v", err)
+			}
+			if !proto.Equal(equivalentPb, out) {
+				t.Errorf("failed: in=%#q, out=%#q", equivalentPb, out)
+			}
 		}
 	}
 }
@@ -127,16 +173,19 @@ func TestMarshalUnmarshalWithPointers(t *testing.T) {
 	reg := rb.Build()
 
 	for _, testCase := range tests {
-		b, err := bson.MarshalWithRegistry(reg, &testCase.pb)
+		b, err := bson.MarshalWithRegistry(reg, testCase.pb)
 		if err != nil {
 			t.Errorf("bson.MarshalWithRegistry error = %v", err)
 		}
-		out := testCase.new()
-		if err = bson.UnmarshalWithRegistry(reg, b, &out); err != nil {
-			t.Errorf("bson.UnmarshalWithRegistry error = %v", err)
-		}
-		if !proto.Equal(testCase.pb, out) {
-			t.Errorf("failed: in=%#v, out=%#v", testCase.pb, out)
+
+		for _, equivalentPb := range append(testCase.equivalentPbs, testCase.pb) {
+			out := reflect.New(reflect.TypeOf(equivalentPb).Elem()).Interface().(proto.Message)
+			if err = bson.UnmarshalWithRegistry(reg, b, &out); err != nil {
+				t.Errorf("bson.UnmarshalWithRegistry error = %v", err)
+			}
+			if !proto.Equal(equivalentPb, out) {
+				t.Errorf("failed: in=%#q, out=%#q", equivalentPb, out)
+			}
 		}
 	}
 }


### PR DESCRIPTION
As according to the spec: https://developers.google.com/protocol-buffers/docs/proto#updating

```
optional is compatible with repeated. Given serialized data of a repeated field as input, clients that expect this field to be optional will take the last input value if it's a primitive type field or merge all input elements if it's a message type field.
```