### PR TITLE
Auto push docs site

### DIFF
--- a/cloudbuild-deploy.json
+++ b/cloudbuild-deploy.json
@@ -1,0 +1,13 @@
+{
+  "steps": [
+    {
+      "name": "l.gcr.io/google/bazel:2.0.0",
+      "entrypoint": "bash",
+      "args": ["./scripts/cloudbuild/bazel_deploy"]
+    }
+  ],
+  "timeout": "3600s",
+  "options": {
+    "machineType": "N1_HIGHCPU_8"
+  }
+}

--- a/cloudbuild-triggers.json
+++ b/cloudbuild-triggers.json
@@ -1,0 +1,12 @@
+{
+  "name": "deploy",
+  "description": "Deploy docs site and other artifacts on merge to master.",
+  "github": {
+    "owner": "dataform-co",
+    "name": "dataform",
+    "push": {
+      "branch": "master"
+    }
+  },
+  "filename": "cloudbuild-deploy.json"
+}

--- a/scripts/cloudbuild/bazel_deploy
+++ b/scripts/cloudbuild/bazel_deploy
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+
+# Push the docs site.
+bazel run --config=remote-cache docs:push


### PR DESCRIPTION
This defines extra gcloud triggers for when pushing to master that deploys the docs site.
- The triggers file tells cloudbuild to run this on a push to master
- The deploy script is run, and runs docs:push to push docker images

Kubernetes updates will still be applied by our closed source builds for now.