### PR TITLE
Quick patch for redshift cancellation

### DIFF
--- a/api/dbadapters/redshift.ts
+++ b/api/dbadapters/redshift.ts
@@ -305,7 +305,7 @@ class PgPoolExecutor {
         rowLimit: options?.rowLimit,
         byteLimit: options?.byteLimit
       });
-      options?.onCancel?.(() => query.destroy());
+      options?.onCancel?.(() => query.destroy(new Error("Query cancelled.")));
       query.on("data", (row: any) => {
         try {
           verifyUniqueColumnNames((query as any).cursor._result.fields);


### PR DESCRIPTION
In previous experiments, calling query.destroy without an error didn't always cause error or end to emit. This should fix that.