### PR TITLE
Remove second invocation of runCli().

### DIFF
--- a/cli/BUILD
+++ b/cli/BUILD
@@ -26,18 +26,6 @@ ts_library(
     ],
 )
 
-load("@build_bazel_rules_nodejs//:index.bzl", "nodejs_binary")
-
-nodejs_binary(
-    name = "bin",
-    data = [
-        ":cli",
-        "@npm//source-map-support",
-    ],
-    entry_point = ":index.ts",
-    templated_args = ["--node_options=--require=source-map-support/register"],
-)
-
 load("//tools/common:copy.bzl", "copy_file")
 
 copy_file(

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -662,7 +662,3 @@ export function runCli() {
     yargs.showHelp();
   }
 }
-
-if (require.main === module) {
-  runCli();
-}

--- a/packages/@dataform/cli/BUILD
+++ b/packages/@dataform/cli/BUILD
@@ -13,6 +13,18 @@ ts_library(
     ],
 )
 
+load("@build_bazel_rules_nodejs//:index.bzl", "nodejs_binary")
+
+nodejs_binary(
+    name = "bin",
+    data = [
+        ":cli",
+        "@npm//source-map-support",
+    ],
+    entry_point = ":index.ts",
+    templated_args = ["--node_options=--require=source-map-support/register"],
+)
+
 externals = [
     "@google-cloud/bigquery",
     "protobufjs",

--- a/scripts/run
+++ b/scripts/run
@@ -1,5 +1,5 @@
 #!/bin/bash
 set -e
 
-bazel build //cli:bin
-./bazel-bin/cli/bin.sh "$@"
+bazel build //packages/@dataform/cli:bin
+./bazel-bin/packages/@dataform/cli/bin.sh "$@"

--- a/version.bzl
+++ b/version.bzl
@@ -1,3 +1,3 @@
 # NOTE: If you change the format of this line, you must change the bash command
 # in /scripts/publish to extract the version string correctly.
-DF_VERSION = "1.6.7"
+DF_VERSION = "1.6.8"


### PR DESCRIPTION
I'm not quite sure how to test this (seems like maybe `scripts/run` should run the JS bundle?), but I believe this fixes https://github.com/dataform-co/dataform/issues/754.

We didn't see this issue locally because `scripts/run` doesn't use the rollup bundle. I *think* that when rolled up, the `if (require.main === module)` condition always evaluates to true, so the call to `runCli()` in there also executes.