### PR TITLE
Flex grow sizing fix

### DIFF
--- a/components/flex.scss
+++ b/components/flex.scss
@@ -4,10 +4,16 @@
 
 .flex.row {
   flex-direction: row;
+  .item.fill {
+    min-width: 0px;
+  }
 }
 
 .flex.column {
   flex-direction: column;
+  .item.fill {
+    min-height: 0px;
+  }
 }
 
 .flex .item.fill {


### PR DESCRIPTION
Setting a min-height resolves some issues with flex grow and avoids height 100% which causes a bunch of other issues (it doesn't work properly).