### PR TITLE
Redshift fixes

### DIFF
--- a/api/BUILD
+++ b/api/BUILD
@@ -12,7 +12,6 @@ ts_library(
         "//api/utils",
         "//common/errors",
         "//common/strings",
-        "//common/promises",
         "//core",
         "//protos:ts",
         "//sqlx",

--- a/api/dbadapters/redshift.ts
+++ b/api/dbadapters/redshift.ts
@@ -6,9 +6,9 @@ import { IDbAdapter, OnCancel } from "df/api/dbadapters/index";
 import { SSHTunnelProxy } from "df/api/ssh_tunnel_proxy";
 import { parseRedshiftEvalError } from "df/api/utils/error_parsing";
 import { ErrorWithCause } from "df/common/errors/errors";
-import { runAsyncIgnoringErrors, sleep } from "df/common/promises";
 import { collectEvaluationQueries, QueryOrAction } from "df/core/adapters";
 import { dataform } from "df/protos/ts";
+
 
 interface ICursor {
   read: (
@@ -309,7 +309,7 @@ class PgPoolExecutor {
         client.release(e);
         reject(e);
       });
-      query.on("end", async () => {
+      query.on("end", () => {
         client.release();
         resolve(results);
       });

--- a/tests/integration/redshift.spec.ts
+++ b/tests/integration/redshift.spec.ts
@@ -8,7 +8,7 @@ import { dataform } from "df/protos/ts";
 import { suite, test } from "df/testing";
 import { compile, getTableRows, keyBy } from "df/tests/integration/utils";
 
-suite("@dataform/integration/redshift", { parallel: true }, ({ before, after }) => {
+suite("@dataform/integration/redshift", { parallel: false }, ({ before, after }) => {
   const credentials = dfapi.credentials.read("redshift", "test_credentials/redshift.json");
   let dbadapter: dbadapters.IDbAdapter;
 
@@ -185,9 +185,11 @@ suite("@dataform/integration/redshift", { parallel: true }, ({ before, after }) 
     }
   });
 
-  suite("evaluate", async () => {
+  suite("evaluate", () => {
     test("evaluate from valid compiled graph as valid", async () => {
       const compiledGraph = await compile("tests/integration/redshift_project", "evaluate");
+      const executionGraph = await dfapi.build(compiledGraph, {}, dbadapter);
+      await dfapi.run(dbadapter, executionGraph).result();
 
       const view = keyBy(compiledGraph.tables, t => t.name)[
         "df_integration_test_evaluate.example_view"


### PR DESCRIPTION
- Disable parallelism on the redshift test. It appears that running two things at the same time with the same adapter is causing flakiness, haven't worked out why yet. Bug: #918
- Change "close" handler to "end" handler - as this is what's in the docs and seems to be partly the cause of #914
- Change the error handler to dispose of the connection, so that it can't be re-used. It seems like errored connections do weird things that also cause some of the issues in #914, and as it shouldn't be that common a situation, shouldn't cause too many connections to be created
- Add some better error messages to integration tests

Fixes #914 