### PR TITLE
Enable unit tests to compare object values.

### DIFF
--- a/api/commands/run.ts
+++ b/api/commands/run.ts
@@ -245,18 +245,10 @@ export class Runner {
         .add(dbadapters.CACHED_STATE_TABLE_TARGET.schema);
     }
 
-    // throw new Error(
-    //   "" +
-    //     Array.from(databaseSchemas.entries()).map(
-    //       ([database, schemas]) => database + ":::" + Array.from(schemas)
-    //     )
-    // );
-
     // Create all nonexistent schemas.
     await Promise.all(
       Array.from(databaseSchemas.entries()).map(async ([database, schemas]) => {
         const existingSchemas = new Set(await this.dbadapter.schemas(database));
-        // throw new Error("" + Array.from(existingSchemas));
         await Promise.all(
           Array.from(schemas)
             .filter(schema => !existingSchemas.has(schema))

--- a/api/commands/run.ts
+++ b/api/commands/run.ts
@@ -230,7 +230,7 @@ export class Runner {
       .forEach(({ target }) => {
         // This field may not be present for older versions of dataform.
         const trueDatabase = target.database || this.graph.projectConfig.defaultDatabase;
-        if (!databaseSchemas.has(target.database)) {
+        if (!databaseSchemas.has(trueDatabase)) {
           databaseSchemas.set(trueDatabase, new Set<string>());
         }
         databaseSchemas.get(trueDatabase).add(target.schema);
@@ -245,10 +245,18 @@ export class Runner {
         .add(dbadapters.CACHED_STATE_TABLE_TARGET.schema);
     }
 
+    // throw new Error(
+    //   "" +
+    //     Array.from(databaseSchemas.entries()).map(
+    //       ([database, schemas]) => database + ":::" + Array.from(schemas)
+    //     )
+    // );
+
     // Create all nonexistent schemas.
     await Promise.all(
       Array.from(databaseSchemas.entries()).map(async ([database, schemas]) => {
         const existingSchemas = new Set(await this.dbadapter.schemas(database));
+        // throw new Error("" + Array.from(existingSchemas));
         await Promise.all(
           Array.from(schemas)
             .filter(schema => !existingSchemas.has(schema))

--- a/api/commands/test.ts
+++ b/api/commands/test.ts
@@ -81,13 +81,21 @@ async function runTest(
 
     for (const column of actualColumns) {
       const normalizedColumn = normalizeColumnName(column);
-      if (actualResultRow[normalizedColumn] !== expectedResultRow[normalizedColumn]) {
+      const expectedValue = expectedResultRow[normalizedColumn];
+      const actualValue = actualResultRow[normalizedColumn];
+      if (typeof expectedValue !== typeof actualValue) {
         rowMessages.push(
-          `For row ${i} and column "${column}": expected "${
-            expectedResultRow[normalizedColumn]
-          }" (${typeof expectedResultRow[normalizedColumn]}), but saw "${
-            actualResultRow[normalizedColumn]
-          }" (${typeof actualResultRow[normalizedColumn]}).`
+          `For row ${i} and column "${column}": expected type "${typeof expectedValue}", but saw type "${typeof actualValue}".`
+        );
+        break;
+      }
+      const comparableExpectedValue =
+        typeof expectedValue === "object" ? JSON.stringify(expectedValue) : expectedValue;
+      const comparableActualValue =
+        typeof actualValue === "object" ? JSON.stringify(actualValue) : actualValue;
+      if (comparableExpectedValue !== comparableActualValue) {
+        rowMessages.push(
+          `For row ${i} and column "${column}": expected "${comparableExpectedValue}", but saw "${comparableActualValue}".`
         );
       }
     }

--- a/core/session.ts
+++ b/core/session.ts
@@ -184,8 +184,12 @@ export class Session {
       }
       return this.adapter().resolveTarget({
         ...resolved.proto.target,
-        schema: `${resolved.proto.target.schema}${this.getSuffixWithUnderscore()}`,
-        name: `${this.getTablePrefixWithUnderscore()}${resolved.proto.target.name}`
+        schema: this.adapter().normalizeIdentifier(
+          `${resolved.proto.target.schema}${this.getSuffixWithUnderscore()}`
+        ),
+        name: this.adapter().normalizeIdentifier(
+          `${this.getTablePrefixWithUnderscore()}${resolved.proto.target.name}`
+        )
       });
     }
     // TODO: Here we allow 'ref' to go unresolved. This is for backwards compatibility with projects
@@ -198,8 +202,10 @@ export class Session {
         utils.target(
           this.adapter(),
           this.config,
-          `${this.getTablePrefixWithUnderscore()}${ref}`,
-          `${this.config.defaultSchema}${this.getSuffixWithUnderscore()}`
+          this.adapter().normalizeIdentifier(`${this.getTablePrefixWithUnderscore()}${ref}`),
+          this.adapter().normalizeIdentifier(
+            `${this.config.defaultSchema}${this.getSuffixWithUnderscore()}`
+          )
         )
       );
     }
@@ -207,8 +213,8 @@ export class Session {
       utils.target(
         this.adapter(),
         this.config,
-        `${this.getTablePrefixWithUnderscore()}${ref.name}`,
-        `${ref.schema}${this.getSuffixWithUnderscore()}`
+        this.adapter().normalizeIdentifier(`${this.getTablePrefixWithUnderscore()}${ref.name}`),
+        this.adapter().normalizeIdentifier(`${ref.schema}${this.getSuffixWithUnderscore()}`)
       )
     );
   }
@@ -459,8 +465,12 @@ export class Session {
     actions.forEach(action => {
       newTargetByOriginalTarget.set(action.target, {
         ...action.target,
-        schema: `${action.target.schema}${this.getSuffixWithUnderscore()}`,
-        name: `${this.getTablePrefixWithUnderscore()}${action.target.name}`
+        schema: this.adapter().normalizeIdentifier(
+          `${action.target.schema}${this.getSuffixWithUnderscore()}`
+        ),
+        name: this.adapter().normalizeIdentifier(
+          `${this.getTablePrefixWithUnderscore()}${action.target.name}`
+        )
       });
       action.target = newTargetByOriginalTarget.get(action.target);
       action.name = utils.targetToName(action.target);

--- a/tests/integration/bigquery_project/definitions/test.js
+++ b/tests/integration/bigquery_project/definitions/test.js
@@ -3,16 +3,16 @@ test("successful")
   .input(
     "sample_data",
     `
-        select 'hi' as col1, 1 as col2, 3.5 as col3, true as col4 union all
-        select 'ben' as col2, 2 as col2, 6.5 as col3, false as col4 union all
-        select 'sup?' as col3, 3 as col2, 9.5 as col3, true as col4
+        select 'hi' as col1, 1 as col2, 3.5 as col3, true as col4, date '2020-07-23' as col5 union all
+        select 'ben' as col2, 2 as col2, 6.5 as col3, false as col4, date '2020-07-24' as col5 union all
+        select 'sup?' as col3, 3 as col2, 9.5 as col3, true as col4, date '2020-07-25' as col5
     `
   )
   .expect(
     `
-        select 'hi' as col1, 1 as col2, 3.5 as col3, true as col4 union all
-        select 'ben' as col2, 2 as col2, 6.5 as col3, false as col4 union all
-        select 'sup?' as col3, 3 as col2, 9.5 as col3, true as col4
+        select 'hi' as col1, 1 as col2, 3.5 as col3, true as col4, date '2020-07-23' as col5 union all
+        select 'ben' as col2, 2 as col2, 6.5 as col3, false as col4, date '2020-07-24' as col5 union all
+        select 'sup?' as col3, 3 as col2, 9.5 as col3, true as col4, date '2020-07-25' as col5
     `
   );
 

--- a/tests/integration/redshift_project/definitions/test.js
+++ b/tests/integration/redshift_project/definitions/test.js
@@ -3,16 +3,16 @@ test("successful")
   .input(
     "sample_data",
     `
-        select 'hi' as col1, 1 as col2, 3.5 as col3, true as col4 union all
-        select 'ben' as col2, 2 as col2, 6.5 as col3, false as col4 union all
-        select 'sup?' as col3, 3 as col2, 9.5 as col3, true as col4
+        select 'hi' as col1, 1 as col2, 3.5 as col3, true as col4, cast('20200723' as timestamp) as col5 union all
+        select 'ben' as col2, 2 as col2, 6.5 as col3, false as col4, cast('20200724' as timestamp) as col5 union all
+        select 'sup?' as col3, 3 as col2, 9.5 as col3, true as col4, cast('20200725' as timestamp) as col5
     `
   )
   .expect(
     `
-        select 'hi' as col1, 1 as col2, 3.5 as col3, true as col4 union all
-        select 'ben' as col2, 2 as col2, 6.5 as col3, false as col4 union all
-        select 'sup?' as col3, 3 as col2, 9.5 as col3, true as col4
+        select 'hi' as col1, 1 as col2, 3.5 as col3, true as col4, cast('20200723' as timestamp) as col5 union all
+        select 'ben' as col2, 2 as col2, 6.5 as col3, false as col4, cast('20200724' as timestamp) as col5 union all
+        select 'sup?' as col3, 3 as col2, 9.5 as col3, true as col4, cast('20200725' as timestamp) as col5
     `
   );
 

--- a/tests/integration/snowflake.spec.ts
+++ b/tests/integration/snowflake.spec.ts
@@ -6,9 +6,9 @@ import * as adapters from "df/core/adapters";
 import { SnowflakeAdapter } from "df/core/adapters/snowflake";
 import { dataform } from "df/protos/ts";
 import { suite, test } from "df/testing";
-import { dropAllTables, getTableRows, keyBy } from "df/tests/integration/utils";
+import { compile, dropAllTables, getTableRows, keyBy } from "df/tests/integration/utils";
 
-suite("@dataform/integration/snowflake", ({ before, after }) => {
+suite("@dataform/integration/snowflake", { parallel: true }, ({ before, after }) => {
   const credentials = dfapi.credentials.read("snowflake", "test_credentials/snowflake.json");
   let dbadapter: dbadapters.IDbAdapter;
 
@@ -19,11 +19,7 @@ suite("@dataform/integration/snowflake", ({ before, after }) => {
   after("close adapter", () => dbadapter.close());
 
   test("run", { timeout: 90000 }, async () => {
-    const compiledGraph = await dfapi.compile({
-      projectDir: "tests/integration/snowflake_project"
-    });
-
-    expect(compiledGraph.graphErrors.compilationErrors).to.eql([]);
+    const compiledGraph = await compile("tests/integration/snowflake_project", "project_e2e");
 
     const adapter = adapters.create(compiledGraph.projectConfig, compiledGraph.dataformCoreVersion);
 
@@ -33,51 +29,24 @@ suite("@dataform/integration/snowflake", ({ before, after }) => {
     await dropAllTables(tablesToDelete, adapter, dbadapter);
 
     // Drop schemas to make sure schema creation works.
-    await dbadapter.execute(`drop schema if exists "INTEGRATION_TESTS"."df_integration_test"`);
-    await dbadapter.execute(`drop schema if exists "INTEGRATION_TESTS2"."df_integration_test"`);
-
-    // Run the tests.
-    const testResults = await dfapi.test(dbadapter, compiledGraph.tests);
-    expect(testResults).to.eql([
-      { name: "successful", successful: true },
-      {
-        name: "expected more rows than got",
-        successful: false,
-        messages: ["Expected 3 rows, but saw 2 rows."]
-      },
-      {
-        name: "expected fewer columns than got",
-        successful: false,
-        messages: ['Expected columns "COL1,COL2,COL3", but saw "COL1,COL2,COL3,COL4".']
-      },
-      {
-        name: "wrong columns",
-        successful: false,
-        messages: ['Expected columns "COL1,COL2,COL3,COL4", but saw "COL1,COL2,COL3,COL5".']
-      },
-      {
-        name: "wrong row contents",
-        successful: false,
-        messages: [
-          'For row 0 and column "COL2": expected "1" (number), but saw "5" (number).',
-          'For row 1 and column "COL3": expected "6.5" (number), but saw "12" (number).',
-          'For row 2 and column "COL1": expected "sup?" (string), but saw "WRONG" (string).'
-        ]
-      }
-    ]);
+    await dbadapter.execute(
+      `drop schema if exists "INTEGRATION_TESTS"."DF_INTEGRATION_TEST_PROJECT_E2E"`
+    );
+    await dbadapter.execute(
+      `drop schema if exists "INTEGRATION_TESTS2"."DF_INTEGRATION_TEST_PROJECT_E2E"`
+    );
 
     // Run the project.
     let executionGraph = await dfapi.build(compiledGraph, {}, dbadapter);
     let executedGraph = await dfapi.run(dbadapter, executionGraph).result();
 
-    const executionActionMap = keyBy(executionGraph.actions, v => v.name);
     const actionMap = keyBy(executedGraph.actions, v => v.name);
     expect(Object.keys(actionMap).length).eql(14);
 
     // Check the status of action execution.
     const expectedFailedActions = [
-      "DF_INTEGRATION_TEST_ASSERTIONS.EXAMPLE_ASSERTION_UNIQUENESS_FAIL",
-      "DF_INTEGRATION_TEST_ASSERTIONS.EXAMPLE_ASSERTION_FAIL"
+      "DF_INTEGRATION_TEST_ASSERTIONS_PROJECT_E2E.EXAMPLE_ASSERTION_UNIQUENESS_FAIL",
+      "DF_INTEGRATION_TEST_ASSERTIONS_PROJECT_E2E.EXAMPLE_ASSERTION_FAIL"
     ];
     for (const actionName of Object.keys(actionMap)) {
       const expectedResult = expectedFailedActions.includes(actionName)
@@ -85,51 +54,53 @@ suite("@dataform/integration/snowflake", ({ before, after }) => {
         : dataform.ActionResult.ExecutionStatus.SUCCESSFUL;
       expect(
         dataform.ActionResult.ExecutionStatus[actionMap[actionName].status],
-        `ActionResult ExecutionStatus for action "${actionName}"`
+        `ActionResult ExecutionStatus for action "${actionName}"` +
+          ":" +
+          actionMap[actionName].tasks.map(t => t.errorMessage)
       ).equals(dataform.ActionResult.ExecutionStatus[expectedResult]);
     }
 
     expect(
-      actionMap["DF_INTEGRATION_TEST_ASSERTIONS.EXAMPLE_ASSERTION_UNIQUENESS_FAIL"].tasks[1]
-        .errorMessage
+      actionMap["DF_INTEGRATION_TEST_ASSERTIONS_PROJECT_E2E.EXAMPLE_ASSERTION_UNIQUENESS_FAIL"]
+        .tasks[1].errorMessage
     ).to.eql("snowflake error: Assertion failed: query returned 1 row(s).");
 
     // Check the status of the s3 load operation.
-    expect(actionMap["DF_INTEGRATION_TEST.LOAD_FROM_S3"].status).equals(
+    expect(actionMap["DF_INTEGRATION_TEST_PROJECT_E2E.LOAD_FROM_S3"].status).equals(
       dataform.ActionResult.ExecutionStatus.SUCCESSFUL
     );
 
     // Check the s3 table has two rows, as per:
     // https://dataform-integration-tests.s3.us-east-2.amazonaws.com/sample-data/sample_data.csv
     const s3Table = keyBy(compiledGraph.operations, t => t.name)[
-      "DF_INTEGRATION_TEST.LOAD_FROM_S3"
+      "DF_INTEGRATION_TEST_PROJECT_E2E.LOAD_FROM_S3"
     ];
     const s3Rows = await getTableRows(s3Table.target, adapter, dbadapter);
     expect(s3Rows.length).equals(2);
 
     // Check the status of the view in the non-default database.
     const tada2DatabaseView = keyBy(compiledGraph.tables, t => t.name)[
-      "INTEGRATION_TESTS2.DF_INTEGRATION_TEST.SAMPLE_DATA_2"
+      "INTEGRATION_TESTS2.DF_INTEGRATION_TEST_PROJECT_E2E.SAMPLE_DATA_2"
     ];
     const tada2DatabaseViewRows = await getTableRows(tada2DatabaseView.target, adapter, dbadapter);
     expect(tada2DatabaseViewRows.length).equals(3);
 
     // Check the data in the incremental tables.
     let incrementalTable = keyBy(compiledGraph.tables, t => t.name)[
-      "DF_INTEGRATION_TEST.EXAMPLE_INCREMENTAL"
+      "DF_INTEGRATION_TEST_PROJECT_E2E.EXAMPLE_INCREMENTAL"
     ];
     let incrementalRows = await getTableRows(incrementalTable.target, adapter, dbadapter);
     expect(incrementalRows.length).equals(3);
 
     const incrementalTable2 = keyBy(compiledGraph.tables, t => t.name)[
-      "INTEGRATION_TESTS2.DF_INTEGRATION_TEST.EXAMPLE_INCREMENTAL_TADA2"
+      "INTEGRATION_TESTS2.DF_INTEGRATION_TEST_PROJECT_E2E.EXAMPLE_INCREMENTAL_TADA2"
     ];
     const incrementalRows2 = await getTableRows(incrementalTable2.target, adapter, dbadapter);
     expect(incrementalRows2.length).equals(3);
 
     // Check the data in the incremental merge table.
     incrementalTable = keyBy(compiledGraph.tables, t => t.name)[
-      "DF_INTEGRATION_TEST.EXAMPLE_INCREMENTAL_MERGE"
+      "DF_INTEGRATION_TEST_PROJECT_E2E.EXAMPLE_INCREMENTAL_MERGE"
     ];
     incrementalRows = await getTableRows(incrementalTable.target, adapter, dbadapter);
     expect(incrementalRows.length).equals(2);
@@ -154,23 +125,57 @@ suite("@dataform/integration/snowflake", ({ before, after }) => {
 
     // Check there are the expected number of extra rows in the incremental tables.
     incrementalTable = keyBy(compiledGraph.tables, t => t.name)[
-      "DF_INTEGRATION_TEST.EXAMPLE_INCREMENTAL"
+      "DF_INTEGRATION_TEST_PROJECT_E2E.EXAMPLE_INCREMENTAL"
     ];
     incrementalRows = await getTableRows(incrementalTable.target, adapter, dbadapter);
     expect(incrementalRows.length).equals(5);
 
     incrementalTable = keyBy(compiledGraph.tables, t => t.name)[
-      "INTEGRATION_TESTS2.DF_INTEGRATION_TEST.EXAMPLE_INCREMENTAL_TADA2"
+      "INTEGRATION_TESTS2.DF_INTEGRATION_TEST_PROJECT_E2E.EXAMPLE_INCREMENTAL_TADA2"
     ];
     incrementalRows = await getTableRows(incrementalTable2.target, adapter, dbadapter);
     expect(incrementalRows.length).equals(5);
 
     // Check the data in the incremental merge table.
     incrementalTable = keyBy(compiledGraph.tables, t => t.name)[
-      "DF_INTEGRATION_TEST.EXAMPLE_INCREMENTAL_MERGE"
+      "DF_INTEGRATION_TEST_PROJECT_E2E.EXAMPLE_INCREMENTAL_MERGE"
     ];
     incrementalRows = await getTableRows(incrementalTable.target, adapter, dbadapter);
     expect(incrementalRows.length).equals(2);
+  });
+
+  test("run unit tests", async () => {
+    const compiledGraph = await compile("tests/integration/snowflake_project", "unit_tests");
+
+    // Run the tests.
+    const testResults = await dfapi.test(dbadapter, compiledGraph.tests);
+    expect(testResults).to.eql([
+      { name: "successful", successful: true },
+      {
+        name: "expected more rows than got",
+        successful: false,
+        messages: ["Expected 3 rows, but saw 2 rows."]
+      },
+      {
+        name: "expected fewer columns than got",
+        successful: false,
+        messages: ['Expected columns "COL1,COL2,COL3", but saw "COL1,COL2,COL3,COL4".']
+      },
+      {
+        name: "wrong columns",
+        successful: false,
+        messages: ['Expected columns "COL1,COL2,COL3,COL4", but saw "COL1,COL2,COL3,COL5".']
+      },
+      {
+        name: "wrong row contents",
+        successful: false,
+        messages: [
+          'For row 0 and column "COL2": expected "1", but saw "5".',
+          'For row 1 and column "COL3": expected "6.5", but saw "12".',
+          'For row 2 and column "COL1": expected "sup?", but saw "WRONG".'
+        ]
+      }
+    ]);
   });
 
   suite("result limit works", async () => {
@@ -199,20 +204,22 @@ suite("@dataform/integration/snowflake", ({ before, after }) => {
   suite("evaluate", async () => {
     test("evaluate from valid compiled graph as valid", async () => {
       // Create and run the project.
-      const compiledGraph = await dfapi.compile({
-        projectDir: "tests/integration/snowflake_project"
-      });
+      const compiledGraph = await compile("tests/integration/snowflake_project", "evaluate");
       const executionGraph = await dfapi.build(compiledGraph, {}, dbadapter);
       await dfapi.run(dbadapter, executionGraph).result();
 
-      const view = keyBy(compiledGraph.tables, t => t.name)["DF_INTEGRATION_TEST.EXAMPLE_VIEW"];
+      const view = keyBy(compiledGraph.tables, t => t.name)[
+        "DF_INTEGRATION_TEST_EVALUATE.EXAMPLE_VIEW"
+      ];
       let evaluations = await dbadapter.evaluate(dataform.Table.create(view));
       expect(evaluations.length).to.equal(1);
       expect(evaluations[0].status).to.equal(
         dataform.QueryEvaluation.QueryEvaluationStatus.SUCCESS
       );
 
-      const table = keyBy(compiledGraph.tables, t => t.name)["DF_INTEGRATION_TEST.EXAMPLE_TABLE"];
+      const table = keyBy(compiledGraph.tables, t => t.name)[
+        "DF_INTEGRATION_TEST_EVALUATE.EXAMPLE_TABLE"
+      ];
       evaluations = await dbadapter.evaluate(dataform.Table.create(table));
       expect(evaluations.length).to.equal(1);
       expect(evaluations[0].status).to.equal(
@@ -220,7 +227,7 @@ suite("@dataform/integration/snowflake", ({ before, after }) => {
       );
 
       const assertion = keyBy(compiledGraph.assertions, t => t.name)[
-        "DF_INTEGRATION_TEST_ASSERTIONS.EXAMPLE_ASSERTION_PASS"
+        "DF_INTEGRATION_TEST_ASSERTIONS_EVALUATE.EXAMPLE_ASSERTION_PASS"
       ];
       evaluations = await dbadapter.evaluate(dataform.Assertion.create(assertion));
       expect(evaluations.length).to.equal(1);
@@ -229,7 +236,7 @@ suite("@dataform/integration/snowflake", ({ before, after }) => {
       );
 
       const incremental = keyBy(compiledGraph.tables, t => t.name)[
-        "DF_INTEGRATION_TEST.EXAMPLE_INCREMENTAL"
+        "DF_INTEGRATION_TEST_EVALUATE.EXAMPLE_INCREMENTAL"
       ];
       evaluations = await dbadapter.evaluate(dataform.Table.create(incremental));
       expect(evaluations.length).to.equal(2);

--- a/tests/integration/snowflake_project/definitions/test.js
+++ b/tests/integration/snowflake_project/definitions/test.js
@@ -3,16 +3,16 @@ test("successful")
   .input(
     "sample_data",
     `
-        select 'hi' as col1, 1 as col2, 3.5 as col3, true as col4 union all
-        select 'ben' as col2, 2 as col2, 6.5 as col3, false as col4 union all
-        select 'sup?' as col3, 3 as col2, 9.5 as col3, true as col4
+        select 'hi' as col1, 1 as col2, 3.5 as col3, true as col4, date('2020-07-23') as col5 union all
+        select 'ben' as col2, 2 as col2, 6.5 as col3, false as col4, date('2020-07-24') as col5 union all
+        select 'sup?' as col3, 3 as col2, 9.5 as col3, true as col4, date('2020-07-25') as col5
     `
   )
   .expect(
     `
-        select 'hi' as col1, 1 as col2, 3.5 as col3, true as col4 union all
-        select 'ben' as col2, 2 as col2, 6.5 as col3, false as col4 union all
-        select 'sup?' as col3, 3 as col2, 9.5 as col3, true as col4
+        select 'hi' as col1, 1 as col2, 3.5 as col3, true as col4, date('2020-07-23') as col5 union all
+        select 'ben' as col2, 2 as col2, 6.5 as col3, false as col4, date('2020-07-24') as col5 union all
+        select 'sup?' as col3, 3 as col2, 9.5 as col3, true as col4, date('2020-07-25') as col5
     `
   );
 

--- a/tests/integration/sqldatawarehouse.spec.ts
+++ b/tests/integration/sqldatawarehouse.spec.ts
@@ -6,9 +6,9 @@ import * as adapters from "df/core/adapters";
 import { SQLDataWarehouseAdapter } from "df/core/adapters/sqldatawarehouse";
 import { dataform } from "df/protos/ts";
 import { suite, test } from "df/testing";
-import { dropAllTables, getTableRows, keyBy } from "df/tests/integration/utils";
+import { compile, dropAllTables, getTableRows, keyBy } from "df/tests/integration/utils";
 
-suite("@dataform/integration/sqldatawarehouse", ({ before, after }) => {
+suite("@dataform/integration/sqldatawarehouse", { parallel: true }, ({ before, after }) => {
   const credentials = dfapi.credentials.read(
     "sqldatawarehouse",
     "test_credentials/sqldatawarehouse.json"
@@ -21,17 +21,71 @@ suite("@dataform/integration/sqldatawarehouse", ({ before, after }) => {
   after("close adapter", () => dbadapter.close());
 
   test("run", { timeout: 60000 }, async () => {
-    const compiledGraph = await dfapi.compile({
-      projectDir: "tests/integration/sqldatawarehouse_project"
-    });
-
-    expect(compiledGraph.graphErrors.compilationErrors).to.eql([]);
+    const compiledGraph = await compile(
+      "tests/integration/sqldatawarehouse_project",
+      "project_e2e"
+    );
 
     const adapter = adapters.create(compiledGraph.projectConfig, compiledGraph.dataformCoreVersion);
 
     // Drop all the tables before we do anything.
     const tablesToDelete = (await dfapi.build(compiledGraph, {}, dbadapter)).warehouseState.tables;
     await dropAllTables(tablesToDelete, adapter, dbadapter);
+
+    // Run the project.
+    let executionGraph = await dfapi.build(compiledGraph, {}, dbadapter);
+    let executedGraph = await dfapi.run(dbadapter, executionGraph).result();
+
+    const actionMap = keyBy(executedGraph.actions, v => v.name);
+    expect(Object.keys(actionMap).length).eql(11);
+
+    // Check the status of action execution.
+    const expectedFailedActions = [
+      "df_integration_test_assertions_project_e2e.example_assertion_uniqueness_fail",
+      "df_integration_test_assertions_project_e2e.example_assertion_fail"
+    ];
+    for (const actionName of Object.keys(actionMap)) {
+      const expectedResult = expectedFailedActions.includes(actionName)
+        ? dataform.ActionResult.ExecutionStatus.FAILED
+        : dataform.ActionResult.ExecutionStatus.SUCCESSFUL;
+      expect(actionMap[actionName].status).equals(expectedResult);
+    }
+
+    expect(
+      actionMap["df_integration_test_assertions_project_e2e.example_assertion_uniqueness_fail"]
+        .tasks[2].errorMessage
+    ).to.eql("sqldatawarehouse error: Assertion failed: query returned 1 row(s).");
+
+    // Check the data in the incremental table.
+    let incrementalTable = keyBy(compiledGraph.tables, t => t.name)[
+      "df_integration_test_project_e2e.example_incremental"
+    ];
+    let incrementalRows = await getTableRows(incrementalTable.target, adapter, dbadapter);
+    expect(incrementalRows.length).equals(1);
+
+    // Re-run some of the actions.
+    executionGraph = await dfapi.build(
+      compiledGraph,
+      {
+        actions: ["example_incremental", "example_table", "example_view"]
+      },
+      dbadapter
+    );
+
+    executedGraph = await dfapi.run(dbadapter, executionGraph).result();
+    expect(executedGraph.status).equals(dataform.RunResult.ExecutionStatus.SUCCESSFUL);
+
+    // Check there is an extra row in the incremental table.
+    incrementalTable = keyBy(compiledGraph.tables, t => t.name)[
+      "df_integration_test_project_e2e.example_incremental"
+    ];
+    incrementalRows = await getTableRows(incrementalTable.target, adapter, dbadapter);
+
+    expect(incrementalRows.length).equals(2);
+  });
+
+  test("run unit tests", async () => {
+    const compiledGraph = await compile("tests/integration/sqldatawarehouse_project", "unit_tests");
 
     // Run the tests.
     const testResults = await dfapi.test(dbadapter, compiledGraph.tests);
@@ -56,64 +110,12 @@ suite("@dataform/integration/sqldatawarehouse", ({ before, after }) => {
         name: "wrong row contents",
         successful: false,
         messages: [
-          'For row 0 and column "col2": expected "1" (number), but saw "5" (number).',
-          'For row 1 and column "col3": expected "6.5" (number), but saw "12" (number).',
-          'For row 2 and column "col1": expected "sup?" (string), but saw "WRONG" (string).'
+          'For row 0 and column "col2": expected "1", but saw "5".',
+          'For row 1 and column "col3": expected "6.5", but saw "12".',
+          'For row 2 and column "col1": expected "sup?", but saw "WRONG".'
         ]
       }
     ]);
-
-    // Run the project.
-    let executionGraph = await dfapi.build(compiledGraph, {}, dbadapter);
-    let executedGraph = await dfapi.run(dbadapter, executionGraph).result();
-
-    const executionActionMap = keyBy(executionGraph.actions, v => v.name);
-    const actionMap = keyBy(executedGraph.actions, v => v.name);
-    expect(Object.keys(actionMap).length).eql(11);
-
-    // Check the status of action execution.
-    const expectedFailedActions = [
-      "df_integration_test_assertions.example_assertion_uniqueness_fail",
-      "df_integration_test_assertions.example_assertion_fail"
-    ];
-    for (const actionName of Object.keys(actionMap)) {
-      const expectedResult = expectedFailedActions.includes(actionName)
-        ? dataform.ActionResult.ExecutionStatus.FAILED
-        : dataform.ActionResult.ExecutionStatus.SUCCESSFUL;
-      expect(actionMap[actionName].status).equals(expectedResult);
-    }
-
-    expect(
-      actionMap["df_integration_test_assertions.example_assertion_uniqueness_fail"].tasks[2]
-        .errorMessage
-    ).to.eql("sqldatawarehouse error: Assertion failed: query returned 1 row(s).");
-
-    // Check the data in the incremental table.
-    let incrementalTable = keyBy(compiledGraph.tables, t => t.name)[
-      "df_integration_test.example_incremental"
-    ];
-    let incrementalRows = await getTableRows(incrementalTable.target, adapter, dbadapter);
-    expect(incrementalRows.length).equals(1);
-
-    // Re-run some of the actions.
-    executionGraph = await dfapi.build(
-      compiledGraph,
-      {
-        actions: ["example_incremental", "example_table", "example_view"]
-      },
-      dbadapter
-    );
-
-    executedGraph = await dfapi.run(dbadapter, executionGraph).result();
-    expect(executedGraph.status).equals(dataform.RunResult.ExecutionStatus.SUCCESSFUL);
-
-    // Check there is an extra row in the incremental table.
-    incrementalTable = keyBy(compiledGraph.tables, t => t.name)[
-      "df_integration_test.example_incremental"
-    ];
-    incrementalRows = await getTableRows(incrementalTable.target, adapter, dbadapter);
-
-    expect(incrementalRows.length).equals(2);
   });
 
   suite("result limit works", async () => {
@@ -142,20 +144,22 @@ suite("@dataform/integration/sqldatawarehouse", ({ before, after }) => {
   suite("evaluate", async () => {
     test("evaluate from valid compiled graph as valid", async () => {
       // Create and run the project.
-      const compiledGraph = await dfapi.compile({
-        projectDir: "tests/integration/sqldatawarehouse_project"
-      });
+      const compiledGraph = await compile("tests/integration/sqldatawarehouse_project", "evaluate");
       const executionGraph = await dfapi.build(compiledGraph, {}, dbadapter);
       await dfapi.run(dbadapter, executionGraph).result();
 
-      const view = keyBy(compiledGraph.tables, t => t.name)["df_integration_test.example_view"];
+      const view = keyBy(compiledGraph.tables, t => t.name)[
+        "df_integration_test_evaluate.example_view"
+      ];
       let evaluations = await dbadapter.evaluate(dataform.Table.create(view));
       expect(evaluations.length).to.equal(1);
       expect(evaluations[0].status).to.equal(
         dataform.QueryEvaluation.QueryEvaluationStatus.SUCCESS
       );
 
-      const table = keyBy(compiledGraph.tables, t => t.name)["df_integration_test.example_table"];
+      const table = keyBy(compiledGraph.tables, t => t.name)[
+        "df_integration_test_evaluate.example_table"
+      ];
       evaluations = await dbadapter.evaluate(dataform.Table.create(table));
       expect(evaluations.length).to.equal(1);
       expect(evaluations[0].status).to.equal(
@@ -163,7 +167,7 @@ suite("@dataform/integration/sqldatawarehouse", ({ before, after }) => {
       );
 
       const assertion = keyBy(compiledGraph.assertions, t => t.name)[
-        "df_integration_test_assertions.example_assertion_pass"
+        "df_integration_test_assertions_evaluate.example_assertion_pass"
       ];
       evaluations = await dbadapter.evaluate(dataform.Assertion.create(assertion));
       expect(evaluations.length).to.equal(1);
@@ -172,7 +176,7 @@ suite("@dataform/integration/sqldatawarehouse", ({ before, after }) => {
       );
 
       const incremental = keyBy(compiledGraph.tables, t => t.name)[
-        "df_integration_test.example_incremental"
+        "df_integration_test_evaluate.example_incremental"
       ];
       evaluations = await dbadapter.evaluate(dataform.Table.create(incremental));
       expect(evaluations.length).to.equal(2);

--- a/tests/integration/sqldatawarehouse_project/definitions/test.js
+++ b/tests/integration/sqldatawarehouse_project/definitions/test.js
@@ -3,16 +3,16 @@ test("successful")
   .input(
     "sample_data",
     `
-        select 'hi' as col1, 1 as col2, 3.5 as col3, cast(1 as bit) as col4 union all
-        select 'ben' as col2, 2 as col2, 6.5 as col3, cast(0 as bit) as col4 union all
-        select 'sup?' as col3, 3 as col2, 9.5 as col3, cast(1 as bit) as col4
+        select 'hi' as col1, 1 as col2, 3.5 as col3, cast(1 as bit) as col4, cast('2020-07-23' as date) as col5 union all
+        select 'ben' as col2, 2 as col2, 6.5 as col3, cast(0 as bit) as col4, cast('2020-07-24' as date) as col5 union all
+        select 'sup?' as col3, 3 as col2, 9.5 as col3, cast(1 as bit) as col4, cast('2020-07-25' as date) as col5
     `
   )
   .expect(
     `
-        select 'hi' as col1, 1 as col2, 3.5 as col3, cast(1 as bit) as col4 union all
-        select 'ben' as col2, 2 as col2, 6.5 as col3, cast(0 as bit) as col4 union all
-        select 'sup?' as col3, 3 as col2, 9.5 as col3, cast(1 as bit) as col4
+        select 'hi' as col1, 1 as col2, 3.5 as col3, cast(1 as bit) as col4, cast('2020-07-23' as date) as col5 union all
+        select 'ben' as col2, 2 as col2, 6.5 as col3, cast(0 as bit) as col4, cast('2020-07-24' as date) as col5 union all
+        select 'sup?' as col3, 3 as col2, 9.5 as col3, cast(1 as bit) as col4, cast('2020-07-25' as date) as col5
     `
   );
 

--- a/tests/integration/utils.ts
+++ b/tests/integration/utils.ts
@@ -1,3 +1,6 @@
+import { expect } from "chai";
+
+import * as dfapi from "df/api";
 import * as dbadapters from "df/api/dbadapters";
 import * as adapters from "df/core/adapters";
 import { dataform } from "df/protos/ts";
@@ -25,4 +28,23 @@ export async function getTableRows(
   dbadapter: dbadapters.IDbAdapter
 ) {
   return (await dbadapter.execute(`SELECT * FROM ${adapter.resolveTarget(target)}`)).rows;
+}
+
+export async function compile(
+  projectDir: string,
+  schemaSuffixOverride: string,
+  projectConfigOverrides?: dataform.IProjectConfig
+) {
+  const compiledGraph = await dfapi.compile({
+    projectDir,
+    schemaSuffixOverride
+  });
+
+  expect(compiledGraph.graphErrors.compilationErrors).to.eql([]);
+
+  compiledGraph.projectConfig = {
+    ...compiledGraph.projectConfig,
+    ...projectConfigOverrides
+  };
+  return compiledGraph;
 }

--- a/version.bzl
+++ b/version.bzl
@@ -1,3 +1,3 @@
 # NOTE: If you change the format of this line, you must change the bash command
 # in /scripts/publish to extract the version string correctly.
-DF_VERSION = "1.8.3"
+DF_VERSION = "1.8.4"


### PR DESCRIPTION
fixes https://github.com/dataform-co/dataform/issues/908

- pull out unit test tests from overall integration tests, and parallelise all integration tests, which uncovered:
- fix a bug to do with determining what schemas should be created
- fix a bug which prevented schema suffixes working correctly for snowflake