### PR TITLE
Disable transactions for redshift incremental tables

### DIFF
--- a/tests/integration/redshift.spec.ts
+++ b/tests/integration/redshift.spec.ts
@@ -8,7 +8,7 @@ import { dataform } from "df/protos/ts";
 import { suite, test } from "df/testing";
 import { compile, getTableRows, keyBy } from "df/tests/integration/utils";
 
-suite("@dataform/integration/redshift", { parallel: false }, ({ before, after }) => {
+suite("@dataform/integration/redshift", { parallel: true }, ({ before, after }) => {
   const credentials = dfapi.credentials.read("redshift", "test_credentials/redshift.json");
   let dbadapter: dbadapters.IDbAdapter;
 


### PR DESCRIPTION
The connection for each task is pulled fresh from the query pool, thus there is no guarantee that these statements will execute in the same connection. This appears to cause a number of issues in certain situations, as we start transactions and don't necessarily end them.

- Remove the transactions as they didn't work as intended and are causing issues.
- Make the redshift tests parallel again as this was one of the issues causing flakiness.
- Fix another issue with incremental tables that have the same name but are published in different schemas at the same time.

We should aim to reintroduce these transactions correctly, but this will require more work to make sure that subsequent tasks in an action run in the same pool connection, or possibly proper framework support for the concept of a transaction. Relevant PG docs - https://node-postgres.com/features/transactions