### PR TITLE
Move to es2017 as default

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -59,7 +59,7 @@ load("@bazel_gazelle//:def.bzl", "gazelle")
 # gazelle:proto_group go_package
 gazelle(name = "gazelle")
 
-load("@npm_bazel_typescript//:index.bzl", "ts_library")
+load("//tools:ts_library.bzl", "ts_library")
 
 # TODO: This is only here in order to workaround a bug in the way bazel resolves
 # workspace imports when in nested repositories, and can be removed once that is fixed.

--- a/api/BUILD
+++ b/api/BUILD
@@ -1,6 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@npm_bazel_typescript//:index.bzl", "ts_library")
+load("//tools:ts_library.bzl", "ts_library")
 
 ts_library(
     name = "lib",

--- a/api/utils/BUILD
+++ b/api/utils/BUILD
@@ -1,6 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@npm_bazel_typescript//:index.bzl", "ts_library")
+load("//tools:ts_library.bzl", "ts_library")
 
 ts_library(
     name = "utils",

--- a/app/BUILD
+++ b/app/BUILD
@@ -26,7 +26,7 @@ css_typings(
     ],
 )
 
-load("@npm_bazel_typescript//:index.bzl", "ts_library")
+load("//tools:ts_library.bzl", "ts_library")
 
 ts_library(
     name = "app",

--- a/cli/BUILD
+++ b/cli/BUILD
@@ -1,6 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@npm_bazel_typescript//:index.bzl", "ts_library")
+load("//tools:ts_library.bzl", "ts_library")
 
 ts_library(
     name = "cli",

--- a/common/errors/BUILD
+++ b/common/errors/BUILD
@@ -1,5 +1,5 @@
 load("@df//testing:index.bzl", "ts_test_suite")
-load("@npm_bazel_typescript//:index.bzl", "ts_library")
+load("//tools:ts_library.bzl", "ts_library")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/common/strings/BUILD
+++ b/common/strings/BUILD
@@ -1,5 +1,5 @@
 load("@df//testing:index.bzl", "ts_test_suite")
-load("@npm_bazel_typescript//:index.bzl", "ts_library")
+load("//tools:ts_library.bzl", "ts_library")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/components/BUILD
+++ b/components/BUILD
@@ -1,6 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@npm_bazel_typescript//:index.bzl", "ts_library")
+load("//tools:ts_library.bzl", "ts_library")
 load("@df//tools:css_typings.bzl", "css_typings")
 load("@io_bazel_rules_sass//:defs.bzl", "multi_sass_binary")
 load("@io_bazel_rules_sass//:defs.bzl", "sass_library")

--- a/components/blueprint/BUILD
+++ b/components/blueprint/BUILD
@@ -1,5 +1,5 @@
 load("@io_bazel_rules_sass//:defs.bzl", "multi_sass_binary")
-load("@npm_bazel_typescript//:index.bzl", "ts_library")
+load("//tools:ts_library.bzl", "ts_library")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/components/charts/BUILD
+++ b/components/charts/BUILD
@@ -1,6 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@npm_bazel_typescript//:index.bzl", "ts_library")
+load("//tools:ts_library.bzl", "ts_library")
 load("@df//tools:css_typings.bzl", "css_typings")
 load("@io_bazel_rules_sass//:defs.bzl", "multi_sass_binary")
 

--- a/core/BUILD
+++ b/core/BUILD
@@ -1,4 +1,4 @@
-load("@npm_bazel_typescript//:index.bzl", "ts_library")
+load("//tools:ts_library.bzl", "ts_library")
 load("//tools:expand_template.bzl", "expand_template")
 load("//:version.bzl", "DF_VERSION")
 

--- a/grpc-web-proxy/BUILD
+++ b/grpc-web-proxy/BUILD
@@ -1,6 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@npm_bazel_typescript//:index.bzl", "ts_library")
+load("//tools:ts_library.bzl", "ts_library")
 
 ts_library(
     name = "grpc-web-proxy",

--- a/packages/@dataform/assertion_utils/BUILD
+++ b/packages/@dataform/assertion_utils/BUILD
@@ -1,4 +1,4 @@
-load("@npm_bazel_typescript//:index.bzl", "ts_library")
+load("//tools:ts_library.bzl", "ts_library")
 load("//:version.bzl", "DF_VERSION")
 load("//packages:index.bzl", "pkg_json", "pkg_npm_tar")
 

--- a/packages/@dataform/cli/BUILD
+++ b/packages/@dataform/cli/BUILD
@@ -1,4 +1,4 @@
-load("@npm_bazel_typescript//:index.bzl", "ts_library")
+load("//tools:ts_library.bzl", "ts_library")
 load("//:version.bzl", "DF_VERSION")
 load("//packages:index.bzl", "pkg_bundle", "pkg_json", "pkg_npm_tar")
 

--- a/packages/@dataform/core/BUILD
+++ b/packages/@dataform/core/BUILD
@@ -1,4 +1,4 @@
-load("@npm_bazel_typescript//:index.bzl", "ts_library")
+load("//tools:ts_library.bzl", "ts_library")
 load("//:version.bzl", "DF_VERSION")
 load("//packages:index.bzl", "pkg_bundle", "pkg_bundle_dts", "pkg_json", "pkg_npm_tar")
 

--- a/packages/@dataform/crossdb/BUILD
+++ b/packages/@dataform/crossdb/BUILD
@@ -1,4 +1,4 @@
-load("@npm_bazel_typescript//:index.bzl", "ts_library")
+load("//tools:ts_library.bzl", "ts_library")
 load("//packages:index.bzl", "pkg_json", "pkg_npm_tar")
 load("//:version.bzl", "DF_VERSION")
 

--- a/packages/BUILD
+++ b/packages/BUILD
@@ -1,4 +1,4 @@
-load("@npm_bazel_typescript//:index.bzl", "ts_library")
+load("//tools:ts_library.bzl", "ts_library")
 load("@build_bazel_rules_nodejs//:index.bzl", "nodejs_binary")
 
 package(default_visibility = ["//visibility:public"])

--- a/server/BUILD
+++ b/server/BUILD
@@ -12,7 +12,7 @@ ts_grpc_service(
     service = "dataform.server.Service",
 )
 
-load("@npm_bazel_typescript//:index.bzl", "ts_library")
+load("//tools:ts_library.bzl", "ts_library")
 
 ts_library(
     name = "server",

--- a/sql/BUILD
+++ b/sql/BUILD
@@ -1,4 +1,4 @@
-load("@npm_bazel_typescript//:index.bzl", "ts_library")
+load("//tools:ts_library.bzl", "ts_library")
 load("//testing:index.bzl", "ts_test_suite")
 
 package(default_visibility = ["//visibility:public"])

--- a/sqlx/BUILD
+++ b/sqlx/BUILD
@@ -1,6 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@npm_bazel_typescript//:index.bzl", "ts_library")
+load("//tools:ts_library.bzl", "ts_library")
 
 ts_library(
     name = "sqlx",

--- a/testing/BUILD
+++ b/testing/BUILD
@@ -1,6 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@npm_bazel_typescript//:index.bzl", "ts_library")
+load("//tools:ts_library.bzl", "ts_library")
 
 ts_library(
     name = "testing",

--- a/testing/index.bzl
+++ b/testing/index.bzl
@@ -1,4 +1,4 @@
-load("@npm_bazel_typescript//:index.bzl", "ts_library")
+load("//tools:ts_library.bzl", "ts_library")
 load("@build_bazel_rules_nodejs//:index.bzl", "nodejs_test")
 
 def ts_test(name, entry_point, args = [], templated_args = [], data = [], tags = [], **kwargs):

--- a/tests/utils/BUILD
+++ b/tests/utils/BUILD
@@ -1,6 +1,6 @@
 package(default_visibility = ["//tests:__subpackages__"])
 
-load("@npm_bazel_typescript//:index.bzl", "ts_library")
+load("//tools:ts_library.bzl", "ts_library")
 
 ts_library(
     name = "utils",

--- a/tools/cloudbuild-badge/BUILD
+++ b/tools/cloudbuild-badge/BUILD
@@ -1,6 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@npm_bazel_typescript//:index.bzl", "ts_library")
+load("//tools:ts_library.bzl", "ts_library")
 
 ts_library(
     name = "cloudbuild-badge",

--- a/tools/gen-package-json/BUILD
+++ b/tools/gen-package-json/BUILD
@@ -1,6 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@npm_bazel_typescript//:index.bzl", "ts_library")
+load("//tools:ts_library.bzl", "ts_library")
 
 ts_library(
     name = "json-merge",

--- a/tools/markdown-cms/BUILD
+++ b/tools/markdown-cms/BUILD
@@ -1,6 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@npm_bazel_typescript//:index.bzl", "ts_library")
+load("//tools:ts_library.bzl", "ts_library")
 
 ts_library(
     name = "markdown-cms",

--- a/tools/protobufjs/BUILD
+++ b/tools/protobufjs/BUILD
@@ -1,6 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@npm_bazel_typescript//:index.bzl", "ts_library")
+load("//tools:ts_library.bzl", "ts_library")
 load("@build_bazel_rules_nodejs//:index.bzl", "nodejs_binary")
 
 exports_files([

--- a/tools/stackdriver-github-bridge/BUILD
+++ b/tools/stackdriver-github-bridge/BUILD
@@ -1,6 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@npm_bazel_typescript//:index.bzl", "ts_library")
+load("//tools:ts_library.bzl", "ts_library")
 
 ts_library(
     name = "stackdriver-github-bridge",

--- a/tools/ts_library.bzl
+++ b/tools/ts_library.bzl
@@ -1,0 +1,8 @@
+load("@npm_bazel_typescript//:index.bzl", native_ts_library = "ts_library")
+
+def ts_library(**kwargs):
+    native_ts_library(
+        devmode_target = "es2017",
+        prodmode_target = "es2017",
+        **kwargs
+    )

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
     "noImplicitThis": true,
     "preserveConstEnums": true,
     "removeComments": true,
-    "target": "es6",
+    "target": "es2017",
     "sourceMap": true,
     "skipLibCheck": true,
     "experimentalDecorators": true,

--- a/vscode/BUILD
+++ b/vscode/BUILD
@@ -1,4 +1,4 @@
-load("@npm_bazel_typescript//:index.bzl", "ts_library")
+load("//tools:ts_library.bzl", "ts_library")
 
 package(default_visibility = ["//visibility:public"])
 


### PR DESCRIPTION
Currently compiling to es2015, which produces generator code instead of async/await, which makes the --async-stack-traces effectively a no-op.

Note that es2017 is pretty much supported in node 10 and above AFAICT.