### PR TITLE
Hide singleQueryPerAction

### DIFF
--- a/content/docs/guides/configuration.md
+++ b/content/docs/guides/configuration.md
@@ -42,7 +42,7 @@ by changing the `defaultSchema` property to some other value. For example, to ch
 
 ### Running operations in context
 
-BigQuery and SQL Data Warehouse by default run all operations for a file in the same context. This functionality is not supported for Redshift or Snowflake.
+BigQuery and SQL Data Warehouse run all operations for a file in the same context. For Redshift or Snowflake, operations are run as separate queries.
 
 This is useful for scripting, for example defining variables or UDFs in BigQuery before the create table statement.
 
@@ -59,16 +59,6 @@ select var as col;
 is treated as if the `pre_operations` block wasn't there, becoming `declare var string; set var = 'val'; select var as col;`. For a table, SQL would be injected into the relevant place; the previous statement would be executed as `` declare var string; set var = 'val'; create or replace table `tada-analytics.dataform_data.silly_table` as select var as col; ``.
 
 For Redshift or Snowflake, the `pre_operations` block is always executed as a separate query before the main block.
-
-To disable running all operations in the same context, place the following flag in your `dataform.json` file:
-
-```json
-{
-  ...
-  "useSingleQueryPerAction": false,
-  ...
-}
-```
 
 ### Enable run caching to cut warehouse costs
 

--- a/content/docs/guides/configuration.md
+++ b/content/docs/guides/configuration.md
@@ -40,26 +40,6 @@ by changing the `defaultSchema` property to some other value. For example, to ch
 
 [Assertions](assertions) are created inside a different schema as specified by the `assertionsSchema` property.
 
-### Running operations in context
-
-BigQuery and SQL Data Warehouse run all operations for a file in the same context. For Redshift or Snowflake, operations are run as separate queries.
-
-This is useful for scripting, for example defining variables or UDFs in BigQuery before the create table statement.
-
-The executed SQL is created by joining all operations with a semi-colon `;`. For example,
-
-```sql
-pre_operations {
-  declare var string;
-  set var = 'val';
-}
-select var as col;
-```
-
-is treated as if the `pre_operations` block wasn't there, becoming `declare var string; set var = 'val'; select var as col;`. For a table, SQL would be injected into the relevant place; the previous statement would be executed as `` declare var string; set var = 'val'; create or replace table `tada-analytics.dataform_data.silly_table` as select var as col; ``.
-
-For Redshift or Snowflake, the `pre_operations` block is always executed as a separate query before the main block.
-
 ### Enable run caching to cut warehouse costs
 
 Dataform has a built-in run caching feature. Once enabled, Dataform only runs actions (datasets, assertions, or operations) that might update the data in the action's output.

--- a/content/docs/guides/operations.md
+++ b/content/docs/guides/operations.md
@@ -29,7 +29,7 @@ These statements will be run without modification against the warehouse. You can
 
 <div className="bp3-callout bp3-icon-info-sign bp3-intent-none" markdown="1">
   BigQuery and SQL Data Warehouse run all operations for a file in the same context; the executed SQL is created by joining all operations with a semi-colon <code>;</code>.
-  For Redshift or Snowflake, operations are run as separate queries.
+  For other warehouse types, operations are run as separate queries.
 </div>
 
 ## Custom dataset builds

--- a/content/docs/guides/operations.md
+++ b/content/docs/guides/operations.md
@@ -27,7 +27,10 @@ DROP VIEW IF EXISTS someschema.someview
 
 These statements will be run without modification against the warehouse. You can use warehouse specific commands in these files, such as BigQuery's DML or DDL statements, or Redshift/Postgres specific commands.
 
-Operations files behave very similarly to the statements provided to the `pre_operations { ... }` and `post_operations { ... }` blocks used when publishing datasets.
+<div className="bp3-callout bp3-icon-info-sign bp3-intent-none" markdown="1">
+  BigQuery and SQL Data Warehouse run all operations for a file in the same context; the executed SQL is created by joining all operations with a semi-colon <code>;</code>.
+  For Redshift or Snowflake, operations are run as separate queries.
+</div>
 
 ## Custom dataset builds
 

