### PR TITLE
Always drop assertion views in Redshift before recreating them.

### DIFF
--- a/api/dbadapters/redshift.ts
+++ b/api/dbadapters/redshift.ts
@@ -275,14 +275,14 @@ class PgPoolExecutor {
         // the cursor. I've filed a bug (https://github.com/brianc/node-pg-cursor/issues/55),
         // but setting a minimum of 2 resulting rows seems to do the trick.
         cursor.read(Math.max(2, options.maxResults), (err, rows, queryResult) => {
+          if (err) {
+            reject(err);
+            return;
+          }
           try {
             verifyUniqueColumnNames(queryResult.fields);
           } catch (e) {
             reject(e);
-          }
-          if (err) {
-            reject(err);
-            return;
           }
           // Close the cursor after reading the first page of results.
           cursor.close(closeErr => {

--- a/core/adapters/redshift.ts
+++ b/core/adapters/redshift.ts
@@ -72,6 +72,7 @@ export class RedshiftAdapter extends Adapter implements IAdapter {
         name: assertion.name
       });
     return Tasks.create()
+      .add(Task.statement(this.dropIfExists(target, "view")))
       .add(Task.statement(this.createOrReplaceView(target, assertion.query, true)))
       .add(Task.assertion(`select sum(1) as row_count from ${this.resolveTarget(target)}`));
   }

--- a/tests/integration/redshift.spec.ts
+++ b/tests/integration/redshift.spec.ts
@@ -92,7 +92,7 @@ suite("@dataform/integration/redshift", ({ before, after }) => {
     }
 
     expect(
-      actionMap["df_integration_test_assertions.example_assertion_uniqueness_fail"].tasks[1]
+      actionMap["df_integration_test_assertions.example_assertion_uniqueness_fail"].tasks[2]
         .errorMessage
     ).to.eql("redshift error: Assertion failed: query returned 1 row(s).");
 


### PR DESCRIPTION
fixes https://github.com/dataform-co/dataform/issues/259

- also stop trying to verify returned column names before we check if the query itself resulted in an error (as with assertions)