### PR TITLE
Specify application parameter for Snowflake

### DIFF
--- a/api/dbadapters/snowflake.ts
+++ b/api/dbadapters/snowflake.ts
@@ -212,7 +212,8 @@ async function connect(snowflakeCredentials: dataform.ISnowflake) {
           password: snowflakeCredentials.password,
           database: snowflakeCredentials.databaseName,
           warehouse: snowflakeCredentials.warehouse,
-          role: snowflakeCredentials.role
+          role: snowflakeCredentials.role,
+          application: "Dataform"
         })
         .connect((err, conn) => {
           if (err) {


### PR DESCRIPTION
see docs here: https://docs.snowflake.com/en/user-guide/jdbc-configure.html#connection-parameters

These docs are for JDBC but I've been told by a solutions engineer at Snowflake that the same thing applies to the node.js driver (even though this specific bit isn't documented).