### PR TITLE
Future-proof protomongo package against changes to the Go protobuf package.

### DIFF
--- a/protomongo/protomongo.go
+++ b/protomongo/protomongo.go
@@ -191,10 +191,12 @@ func (pc *protobufCodec) protoHelper(pb descriptor.Message, t reflect.Type) *pro
 	oneofFieldWrapperProps := make([]*proto.Properties, 0)
 	normalPropsByTag := make(map[string]*proto.Properties)
 	for _, prop := range props.Prop {
-		if oneofNames[prop.OrigName] {
-			oneofFieldWrapperProps = append(oneofFieldWrapperProps, prop)
-		} else {
-			normalPropsByTag[strconv.Itoa(prop.Tag)] = prop
+		if !strings.HasPrefix(prop.Name, "XXX_") {
+			if oneofNames[prop.OrigName] {
+				oneofFieldWrapperProps = append(oneofFieldWrapperProps, prop)
+			} else {
+				normalPropsByTag[strconv.Itoa(prop.Tag)] = prop
+			}
 		}
 	}
 	oneofPropsByTag := make(map[string]*proto.OneofProperties)


### PR DESCRIPTION
It looks like an update to the `github.com/golang/protobuf/proto` package changes the behaviour of `GetProperties`, and now the returned `Properties` includes the `XXX_`-prefixed properties (unknown fields, etc). 

As per the comment at the top of https://godoc.org/github.com/golang/protobuf/proto#Properties, these properties are essentially useless, and as such we filter them out.

This is required to upgrade to the latest version of Bazel.