### PR TITLE
Some tweaks to ts_gprc proto gen to handle closed-source services

### DIFF
--- a/server/BUILD
+++ b/server/BUILD
@@ -7,7 +7,7 @@ ts_grpc_service(
     name = "grpc_service",
     srcs = ["//protos:files"],
     protos_import = "@dataform/protos",
-    root = "protos",
+    root_name = "protos",
     root_paths = ["."],
     service = "dataform.server.Service",
 )

--- a/server/BUILD
+++ b/server/BUILD
@@ -8,6 +8,7 @@ ts_grpc_service(
     srcs = ["//protos:files"],
     protos_import = "@dataform/protos",
     root = "protos",
+    root_paths = ["."],
     service = "dataform.server.Service",
 )
 

--- a/tools/protobufjs/generate_service_defs.ts
+++ b/tools/protobufjs/generate_service_defs.ts
@@ -26,15 +26,15 @@ const argv = yargs
     type: "string",
     description: "Output typescript file path."
   })
-  .option("root", {
+  .option("root-name", {
     type: "string",
     required: true,
-    description: "The root path or parent directory of the protos."
+    description: "The name of the root object where protos live (e.g. rootName.MyProto)."
   })
   .option("protos-import", {
     type: "string",
     required: true,
-    description: "The import to use for the generated protobufs library."
+    description: "The import to use for the generated protobufs library (e.g. import protos from 'protosImport')."
   }).argv;
 
 protobufjs.Root.prototype.resolvePath = (_, fileName) => {
@@ -52,7 +52,7 @@ protobufjs.Root.prototype.resolvePath = (_, fileName) => {
 protobufjs
   .load((argv.protos as string[]).map(protoPath => String(protoPath)))
   .then(root => {
-    const processedRoot = processPackage(argv.root, root);
+    const processedRoot = processPackage(argv["root-name"], root);
     writeAllServices([processedRoot.name], processedRoot);
   })
   .catch(e => console.log(e));
@@ -296,7 +296,7 @@ ${service.methods
     return `
 ${camelToLowerCamel(method.name)}: {
   path: '/${currentNamespaceParts
-    // We need to skip the first entry (argv.root), because it refers to protobuf type namespaces, not actual package names as specified in .proto files.
+    // We need to skip the first entry (argv["root-name"]), because it refers to protobuf type namespaces, not actual package names as specified in .proto files.
     .slice(1)
     .map(part => `${part}.`)
     .join("")}${service.name}/${method.name}',
@@ -404,7 +404,7 @@ function determinePackagePath(currentNamespaceParts: string[], type: string) {
   if (typeParts.length > 1) {
     // This type is already package-qualified, thus it must live outside of the current package,
     // and we can just use the value more or less as-is.
-    return [].concat([argv.root], typeParts.slice(0, -1));
+    return [].concat([argv["root-name"]], typeParts.slice(0, -1));
   }
   // The type is un-namespaced. Thus it must be in the current package.
   return currentNamespaceParts;

--- a/tools/protobufjs/ts_grpc_service.bzl
+++ b/tools/protobufjs/ts_grpc_service.bzl
@@ -4,6 +4,10 @@ def _impl(ctx):
     args.add("--protos")
     for src in ctx.files.srcs:
         args.add(src.path)
+    if len(ctx.attr.root_paths) > 0:
+        args.add("--root-paths")
+        for root_path in ctx.attr.root_paths:
+            args.add(root_path)
     args.add("--root")
     args.add(ctx.attr.root)
     args.add("--protos-import")
@@ -17,7 +21,7 @@ def _impl(ctx):
         outputs = [out],
         executable = ctx.executable._tool,
         arguments = [args],
-        progress_message = "Generating protobuf service interfaces",
+        progress_message = "Generating protobuf service interface for {service}".format(service = ctx.attr.service),
     )
 
     return struct(
@@ -28,6 +32,7 @@ ts_grpc_service = rule(
     implementation = _impl,
     attrs = {
         "srcs": attr.label_list(doc = "proto files", allow_files = [".proto"]),
+        "root_paths": attr.string_list(),
         "protos_import": attr.string(),
         "root": attr.string(),
         "service": attr.string(),

--- a/tools/protobufjs/ts_grpc_service.bzl
+++ b/tools/protobufjs/ts_grpc_service.bzl
@@ -8,8 +8,8 @@ def _impl(ctx):
         args.add("--root-paths")
         for root_path in ctx.attr.root_paths:
             args.add(root_path)
-    args.add("--root")
-    args.add(ctx.attr.root)
+    args.add("--root-name")
+    args.add(ctx.attr.root_name)
     args.add("--protos-import")
     args.add(ctx.attr.protos_import)
     args.add("--output-path")
@@ -34,7 +34,7 @@ ts_grpc_service = rule(
         "srcs": attr.label_list(doc = "proto files", allow_files = [".proto"]),
         "root_paths": attr.string_list(),
         "protos_import": attr.string(),
-        "root": attr.string(),
+        "root_name": attr.string(default = "protos"),
         "service": attr.string(),
         "_tool": attr.label(
             executable = True,


### PR DESCRIPTION
- Adds a way to provide a list of root paths for resolving to imports
- Removes the default root import behaviour. This was causing all kind of weirdness and doesn't seem like we depend on it currently (or should).