### PR TITLE
Markdown CMS fixes

### DIFF
--- a/docs/components/navigation.tsx
+++ b/docs/components/navigation.tsx
@@ -1,11 +1,12 @@
 import { Icon } from "@blueprintjs/core";
+import { ITree } from "@dataform-tools/markdown-cms/tree";
 import * as styles from "df/docs/components/navigation.css";
-import { ITree } from "df/tools/markdown-cms/tree";
+import { IExtraAttributes } from "df/docs/content_tree";
 import * as React from "react";
 
 interface IProps {
   version: string;
-  tree: ITree;
+  tree: ITree<IExtraAttributes>;
   currentPath: string;
 }
 
@@ -13,8 +14,8 @@ export default class Navigation extends React.Component<IProps> {
   public render() {
     return <div className={styles.navigation}>{this.renderTrees(this.props.tree.children)}</div>;
   }
-  private renderTrees(trees: ITree[], depth = 0) {
-    trees.sort((a: ITree, b: ITree) =>
+  private renderTrees(trees: Array<ITree<IExtraAttributes>>, depth = 0) {
+    trees.sort((a: ITree<IExtraAttributes>, b: ITree<IExtraAttributes>) =>
       a.attributes.priority == null && b.attributes.priority == null
         ? a.attributes.title > b.attributes.title
           ? 1

--- a/docs/content_tree.ts
+++ b/docs/content_tree.ts
@@ -1,6 +1,6 @@
 import { GitHubCms } from "@dataform-tools/markdown-cms/github";
 import { LocalCms } from "@dataform-tools/markdown-cms/local";
-import { IBaseAttributes, Tree } from "@dataform-tools/markdown-cms/tree";
+import { Tree } from "@dataform-tools/markdown-cms/tree";
 import NodeCache from "node-cache";
 
 export interface IExtraAttributes {

--- a/docs/layouts/documentation.tsx
+++ b/docs/layouts/documentation.tsx
@@ -1,15 +1,16 @@
 import { Button } from "@blueprintjs/core";
 import Navigation from "df/docs/components/navigation";
 import { IHeaderLink, PageLinks } from "df/docs/components/page_links";
+import { IExtraAttributes } from "df/docs/content_tree";
 import { BaseLayout } from "df/docs/layouts/base";
 import * as styles from "df/docs/layouts/documentation.css";
-import { ITree } from "df/tools/markdown-cms/tree";
+import { ITree } from "@dataform-tools/markdown-cms/tree";
 import * as React from "react";
 
 export interface IProps {
   version: string;
-  index: ITree;
-  current: ITree;
+  index: ITree<IExtraAttributes>;
+  current: ITree<IExtraAttributes>;
   headerLinks?: IHeaderLink[];
 }
 

--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -19,7 +19,9 @@ let config = {
 
     config.resolve.alias = {
       ...config.resolve.alias,
-      df: path.resolve(path.join(process.env.RUNFILES, "df"))
+      df: path.resolve(path.join(process.env.RUNFILES, "df")),
+      "@dataform": path.resolve(path.join(process.env.RUNFILES, "df")),
+      "@dataform-tools": path.resolve(path.join(process.env.RUNFILES, "df/tools"))
     };
     // Make sure webpack can resolve modules that live within our bazel managed deps.
 

--- a/docs/pages/_docs.tsx
+++ b/docs/pages/_docs.tsx
@@ -1,7 +1,7 @@
 import rehypePrism from "@mapbox/rehype-prism";
-import { getContentTree } from "df/docs/content_tree";
+import { getContentTree, IExtraAttributes } from "df/docs/content_tree";
 import Documentation from "df/docs/layouts/documentation";
-import { ITree } from "df/tools/markdown-cms/tree";
+import { ITree } from "@dataform-tools/markdown-cms/tree";
 import { NextPageContext } from "next";
 import * as React from "react";
 import rehypeRaw from "rehype-raw";
@@ -18,8 +18,8 @@ interface IQuery {
 }
 
 interface IProps {
-  index: ITree;
-  current: ITree;
+  index: ITree<IExtraAttributes>;
+  current: ITree<IExtraAttributes>;
   version: string;
 }
 

--- a/docs/pages/_reference.tsx
+++ b/docs/pages/_reference.tsx
@@ -1,7 +1,7 @@
+import { ITree } from "@dataform-tools/markdown-cms/tree";
 import { ITypedoc, Typedoc } from "df/docs/components/typedoc";
-import { getContentTree } from "df/docs/content_tree";
+import { getContentTree, IExtraAttributes } from "df/docs/content_tree";
 import Documentation from "df/docs/layouts/documentation";
-import { ITree } from "df/tools/markdown-cms/tree";
 import { readFile } from "fs";
 import { NextPageContext } from "next";
 import * as React from "react";
@@ -13,8 +13,8 @@ interface IQuery {
 
 interface IProps {
   version: string;
-  index: ITree;
-  current: ITree;
+  index: ITree<IExtraAttributes>;
+  current: ITree<IExtraAttributes>;
   typedoc: ITypedoc;
 }
 

--- a/docs/pages/_web_api_reference.tsx
+++ b/docs/pages/_web_api_reference.tsx
@@ -1,8 +1,8 @@
+import { ITree } from "@dataform-tools/markdown-cms/tree";
 import axios from "axios";
 import { Swagger } from "df/docs/components/swagger";
-import { getContentTree } from "df/docs/content_tree";
+import { getContentTree, IExtraAttributes } from "df/docs/content_tree";
 import Documentation from "df/docs/layouts/documentation";
-import { ITree } from "df/tools/markdown-cms/tree";
 import { NextPageContext } from "next";
 import * as React from "react";
 import { Spec } from "swagger-schema-official";
@@ -13,8 +13,8 @@ interface IQuery {
 
 interface IProps {
   version: string;
-  index: ITree;
-  current: ITree;
+  index: ITree<IExtraAttributes>;
+  current: ITree<IExtraAttributes>;
   spec: Spec;
   apiHost: string;
 }

--- a/tools/markdown-cms/BUILD
+++ b/tools/markdown-cms/BUILD
@@ -5,6 +5,7 @@ load("@npm_bazel_typescript//:index.bzl", "ts_library")
 ts_library(
     name = "markdown-cms",
     srcs = glob(["**/*.ts"]),
+    module_name = "@dataform-tools/markdown-cms",
     deps = [
         "@npm//@octokit/rest",
         "@npm//@types/node",

--- a/tools/markdown-cms/github.ts
+++ b/tools/markdown-cms/github.ts
@@ -1,6 +1,6 @@
+import { ICms } from "@dataform-tools/markdown-cms/index";
+import { Tree } from "@dataform-tools/markdown-cms/tree";
 import * as Octokit from "@octokit/rest";
-import { ICms } from "df/tools/markdown-cms/index";
-import { Tree } from "df/tools/markdown-cms/tree";
 import { join } from "path";
 
 const octokit = new Octokit({ auth: process.env.GITHUB_AUTH_TOKEN });
@@ -12,7 +12,7 @@ interface IOptions {
   ref: string;
 }
 
-export class GitHubCms implements ICms {
+export class GitHubCms<T> implements ICms<T> {
   constructor(private options: IOptions) {}
 
   public async get(path = "") {
@@ -29,7 +29,7 @@ export class GitHubCms implements ICms {
       : join(this.options.rootPath, path);
 
     const cleanPath = path.endsWith(".md") ? path.substring(0, path.length - 3) : path;
-    const tree = Tree.create(
+    const tree = Tree.create<T>(
       cleanPath,
       await this.content(actualFilePath).catch(e => ""),
       `https://github.com/${this.options.owner}/${this.options.repo}/blob/master/${actualFilePath}`

--- a/tools/markdown-cms/index.ts
+++ b/tools/markdown-cms/index.ts
@@ -1,5 +1,5 @@
-import { Tree } from "df/tools/markdown-cms/tree";
+import { Tree } from "@dataform-tools/markdown-cms/tree";
 
-export interface ICms {
-  get(): Promise<Tree>;
+export interface ICms<T> {
+  get(): Promise<Tree<T>>;
 }

--- a/tools/markdown-cms/local.ts
+++ b/tools/markdown-cms/local.ts
@@ -1,10 +1,10 @@
-import { ICms } from "df/tools/markdown-cms";
-import { Tree } from "df/tools/markdown-cms/tree";
+import { ICms } from "@dataform-tools/markdown-cms";
+import { Tree } from "@dataform-tools/markdown-cms/tree";
 import * as fs from "fs";
-import { basename, dirname, join } from "path";
+import { join } from "path";
 import { promisify } from "util";
 
-export class LocalCms implements ICms {
+export class LocalCms<T> implements ICms<T> {
   constructor(private rootPath: string) {}
 
   public async get(path = "") {
@@ -12,10 +12,12 @@ export class LocalCms implements ICms {
     const actualFilePath = isDir
       ? join(this.rootPath, path, "index.md")
       : join(this.rootPath, path);
-    const rawContent = await promisify(fs.readFile)(actualFilePath, "utf8");
+    const rawContent = (await promisify(fs.exists)(actualFilePath))
+      ? await promisify(fs.readFile)(actualFilePath, "utf8")
+      : "";
 
     const cleanPath = path.endsWith(".md") ? path.substring(0, path.length - 3) : path;
-    const tree = Tree.create(
+    const tree = Tree.create<T>(
       cleanPath,
       rawContent,
       `https://github.com/dataform-co/dataform/blob/master/${actualFilePath}`

--- a/tools/markdown-cms/tree.ts
+++ b/tools/markdown-cms/tree.ts
@@ -2,59 +2,60 @@ import { basename, join } from "path";
 
 const frontMatter = require("front-matter");
 
-export interface IFrontMatter {
-  title?: string;
-  priority?: number;
+export interface IBaseAttributes {
+  title: string;
 }
 
-export interface ITree {
+type IWithBaseAttributes<T> = T & IBaseAttributes;
+
+export interface ITree<T> {
   readonly path: string;
   readonly name: string;
   readonly content: string;
-  readonly attributes?: IFrontMatter;
-  readonly children?: ITree[];
+  readonly attributes?: IWithBaseAttributes<T>;
+  readonly children?: Array<ITree<T>>;
   editLink?: string;
 }
 
-export class Tree implements ITree {
-  public static create(path: string, rawContent: string, editLink?: string): Tree {
+export class Tree<T> implements ITree<T> {
+  public static create<T>(path: string, rawContent: string, editLink?: string): Tree<T> {
     let content: string = null;
-    let attributes: IFrontMatter = { title: basename(path) };
+    let attributes: IBaseAttributes = { title: basename(path) };
 
     const parsedContent = frontMatter(rawContent);
     content = parsedContent.body;
     attributes = parsedContent.attributes;
 
-    return new Tree(path, content, attributes, editLink, []);
+    return new Tree(path, content, attributes as any, editLink, []);
   }
   public readonly name: string;
 
   constructor(
     public readonly path: string,
     public readonly content: string,
-    public readonly attributes?: IFrontMatter,
+    public readonly attributes?: IWithBaseAttributes<T>,
     public readonly editLink?: string,
-    public readonly children: Tree[] = []
+    public readonly children: Array<Tree<T>> = []
   ) {
     const base = basename(path);
     this.name = base.includes(".md") ? base.substring(0, base.length - 3) : base;
   }
 
-  public getChild(path: string): Tree {
+  public getChild(path: string): Tree<T> {
     const pathParts = path.split("/");
     return pathParts.reduce(
-      (acc: Tree, curr: string) =>
+      (acc: Tree<T>, curr: string) =>
         !curr ? acc : acc.children.find(child => child.path === join(acc.path, curr)),
       this
     );
   }
 
-  public addChild(child: Tree) {
+  public addChild(child: Tree<T>) {
     this.children.push(child);
     return this;
   }
 
-  public index(): ITree {
+  public index(): ITree<T> {
     return {
       ...this,
       content: undefined,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,8 @@
     "baseUrl": ".",
     "paths": {
       "df/*": ["*", "bazel-bin/*", "bazel-genfiles/*"],
-      "@dataform/*": ["*", "bazel-bin/*", "bazel-genfiles/*"]
+      "@dataform/*": ["*", "bazel-bin/*", "bazel-genfiles/*"],
+      "@dataform-tools/*": ["tools/*", "bazel-bin/tools/*", "bazel-genfiles/tools/*"]
     },
     "module": "commonjs",
     "noImplicitAny": true,
@@ -15,7 +16,7 @@
     "skipLibCheck": true,
     "experimentalDecorators": true,
     "jsx": "react",
-    "lib": ["es2017" ,"dom"]
+    "lib": ["es2017", "dom"]
   },
   "exclude": ["bazel-*", "node_modules"]
 }


### PR DESCRIPTION
- Make it so that a index.md file isn't required
- Give the markdown cms library a module_name so it can be used properly
- Update references in docs
- Make the attributes generic so they can be customized (different attributes e.g. for blog posts)
- Fix tsconfig settings
- Make sure next/webpack can resolve custom module names