### PR TITLE
Make the CLI more helpful for projects without node_modules installed.

### DIFF
--- a/api/vm/compile.ts
+++ b/api/vm/compile.ts
@@ -32,6 +32,7 @@ export function compile(compileConfig: dataform.ICompileConfig) {
       return legacyGenIndex;
     }
   };
+  const genIndex = findGenIndex();
   const findCompiler = (): CompilerFunction => {
     try {
       return (
@@ -59,7 +60,7 @@ export function compile(compileConfig: dataform.ICompileConfig) {
   });
 
   const res: string = userCodeVm.run(
-    findGenIndex()(createGenIndexConfig(compileConfig)),
+    genIndex(createGenIndexConfig(compileConfig)),
     vmIndexFileName
   );
   return res;

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -1,5 +1,15 @@
 #!/usr/bin/env node
-import { build, compile, credentials, format, init, run, table, test } from "@dataform/api";
+import {
+  build,
+  compile,
+  credentials,
+  format,
+  init,
+  install,
+  run,
+  table,
+  test
+} from "@dataform/api";
 import { prettyJsonStringify } from "@dataform/api/utils";
 import {
   print,
@@ -217,6 +227,18 @@ const builtYargs = createYargsCli({
           }
         );
         printInitResult(initResult);
+        return 0;
+      }
+    },
+    {
+      format: "install [project-dir]",
+      description: "Install a project's NPM dependencies.",
+      positionalOptions: [projectDirMustExistOption],
+      options: [],
+      processFn: async argv => {
+        print("Installing NPM dependencies...\n");
+        await install(argv["project-dir"]);
+        printSuccess("Project dependencies successfully installed.");
         return 0;
       }
     },
@@ -604,9 +626,13 @@ const builtYargs = createYargsCli({
   .strict()
   .wrap(null)
   .recommendCommands()
-  .fail((msg: string, err: Error) => {
-    const message = err ? err.message.split("\n")[0] : msg;
-    printError(`Dataform encountered an error: ${message}`);
+  .fail((msg: string, err: any) => {
+    if (!!err && err.name === "VMError" && err.code === "ENOTFOUND") {
+      printError("Could not find NPM dependencies. Have you run 'dataform install'?");
+    } else {
+      const message = err && err.message ? err.message.split("\n")[0] : msg;
+      printError(`Dataform encountered an error: ${message}`);
+    }
     process.exit(1);
   }).argv;
 

--- a/version.bzl
+++ b/version.bzl
@@ -1,3 +1,3 @@
 # NOTE: If you change the format of this line, you must change the bash command
 # in /scripts/publish to extract the version string correctly.
-DF_VERSION = "1.4.15"
+DF_VERSION = "1.4.16"


### PR DESCRIPTION
- Print a more helpful error
- Give the user a `dataform install` command, which essentially just runs `npm i`

fixes https://github.com/dataform-co/dataform/issues/511