### PR TITLE
Fix dialog header

### DIFF
--- a/components/dialog.tsx
+++ b/components/dialog.tsx
@@ -13,8 +13,6 @@ export const Dialog = ({
   return (
     <BlueprintDialog
       className={styles.dialog}
-      isCloseButtonShown={false}
-      title=""
       canOutsideClickClose={true}
       hasBackdrop={true}
       usePortal={true}


### PR DESCRIPTION
My bad, I didn't test this properly because I thought it was card, not dialog.

Removes warning that's something like `"isCloseButtonShown" prop is ignored if title is not set`