### PR TITLE
Add various headers to nginx configs to improve security.

### DIFF
--- a/tools/nginx/spa/nginx.conf
+++ b/tools/nginx/spa/nginx.conf
@@ -56,7 +56,7 @@ http {
             add_header X-Frame-Options "SAMEORIGIN";
             add_header X-Content-Type-Options "nosniff";
             add_header Strict-Transport-Security "max-age=31536000; includeSubDomains";
-            add_header Content-Security-Policy "object-src 'none'; script-src 'sha256-IO5IrRwmhFTw/PQZKTfjHqPMgO3AELXAdLwy0rxX31g=' 'sha256-+mx2mFBu2A7HlQGn+nB8LJBDQe8w16HphmQTCWzN2KQ=' 'unsafe-inline' 'unsafe-eval' 'strict-dynamic' https: http:; base-uri 'none'";
+            add_header Content-Security-Policy "object-src 'none'; script-src 'sha256-IO5IrRwmhFTw/PQZKTfjHqPMgO3AELXAdLwy0rxX31g=' 'sha256-+mx2mFBu2A7HlQGn+nB8LJBDQe8w16HphmQTCWzN2KQ=' 'unsafe-inline' 'strict-dynamic' https: http:; base-uri 'none'";
         }
 
         error_page  500 502 503 504  /50x.html;

--- a/tools/nginx/spa/nginx.conf
+++ b/tools/nginx/spa/nginx.conf
@@ -54,6 +54,9 @@ http {
             try_files $uri /index.html;
 
             add_header X-Frame-Options "SAMEORIGIN";
+            add_header X-Content-Type-Options "nosniff";
+            add_header Strict-Transport-Security "max-age=31536000; includeSubDomains";
+            add_header Content-Security-Policy "object-src 'none'; script-src 'sha256-IO5IrRwmhFTw/PQZKTfjHqPMgO3AELXAdLwy0rxX31g=' 'sha256-+mx2mFBu2A7HlQGn+nB8LJBDQe8w16HphmQTCWzN2KQ=' 'unsafe-inline' 'unsafe-eval' 'strict-dynamic' https: http:; base-uri 'none'";
         }
 
         error_page  500 502 503 504  /50x.html;

--- a/tools/nginx/static/nginx.conf
+++ b/tools/nginx/static/nginx.conf
@@ -52,6 +52,8 @@ http {
             etag off;
 
             add_header X-Frame-Options "SAMEORIGIN";
+            add_header X-Content-Type-Options "nosniff";
+            add_header Strict-Transport-Security "max-age=31536000; includeSubDomains";
         }
 
         location ~* \.(?:jpg|jpeg|gif|png|ico|cur|gz|svg|svgz|mp4|ogg|ogv|webm|htc|css|js)$ {


### PR DESCRIPTION
for both `spa` and `static`: 
- `X-Content-Type-Options "nosniff"`: turn off content-type sniffing - see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Content-Type-Options
- `Strict-Transport-Security`: force browser to only use HTTPS for served domain (and subdomains), and to remember that setting for a year: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security

for `static`:
- `Content-Security-Policy`: use Google's strict CSP (https://csp.withgoogle.com/docs/strict-csp.html). Turn off `object`, `applet`, and `embed` tags. Only allow `script` tags with specific SHA256 hashes, or if the browser doesn't support that, turn on `unsafe-inline`. Allow other scripts to run that have been dynamically added to the page as long as they were added by already trusted scripts. Disable `base` tags.

Note that this PR is tightly bound to the corresponding PR in closed-source, which changes our `script` tags to all be inline, and those inline tags now have SHA256 hashes matching this config: https://github.com/dataform-co/dataform-co/pull/5002

Ideally we'd use auto-generated nonce tags instead, but this would require us to template our HTML in nginx. 