### PR TITLE
Use a Set for transitive_inputs.

### DIFF
--- a/api/commands/build.ts
+++ b/api/commands/build.ts
@@ -147,8 +147,8 @@ export class Builder {
       return transitiveInputTargets;
     }
     if (!transitiveInputsByTarget.has(action.target)) {
-      action.dependencyTargets.forEach(target => transitiveInputTargets.add(target));
       for (const transitiveInputTarget of action.dependencyTargets || []) {
+        transitiveInputTargets.add(transitiveInputTarget);
         const transitiveInputAction = this.allActions.get(transitiveInputTarget);
         // Recursively add transitive inputs for all dependencies that are not tables or declarations.
         // (i.e. recurse through all dependency views, operations, etc.)

--- a/api/commands/build.ts
+++ b/api/commands/build.ts
@@ -2,7 +2,11 @@ import { prune } from "df/api/commands/prune";
 import { state } from "df/api/commands/state";
 import * as dbadapters from "df/api/dbadapters";
 import { actionsByTarget } from "df/api/utils/graphs";
-import { JSONObjectStringifier, StringifiedMap } from "df/common/strings/stringifier";
+import {
+  JSONObjectStringifier,
+  StringifiedMap,
+  StringifiedSet
+} from "df/common/strings/stringifier";
 import { adapters } from "df/core";
 import { IActionProto } from "df/core/session";
 import * as utils from "df/core/utils";
@@ -46,9 +50,10 @@ export class Builder {
       tableMetadataByTarget.set(tableState.target, tableState);
     });
 
-    const transitiveInputsByTarget = new StringifiedMap<dataform.ITarget, dataform.ITarget[]>(
-      JSONObjectStringifier.create()
-    );
+    const transitiveInputsByTarget = new StringifiedMap<
+      dataform.ITarget,
+      StringifiedSet<dataform.ITarget>
+    >(JSONObjectStringifier.create());
     const actions: dataform.IExecutionAction[] = [].concat(
       this.prunedGraph.tables.map(t =>
         this.buildTable(t, tableMetadataByTarget.get(t.target), transitiveInputsByTarget)
@@ -74,7 +79,7 @@ export class Builder {
   private buildTable(
     table: dataform.ITable,
     tableMetadata: dataform.ITableMetadata,
-    transitiveInputsByTarget: StringifiedMap<dataform.ITarget, dataform.ITarget[]>
+    transitiveInputsByTarget: StringifiedMap<dataform.ITarget, StringifiedSet<dataform.ITarget>>
   ) {
     if (table.protected && this.runConfig.fullRefresh) {
       throw new Error("Protected datasets cannot be fully refreshed.");
@@ -86,7 +91,7 @@ export class Builder {
 
     return dataform.ExecutionAction.create({
       name: table.name,
-      transitiveInputs: this.getAllTransitiveInputs(table, transitiveInputsByTarget),
+      transitiveInputs: Array.from(this.getAllTransitiveInputs(table, transitiveInputsByTarget)),
       dependencies: table.dependencies,
       type: "table",
       target: table.target,
@@ -99,11 +104,13 @@ export class Builder {
 
   private buildOperation(
     operation: dataform.IOperation,
-    transitiveInputsByTarget: StringifiedMap<dataform.ITarget, dataform.ITarget[]>
+    transitiveInputsByTarget: StringifiedMap<dataform.ITarget, StringifiedSet<dataform.ITarget>>
   ) {
     return dataform.ExecutionAction.create({
       name: operation.name,
-      transitiveInputs: this.getAllTransitiveInputs(operation, transitiveInputsByTarget),
+      transitiveInputs: Array.from(
+        this.getAllTransitiveInputs(operation, transitiveInputsByTarget)
+      ),
       dependencies: operation.dependencies,
       type: "operation",
       target: operation.target,
@@ -115,11 +122,13 @@ export class Builder {
 
   private buildAssertion(
     assertion: dataform.IAssertion,
-    transitiveInputsByTarget: StringifiedMap<dataform.ITarget, dataform.ITarget[]>
+    transitiveInputsByTarget: StringifiedMap<dataform.ITarget, StringifiedSet<dataform.ITarget>>
   ) {
     return dataform.ExecutionAction.create({
       name: assertion.name,
-      transitiveInputs: this.getAllTransitiveInputs(assertion, transitiveInputsByTarget),
+      transitiveInputs: Array.from(
+        this.getAllTransitiveInputs(assertion, transitiveInputsByTarget)
+      ),
       dependencies: assertion.dependencies,
       type: "assertion",
       target: assertion.target,
@@ -131,13 +140,14 @@ export class Builder {
 
   private getAllTransitiveInputs(
     action: dataform.ITable | dataform.IOperation | dataform.IAssertion,
-    transitiveInputsByTarget: StringifiedMap<dataform.ITarget, dataform.ITarget[]>
-  ) {
+    transitiveInputsByTarget: StringifiedMap<dataform.ITarget, StringifiedSet<dataform.ITarget>>
+  ): StringifiedSet<dataform.ITarget> {
+    const transitiveInputTargets = new StringifiedSet(JSONObjectStringifier.create());
     if (!action.target) {
-      return [];
+      return transitiveInputTargets;
     }
     if (!transitiveInputsByTarget.has(action.target)) {
-      let transitiveInputTargets = action.dependencyTargets;
+      action.dependencyTargets.forEach(target => transitiveInputTargets.add(target));
       for (const transitiveInputTarget of action.dependencyTargets || []) {
         const transitiveInputAction = this.allActions.get(transitiveInputTarget);
         // Recursively add transitive inputs for all dependencies that are not tables or declarations.
@@ -149,8 +159,8 @@ export class Builder {
             transitiveInputAction instanceof dataform.Declaration
           )
         ) {
-          transitiveInputTargets = transitiveInputTargets.concat(
-            this.getAllTransitiveInputs(transitiveInputAction, transitiveInputsByTarget)
+          this.getAllTransitiveInputs(transitiveInputAction, transitiveInputsByTarget).forEach(
+            target => transitiveInputTargets.add(target)
           );
         }
       }

--- a/api/commands/run.ts
+++ b/api/commands/run.ts
@@ -360,7 +360,7 @@ export class Runner {
 
     for (const dependencyTarget of executionAction.transitiveInputs) {
       const dependencyAction = this.graph.actions.find(action =>
-        lodash.isEqual(action.target, dependencyTarget)
+        lodash.isEqual(action.target, dataform.Target.create(dependencyTarget))
       );
       if (!dependencyAction) {
         continue;

--- a/common/strings/stringifier.spec.ts
+++ b/common/strings/stringifier.spec.ts
@@ -3,7 +3,8 @@ import {
   ArrayStringifier,
   JSONObjectStringifier,
   LongStringifier,
-  StringifiedMap
+  StringifiedMap,
+  StringifiedSet
 } from "df/common/strings/stringifier";
 import { suite, test } from "df/testing";
 import Long from "long";
@@ -98,6 +99,44 @@ suite(basename(__filename), () => {
           b: 2
         })
       ).equals("test");
+    });
+  });
+
+  suite("stringified set", () => {
+    const jsonStringifiedSet = new StringifiedSet<IKey>(JSONObjectStringifier.create(), [
+      { a: "1", b: 2 },
+      { a: "2", b: 2 },
+      { a: "2", b: 3 }
+    ]);
+
+    test("has correct stringified values", () => {
+      expect([...jsonStringifiedSet.values()]).deep.equals([
+        { a: "1", b: 2 },
+        { a: "2", b: 2 },
+        { a: "2", b: 3 }
+      ]);
+    });
+
+    test("has correct stringified iterator", () => {
+      expect([...jsonStringifiedSet]).deep.equals([
+        { a: "1", b: 2 },
+        { a: "2", b: 2 },
+        { a: "2", b: 3 }
+      ]);
+    });
+
+    test("add and has", () => {
+      const set = new StringifiedSet<IKey>(JSONObjectStringifier.create());
+      set.add({
+        a: "1",
+        b: 2
+      });
+      expect(
+        set.has({
+          a: "1",
+          b: 2
+        })
+      ).equals(true);
     });
   });
 });

--- a/common/strings/stringifier.ts
+++ b/common/strings/stringifier.ts
@@ -163,3 +163,107 @@ export class StringifiedMap<K, V> implements Map<K, V> {
     return this.map.values();
   }
 }
+
+export class StringifiedSet<T> implements Set<T> {
+  get size() {
+    return this.set.size;
+  }
+
+  get [Symbol.toStringTag]() {
+    return StringifiedSet.name;
+  }
+
+  private set: Set<string>;
+
+  constructor(
+    private readonly stringifier: IStringifier<T>,
+    // tslint:disable-next-line: array-type
+    values?: readonly T[] | null
+  ) {
+    if (values) {
+      this.set = new Set<string>(values.map(value => stringifier.stringify(value)));
+    } else {
+      this.set = new Set<string>();
+    }
+  }
+
+  public add(value: T): this {
+    this.set.add(this.stringifier.stringify(value));
+    return this;
+  }
+
+  public clear(): void {
+    return this.set.clear();
+  }
+
+  public delete(value: T): boolean {
+    return this.set.delete(this.stringifier.stringify(value));
+  }
+
+  public forEach(callbackfn: (value: T, value2: T, set: Set<T>) => void, thisArg?: any): void {
+    return this.set.forEach(
+      (value, value2, _) =>
+        callbackfn(this.stringifier.parse(value), this.stringifier.parse(value2), null),
+      thisArg
+    );
+  }
+
+  public has(value: T): boolean {
+    return this.set.has(this.stringifier.stringify(value));
+  }
+
+  public [Symbol.iterator](): IterableIterator<T> {
+    return this.keys();
+  }
+
+  public entries(): IterableIterator<[T, T]> {
+    const stringifier = this.stringifier;
+    const innerIterator = this.set[Symbol.iterator]();
+    return new (class Iter implements IterableIterator<[T, T]> {
+      public [Symbol.iterator](): IterableIterator<[T, T]> {
+        return this;
+      }
+      public next(): IteratorResult<[T, T], any> {
+        const next = innerIterator.next();
+        return {
+          value: !next.done ? [stringifier.parse(next.value[0]), next.value[1]] : undefined,
+          done: next.done
+        };
+      }
+    })();
+  }
+
+  public keys(): IterableIterator<T> {
+    const stringifier = this.stringifier;
+    const innerIterator = this.set.keys();
+    return new (class Iter implements IterableIterator<T> {
+      public [Symbol.iterator](): IterableIterator<T> {
+        return this;
+      }
+      public next(): IteratorResult<T> {
+        const next = innerIterator.next();
+        return {
+          value: !next.done ? stringifier.parse(next.value) : undefined,
+          done: next.done
+        };
+      }
+    })();
+  }
+
+  public values(): IterableIterator<T> {
+    const stringifier = this.stringifier;
+    const innerIterator = this.set.values();
+    return new (class Iter implements IterableIterator<T> {
+      public [Symbol.iterator](): IterableIterator<T> {
+        return this;
+      }
+      public next(): IteratorResult<T> {
+        const next = innerIterator.next();
+        return {
+          value: !next.done ? stringifier.parse(next.value) : undefined,
+          done: next.done
+        };
+      }
+    })();
+  }
+}


### PR DESCRIPTION
For a large example graph, this drops `ExecutionGraph` size from >18MB to ~3MB.