### PR TITLE
Make prune keep assertions which are direct dependents of actions

### DIFF
--- a/api/commands/prune.ts
+++ b/api/commands/prune.ts
@@ -82,6 +82,8 @@ function computeIncludedActionNames(
       const matchingDependencyNames = !!assertion.dependencies?.length
         ? utils.matchPatterns(assertion.dependencies, allActionNames)
         : [];
+      console.log("assertion.name", assertion.name);
+      console.log("matchingDependencyNames", matchingDependencyNames);
       if (!!matchingDependencyNames?.length) {
         includedActionNames.add(assertion.name);
       }

--- a/api/commands/prune.ts
+++ b/api/commands/prune.ts
@@ -82,8 +82,6 @@ function computeIncludedActionNames(
       const matchingDependencyNames = !!assertion.dependencies?.length
         ? utils.matchPatterns(assertion.dependencies, allActionNames)
         : [];
-      console.log("assertion.name", assertion.name);
-      console.log("matchingDependencyNames", matchingDependencyNames);
       if (!!matchingDependencyNames?.length) {
         includedActionNames.add(assertion.name);
       }

--- a/api/commands/prune.ts
+++ b/api/commands/prune.ts
@@ -75,6 +75,17 @@ function computeIncludedActionNames(
         }
       });
     }
+
+    // Add assertions which are direct dependents of actions.
+    const assertions = compiledGraph.assertions;
+    assertions.forEach(assertion => {
+      const matchingDependencyNames = !!assertion.dependencies?.length
+        ? utils.matchPatterns(assertion.dependencies, allActionNames)
+        : [];
+      if (!!matchingDependencyNames?.length) {
+        includedActionNames.add(assertion.name);
+      }
+    });
   }
 
   return includedActionNames;

--- a/tests/api/api.spec.ts
+++ b/tests/api/api.spec.ts
@@ -47,6 +47,16 @@ suite("@dataform/api", () => {
         },
         query: "query"
       }
+    ],
+    assertions: [
+      {
+        name: "schema.d",
+        target: {
+          schema: "schema",
+          name: "d"
+        },
+        dependencies: ["schema.a"]
+      }
     ]
   });
 
@@ -325,20 +335,24 @@ suite("@dataform/api", () => {
       const prunedGraph = prune(TEST_GRAPH, { actions: ["schema.a"], includeDependencies: true });
       const actionNames = [
         ...prunedGraph.tables.map(action => action.name),
-        ...prunedGraph.operations.map(action => action.name)
+        ...prunedGraph.operations.map(action => action.name),
+        ...prunedGraph.assertions.map(action => action.name)
       ];
       expect(actionNames).includes("schema.a");
       expect(actionNames).includes("schema.b");
+      expect(actionNames).includes("schema.d");
     });
 
     test("prune actions with --actions without dependencies", () => {
       const prunedGraph = prune(TEST_GRAPH, { actions: ["schema.a"], includeDependencies: false });
       const actionNames = [
         ...prunedGraph.tables.map(action => action.name),
-        ...prunedGraph.operations.map(action => action.name)
+        ...prunedGraph.operations.map(action => action.name),
+        ...prunedGraph.assertions.map(action => action.name)
       ];
       expect(actionNames).includes("schema.a");
       expect(actionNames).not.includes("schema.b");
+      expect(actionNames).not.includes("schema.d");
     });
   });
 

--- a/tests/integration/bigquery.spec.ts
+++ b/tests/integration/bigquery.spec.ts
@@ -248,16 +248,14 @@ suite("@dataform/integration/bigquery", { parallel: true }, ({ before, after }) 
       for (const runIteration of [
         {
           runConfig: {
-            actions: ["example_incremental", "example_incremental_merge"],
-            includeDependencies: false
+            actions: ["example_incremental", "example_incremental_merge"]
           },
           expectedIncrementalRows: 3,
           expectedIncrementalMergeRows: 2
         },
         {
           runConfig: {
-            actions: ["example_incremental", "example_incremental_merge"],
-            includeDependencies: false
+            actions: ["example_incremental", "example_incremental_merge"]
           },
           expectedIncrementalRows: 5,
           expectedIncrementalMergeRows: 2
@@ -309,8 +307,15 @@ suite("@dataform/integration/bigquery", { parallel: true }, ({ before, after }) 
         dbadapter
       );
       const runResult = await dfapi.run(dbadapter, executionGraph).result();
-      expect(dataform.RunResult.ExecutionStatus[runResult.status]).eql(
-        dataform.RunResult.ExecutionStatus[dataform.RunResult.ExecutionStatus.SUCCESSFUL]
+      const actionMap = keyBy(runResult.actions, v => v.name);
+      [
+        "dataform-integration-tests.df_integration_test_dataset_metadata.example_incremental",
+        "dataform-integration-tests.df_integration_test_dataset_metadata.example_view",
+        "dataform-integration-tests.df_integration_test_dataset_metadata.sample_data"
+      ].forEach(actionName =>
+        expect(actionMap[actionName].status).to.equals(
+          dataform.ActionResult.ExecutionStatus.SUCCESSFUL
+        )
       );
 
       // Check expected metadata.

--- a/version.bzl
+++ b/version.bzl
@@ -1,3 +1,3 @@
 # NOTE: If you change the format of this line, you must change the bash command
 # in /scripts/publish to extract the version string correctly.
-DF_VERSION = "1.8.5"
+DF_VERSION = "1.8.6"

--- a/version.bzl
+++ b/version.bzl
@@ -1,3 +1,3 @@
 # NOTE: If you change the format of this line, you must change the bash command
 # in /scripts/publish to extract the version string correctly.
-DF_VERSION = "1.8.6"
+DF_VERSION = "1.9.0"


### PR DESCRIPTION
Fixes https://github.com/dataform-co/dataform/issues/940

Implements [this](https://dataform.canny.io/feature-requests/p/include-assertions-by-default-when-publish-tableviewincremental-is-triggered) canny request




