### PR TITLE
add section to environments

### DIFF
--- a/content/docs/dataform-web/guides/environments.md
+++ b/content/docs/dataform-web/guides/environments.md
@@ -152,7 +152,7 @@ Some teams may not be at the stage where they require a `staging` environment, b
 
 In the example below:
 
-- any code deployed whilst developing will use the `defaultDatabase` from the `dataform.json`
+- any code deployed during development will use the `defaultDatabase` from the `dataform.json`
 - any code deployed by schedules will be in the `production` environment and so use the `defaultDatabase` from the `configOverride` in `environmemts.json`
 - schedules will use the version of the code from the `master` branch
 

--- a/content/docs/dataform-web/guides/environments.md
+++ b/content/docs/dataform-web/guides/environments.md
@@ -146,7 +146,7 @@ An alternative approach to separating production and staging data is to append a
 }
 ```
 
-## Example: separating development and production data into two databases
+## Example: use separate databases for development and production data
 
 Some teams may not be at the stage where they require a `staging` environment, but still would like to keep development and production data separated. This can be done using a `configOverride` in the `production` environment.
 

--- a/content/docs/dataform-web/guides/environments.md
+++ b/content/docs/dataform-web/guides/environments.md
@@ -145,3 +145,40 @@ An alternative approach to separating production and staging data is to append a
   ]
 }
 ```
+
+## Example: separating development and production data into two databases
+
+Some teams may not be at the stage where they require a `staging` environment, but still would like to keep development and production data separated. This can be done using a `configOverride` in the `production` environment.
+
+In the example below:
+
+- any code deployed whilst developing will use the `defaultDatabase` from the `dataform.json`
+- any code deployed by schedules will be in the `production` environment and so use the `defaultDatabase` from the `configOverride` in `environmemts.json`
+- schedules will use the version of the code from the `master` branch
+
+`dataform.json`:
+```json
+{
+    "warehouse": "bigquery",
+    "defaultSchema": "dataform_data",
+    "defaultDatabase": "analytics-development",
+}
+```
+
+
+`environments.json`:
+```json
+ {
+    "environments": [
+        {
+            "name": "production",
+            "gitReference": {
+                "branch": "master"
+            },
+            "configOverride": {"defaultDatabase": "analytics-production"}
+        }
+    ]
+}
+```
+
+Note, this is only supported for BigQuery and Snowflake. For other warehouses, we recommend overriding schema suffixes instead of `defaultDatabase`.

--- a/content/docs/dataform-web/guides/environments.md
+++ b/content/docs/dataform-web/guides/environments.md
@@ -153,8 +153,8 @@ Some teams may not be at the stage where they require a `staging` environment, b
 In the example below:
 
 - any code deployed during development will use the `defaultDatabase` from the `dataform.json`
-- any code deployed by schedules will run in the `production` environment and so use the `defaultDatabase` from the `configOverride` in `environments.json`
-- schedules will use the version of the code from the `master` branch
+- schedules only run in the single `production` environment, and so use the `defaultDatabase` from that environment's `configOverride`
+- the `production` environment specifies the `master` Git branch, so all of its schedules will run using that version of the code
 
 `dataform.json`:
 ```json

--- a/content/docs/dataform-web/guides/environments.md
+++ b/content/docs/dataform-web/guides/environments.md
@@ -175,7 +175,7 @@ In the example below:
             "gitReference": {
                 "branch": "master"
             },
-            "configOverride": {"defaultDatabase": "analytics-production"}
+            "configOverride": { "defaultDatabase": "analytics-production" }
         }
     ]
 }

--- a/content/docs/dataform-web/guides/environments.md
+++ b/content/docs/dataform-web/guides/environments.md
@@ -153,7 +153,7 @@ Some teams may not be at the stage where they require a `staging` environment, b
 In the example below:
 
 - any code deployed during development will use the `defaultDatabase` from the `dataform.json`
-- any code deployed by schedules will be in the `production` environment and so use the `defaultDatabase` from the `configOverride` in `environmemts.json`
+- any code deployed by schedules will run in the `production` environment and so use the `defaultDatabase` from the `configOverride` in `environments.json`
 - schedules will use the version of the code from the `master` branch
 
 `dataform.json`:


### PR DESCRIPTION
Example: separating development and production data into two databases