--- a/content/docs/guides/sqlx.md
+++ b/content/docs/guides/sqlx.md
@@ -91,11 +91,9 @@ Some examples can be found [here](datasets#referencing-other-datasets).
 
 - **Post-operations**: the same as pre-operations, but defined with `post_operations { }`, and runs after the main SQL.
 
-BigQuery and SQL Data Warehouse run all operations for a file (such as pre and post operations) in the same context; the executed SQL is created by joining all operations with a semi-colon `;`. For Redshift or Snowflake, operations are run as separate queries.
+BigQuery and SQL Data Warehouse run all operations for a file (such as pre and post operations) in the same context; the executed SQL is created by joining all operations with a semi-colon `;`. For other warehouse types, operations are run as separate queries.
 
 This is useful for scripting, for example defining variables or UDFs in BigQuery before the create table statement.
-
-For Redshift or Snowflake, the `pre_operations` block is always executed as a separate query before the main block, and the `post_operations` block as a separate query afterwards.
 
 ## Sandboxing for fast, secure, reproducible SQLX compilation
 

--- a/content/docs/guides/sqlx.md
+++ b/content/docs/guides/sqlx.md
@@ -15,7 +15,6 @@ If you are new to SQLX and Dataform, reading the introduction could be helpful t
 </p>
 <a href="/introduction/dataform-in-5-minutes"><button intent="primary">How SQLX works in 5 min</button></a></div>
 
-
 ## Structure
 
 SQLX contains the following components:
@@ -92,9 +91,11 @@ Some examples can be found [here](datasets#referencing-other-datasets).
 
 - **Post-operations**: the same as pre-operations, but defined with `post_operations { }`, and runs after the main SQL.
 
-<div className="bp3-callout bp3-icon-info-sign" markdown="1">
-  By default, pre and post operations are run in the same context as the main query for BiqQuery and SQL Data Warehouse. To disable this, see <a href="./datasets">here</a>. This feature is not supported for Redshift or Snowflake.
-</div>
+BigQuery and SQL Data Warehouse run all operations for a file (such as pre and post operations) in the same context; the executed SQL is created by joining all operations with a semi-colon `;`. For Redshift or Snowflake, operations are run as separate queries.
+
+This is useful for scripting, for example defining variables or UDFs in BigQuery before the create table statement.
+
+For Redshift or Snowflake, the `pre_operations` block is always executed as a separate query before the main block, and the `post_operations` block as a separate query afterwards.
 
 ## Sandboxing for fast, secure, reproducible SQLX compilation
 

--- a/protos/core.proto
+++ b/protos/core.proto
@@ -21,6 +21,8 @@ message ProjectConfig {
   string table_prefix = 11;
   
   bool use_run_cache = 10;
+
+  // For internal use only, will be removed at a later date.
   bool use_single_query_per_action = 12;
 
   // Deprecated. Please use 'default_database' instead.
@@ -104,6 +106,7 @@ message RunConfig {
   bool use_run_cache = 8;
   bool disable_set_metadata = 9;
 
+  // For internal use only, will be removed at a later date.
   bool use_single_query_per_action = 10;
 
   reserved 4, 6;

--- a/protos/core.proto
+++ b/protos/core.proto
@@ -104,6 +104,8 @@ message RunConfig {
   bool full_refresh = 2;
   int32 timeout_millis = 7;
   bool use_run_cache = 8;
+
+  // For internal use only, will be removed at a later date.
   bool disable_set_metadata = 9;
 
   // For internal use only, will be removed at a later date.

--- a/tests/api/api.spec.ts
+++ b/tests/api/api.spec.ts
@@ -743,7 +743,7 @@ postOps`
     ].forEach(({ warehouse, expectedQuery }) => {
       test(`${warehouse}_useSingleQueryPerAction`, async () => {
         const testGraph: dataform.ICompiledGraph = dataform.CompiledGraph.create({
-          projectConfig: { warehouse, useSingleQueryPerAction: true },
+          projectConfig: { warehouse },
           tables: [
             {
               name: "a",
@@ -758,7 +758,7 @@ postOps`
         const testState = dataform.WarehouseState.create({});
         const builder = new Builder(
           testGraph,
-          { useSingleQueryPerAction: true },
+          {},
           testState,
           computeAllTransitiveInputs(testGraph)
         );

--- a/tests/api/api.spec.ts
+++ b/tests/api/api.spec.ts
@@ -743,7 +743,7 @@ postOps`
     ].forEach(({ warehouse, expectedQuery }) => {
       test(`${warehouse}_useSingleQueryPerAction`, async () => {
         const testGraph: dataform.ICompiledGraph = dataform.CompiledGraph.create({
-          projectConfig: { warehouse },
+          projectConfig: { warehouse, useSingleQueryPerAction: true },
           tables: [
             {
               name: "a",
@@ -758,7 +758,7 @@ postOps`
         const testState = dataform.WarehouseState.create({});
         const builder = new Builder(
           testGraph,
-          {},
+          { useSingleQueryPerAction: true },
           testState,
           computeAllTransitiveInputs(testGraph)
         );

--- a/tests/integration/bigquery.spec.ts
+++ b/tests/integration/bigquery.spec.ts
@@ -88,7 +88,10 @@ suite("@dataform/integration/bigquery", { parallel: true }, ({ before, after }) 
         const expectedResult = expectedFailedActions.includes(actionName)
           ? dataform.ActionResult.ExecutionStatus.FAILED
           : dataform.ActionResult.ExecutionStatus.SUCCESSFUL;
-        expect(actionMap[actionName].status).equals(expectedResult, `${actionName} has unexpected status.`);
+        expect(actionMap[actionName].status).equals(
+          expectedResult,
+          `${actionName} has unexpected status.`
+        );
       }
 
       expect(
@@ -370,7 +373,6 @@ suite("@dataform/integration/bigquery", { parallel: true }, ({ before, after }) 
     test("evaluate from valid compiled graph as valid", async () => {
       // Create and run the project.
       const compiledGraph = await compile("evaluate", {
-        useSingleQueryPerAction: true,
         useRunCache: false
       });
       const executionGraph = await dfapi.build(compiledGraph, {}, dbadapter);


### PR DESCRIPTION
To confirm, the functionality of putting it in the `dataform.json` should still exist, but its existence should just be hidden to the end user?