### PR TITLE
Increase heading line height

### DIFF
--- a/components/blueprint/core.global.scss
+++ b/components/blueprint/core.global.scss
@@ -60,7 +60,7 @@ h2.bp3-heading,
 
 h3.bp3-heading,
 .bp3-running-text h3 {
-  line-height: 25px;
+  line-height: 28px;
   font-size: 22px;
 }
 


### PR DESCRIPTION
When we changed font sizes, line heights got a bit messed up. Makes card titles not be cut off

<img width="211" alt="Screenshot 2020-05-27 at 16 45 01" src="https://user-images.githubusercontent.com/13434377/83042539-aaf53c80-a039-11ea-8a85-cca29df89c6b.png">

<img width="168" alt="Screenshot 2020-05-27 at 16 45 08" src="https://user-images.githubusercontent.com/13434377/83042548-ae88c380-a039-11ea-8029-2e69573d0020.png">

