### PR TITLE
Update version to 1.6.3 for dfweb

### DIFF
--- a/version.bzl
+++ b/version.bzl
@@ -1,3 +1,3 @@
 # NOTE: If you change the format of this line, you must change the bash command
 # in /scripts/publish to extract the version string correctly.
-DF_VERSION = "1.6.2"
+DF_VERSION = "1.6.3"


### PR DESCRIPTION
We are using this version number as a flag for a dfweb change - https://github.com/dataform-co/dataform-web-tracking/releases/tag/1.6.3

