### PR TITLE
Support building css_typings inside nested repos

### DIFF
--- a/tools/css_typings.bzl
+++ b/tools/css_typings.bzl
@@ -7,12 +7,13 @@ def _impl(ctx):
         outs.append(out)
         patterns = [f.path]
         if not f.root.path == "":
-            patterns = [f.short_path, f.root.path]
+            patterns = [f.short_path, f.root.path + ("/" + ctx.label.workspace_root if ctx.label.workspace_root else "")]
+        out_dir =  out.root.path + ("/" + ctx.label.workspace_root if ctx.label.workspace_root else "")
         ctx.actions.run(
             inputs = [f],
             outputs = [out],
             executable = ctx.executable._tool,
-            arguments = ["--silent", "--outDir", out.root.path, "--pattern"] + patterns,
+            arguments = ["--silent", "--outDir", out_dir, "--pattern"] + patterns,
             progress_message = "Generating CSS type definitions for %s" % f.path,
         )
 


### PR DESCRIPTION
Can't currently build css_typings rules in a repo imported from another repo. This fixes that.

dataform-co/dataform-co#5707