### PR TITLE
Turn on nginx gzip on for application/javascript

### DIFF
--- a/tools/nginx/spa/nginx.conf
+++ b/tools/nginx/spa/nginx.conf
@@ -30,6 +30,7 @@ http {
     keepalive_timeout  65;
 
     gzip  on;
+    gzip_types text/html application/javascript;
 
     server {
         listen  80;

--- a/tools/nginx/static/nginx.conf
+++ b/tools/nginx/static/nginx.conf
@@ -30,6 +30,7 @@ http {
     keepalive_timeout  65;
 
     gzip  on;
+    gzip  application/javascript;
 
     server {
         listen  80;

--- a/tools/nginx/static/nginx.conf
+++ b/tools/nginx/static/nginx.conf
@@ -30,7 +30,7 @@ http {
     keepalive_timeout  65;
 
     gzip  on;
-    gzip  application/javascript;
+    gzip_types  application/javascript;
 
     server {
         listen  80;

--- a/tools/nginx/static/nginx.conf
+++ b/tools/nginx/static/nginx.conf
@@ -30,7 +30,7 @@ http {
     keepalive_timeout  65;
 
     gzip  on;
-    gzip_types  application/javascript;
+    gzip_types text/html application/javascript;
 
     server {
         listen  80;


### PR DESCRIPTION
By default NGinx do compression for `text/html`.

So turning it on for `application/javascript`

https://docs.nginx.com/nginx/admin-guide/web-server/compression/