### PR TITLE
Remove depricated protos for comp/val errors

### DIFF
--- a/protos/core.proto
+++ b/protos/core.proto
@@ -368,10 +368,9 @@ message CompiledGraph {
 
   string dataform_core_version = 10;
 
-  repeated ValidationError deprecated_validation_errors = 5;
-  repeated CompilationError deprecated_compilation_errors = 6;
-
   repeated Target targets = 11;
+
+  reserved 5, 6;
 }
 
 message ExecutionTask {


### PR DESCRIPTION
Related to https://github.com/dataform-co/dataform-co/pull/6803

Is `reserved` actually needed here?