### PR TITLE
Confirm button on controlled dialog now closes the popover it came from

### DIFF
--- a/components/controlled_dialog.tsx
+++ b/components/controlled_dialog.tsx
@@ -1,4 +1,4 @@
-import { Button, IButtonProps, Intent } from "@blueprintjs/core";
+import { Button, Classes, IButtonProps, Intent } from "@blueprintjs/core";
 import * as React from "react";
 
 import { CardActions } from "df/components/card";
@@ -104,6 +104,7 @@ export class ControlledDialog extends React.Component<IProps, IState> {
                   this.setState({ isOpen: false });
                 }}
                 text={confirmButtonProps?.text || "Confirm"}
+                className={`${Classes.POPOVER_DISMISS} ${confirmButtonProps?.className || ""}`}
               />
             )}
           </CardActions>


### PR DESCRIPTION
i.e. if you're on a menu, and a menu item opens a dialog, then clicking confirm within that dialog will close the menu as well. Previously the menu stayed open.

Related to tooltip stickyness.