### PR TITLE
When writing last-modified timestamps to run cache, use (a) the pre-run timestamp for unmodified datasets, or (b) the post-action-execution timestamp for modified datasets.

### DIFF
--- a/api/dbadapters/index.ts
+++ b/api/dbadapters/index.ts
@@ -5,6 +5,7 @@ import { BigQueryDbAdapter } from "df/api/dbadapters/bigquery";
 import { RedshiftDbAdapter } from "df/api/dbadapters/redshift";
 import { SnowflakeDbAdapter } from "df/api/dbadapters/snowflake";
 import { SQLDataWarehouseDBAdapter } from "df/api/dbadapters/sqldatawarehouse";
+import { StringifiedMap } from "df/common/strings/stringifier";
 import { QueryOrAction } from "df/core/adapters";
 import { dataform } from "df/protos/ts";
 
@@ -38,6 +39,10 @@ export interface IDbAdapter {
   preview(target: dataform.ITarget, limitRows?: number): Promise<any[]>;
   prepareSchema(database: string, schema: string): Promise<void>;
   persistStateMetadata(
+    transitiveInputMetadataByTarget: StringifiedMap<
+      dataform.ITarget,
+      dataform.PersistedTableMetadata.ITransitiveInputMetadata
+    >,
     allActions: dataform.IExecutionAction[],
     actionsToPersist: dataform.IExecutionAction[],
     options: {

--- a/api/dbadapters/redshift.ts
+++ b/api/dbadapters/redshift.ts
@@ -193,22 +193,15 @@ export class RedshiftDbAdapter implements IDbAdapter {
     }
   }
 
-  public async prepareStateMetadataTable(): Promise<void> {
-    // Unimplemented.
-  }
-
   public async persistedStateMetadata(): Promise<dataform.IPersistedTableMetadata[]> {
-    const persistedMetadata: dataform.IPersistedTableMetadata[] = [];
-    return persistedMetadata;
+    return [];
   }
 
-  public async persistStateMetadata(actions: dataform.IExecutionAction[]) {
+  public async persistStateMetadata() {
     // Unimplemented.
   }
-  public async setMetadata(action: dataform.IExecutionAction): Promise<void> {
-    // Unimplemented.
-  }
-  public async deleteStateMetadata(actions: dataform.IExecutionAction[]): Promise<void> {
+
+  public async setMetadata(): Promise<void> {
     // Unimplemented.
   }
 

--- a/api/dbadapters/snowflake.ts
+++ b/api/dbadapters/snowflake.ts
@@ -232,22 +232,15 @@ where table_schema = '${target.schema}'
     });
   }
 
-  public async prepareStateMetadataTable(): Promise<void> {
-    // Unimplemented.
-  }
-
   public async persistedStateMetadata(): Promise<dataform.IPersistedTableMetadata[]> {
-    const persistedMetadata: dataform.IPersistedTableMetadata[] = [];
-    return persistedMetadata;
+    return [];
   }
 
-  public async persistStateMetadata(actions: dataform.IExecutionAction[]) {
+  public async persistStateMetadata() {
     // Unimplemented.
   }
-  public async setMetadata(action: dataform.IExecutionAction): Promise<void> {
-    // Unimplemented.
-  }
-  public async deleteStateMetadata(actions: dataform.IExecutionAction[]): Promise<void> {
+
+  public async setMetadata(): Promise<void> {
     // Unimplemented.
   }
 }

--- a/api/dbadapters/sqldatawarehouse.ts
+++ b/api/dbadapters/sqldatawarehouse.ts
@@ -184,22 +184,15 @@ export class SQLDataWarehouseDBAdapter implements IDbAdapter {
     await (await this.pool).close();
   }
 
-  public async prepareStateMetadataTable(): Promise<void> {
-    // Unimplemented.
-  }
   public async persistedStateMetadata(): Promise<dataform.IPersistedTableMetadata[]> {
-    const persistedMetadata: dataform.IPersistedTableMetadata[] = [];
-    return persistedMetadata;
+    return [];
   }
 
-  public async persistStateMetadata(actions: dataform.IExecutionAction[]) {
+  public async persistStateMetadata() {
     // Unimplemented.
   }
 
-  public async setMetadata(action: dataform.IExecutionAction): Promise<void> {
-    // Unimplemented.
-  }
-  public async deleteStateMetadata(actions: dataform.IExecutionAction[]): Promise<void> {
+  public async setMetadata(): Promise<void> {
     // Unimplemented.
   }
 }

--- a/tests/api/api.spec.ts
+++ b/tests/api/api.spec.ts
@@ -1266,7 +1266,8 @@ postOps`
         prepareSchema: (_, __) => {
           return Promise.resolve();
         },
-        close: () => undefined
+        close: () => undefined,
+        table: _ => undefined
       } as IDbAdapter;
 
       const runner = new Runner(mockDbAdapter, CANCEL_TEST_GRAPH);


### PR DESCRIPTION
fixes https://github.com/dataform-co/dataform/issues/860