### PR TITLE
Fix docs link jumping

### DIFF
--- a/docs/layouts/documentation.css
+++ b/docs/layouts/documentation.css
@@ -101,6 +101,6 @@
 :target::before {
   content: "";
   display: block;
-  height: 60px;
-  margin: -60px 0 0;
+  height: 80px;
+  margin: -80px 0 0;
 }

--- a/docs/layouts/documentation.css
+++ b/docs/layouts/documentation.css
@@ -96,3 +96,11 @@
 .whatsNextCard p {
   color: var(--textSecondary);
 }
+
+/* Stops url links, e.g. /assertions#content-link, from being hidden behind the header */
+:target::before {
+  content: "";
+  display: block;
+  height: 60px;
+  margin: -60px 0 0;
+}

--- a/docs/layouts/documentation.css
+++ b/docs/layouts/documentation.css
@@ -98,9 +98,7 @@
 }
 
 /* Stops url links, e.g. /assertions#content-link, from being hidden behind the header */
-:target::before {
-  content: "";
-  display: block;
-  height: 80px;
-  margin: -80px 0 0;
+h2 {
+  padding-top: 80px !important;
+  margin-top: -40px !important;
 }


### PR DESCRIPTION
Fixes https://github.com/dataform-co/dataform-co/issues/6971

This frustrates me, the `::before` element is there, but it's not pushing the page down right. Any ideas?