### PR TITLE
Make prune use targets rather than name

### DIFF
--- a/core/utils.ts
+++ b/core/utils.ts
@@ -28,7 +28,7 @@ export function baseFilename(fullPath: string) {
 export function matchPatterns(patterns: string[], targets: dataform.ITarget[]): dataform.ITarget[] {
   const namesTargetsMap = new Map<string, dataform.ITarget>();
   targets.forEach(t => namesTargetsMap.set(targetToName(t), t));
-  const targetNames = Object.keys(namesTargetsMap);
+  const targetNames = Array.from(namesTargetsMap.keys());
 
   const fullyQualifiedActions: dataform.ITarget[] = [];
   patterns.forEach(pattern => {
@@ -185,7 +185,10 @@ export function setNameAndTarget(
 }
 
 export function targetToName(actionTarget: dataform.ITarget) {
-  const nameParts = [actionTarget.name, actionTarget.schema];
+  const nameParts = [actionTarget.name];
+  if (!!actionTarget.schema) {
+    nameParts.push(actionTarget.schema);
+  }
   if (!!actionTarget.database) {
     nameParts.push(actionTarget.database);
   }

--- a/tests/api/api.spec.ts
+++ b/tests/api/api.spec.ts
@@ -264,11 +264,11 @@ suite("@dataform/api", () => {
       ],
       tables: [
         {
-          name: "tab_a",
+          name: "schema.tab_a",
           dependencies: ["op_d"],
           target: {
             schema: "schema",
-            name: "a"
+            name: "tab_a"
           },
           tags: ["tag1", "tag2"]
         }
@@ -279,14 +279,24 @@ suite("@dataform/api", () => {
       const graph: dataform.ICompiledGraph = dataform.CompiledGraph.create({
         projectConfig: { warehouse: "bigquery" },
         tables: [
-          { name: "a", target: { schema: "schema", name: "a" }, type: "table", dependencies: [] },
           {
-            name: "b",
+            name: "schema.a",
+            target: { schema: "schema", name: "a" },
+            type: "table",
+            dependencies: []
+          },
+          {
+            name: "schema.b",
             target: { schema: "schema", name: "b" },
             type: "inline",
-            dependencies: ["a"]
+            dependencies: ["schema.a"]
           },
-          { name: "c", target: { schema: "schema", name: "c" }, type: "table", dependencies: ["a"] }
+          {
+            name: "schema.c",
+            target: { schema: "schema", name: "c" },
+            type: "table",
+            dependencies: ["schema.a"]
+          }
         ]
       });
 
@@ -296,9 +306,9 @@ suite("@dataform/api", () => {
 
       const actionNames = prunedGraph.tables.map(action => action.name);
 
-      expect(actionNames).includes("a");
-      expect(actionNames).not.includes("b");
-      expect(actionNames).includes("c");
+      expect(actionNames).includes("schema.a");
+      expect(actionNames).not.includes("schema.b");
+      expect(actionNames).includes("schema.c");
     });
 
     test("prune actions with --tags (with dependencies)", () => {
@@ -315,7 +325,7 @@ suite("@dataform/api", () => {
       expect(actionNames).includes("op_b");
       expect(actionNames).not.includes("op_c");
       expect(actionNames).includes("op_d");
-      expect(actionNames).includes("tab_a");
+      expect(actionNames).includes("schema.tab_a");
     });
 
     test("prune actions with --tags but without --actions (without dependencies)", () => {
@@ -331,7 +341,7 @@ suite("@dataform/api", () => {
       expect(actionNames).includes("op_b");
       expect(actionNames).not.includes("op_c");
       expect(actionNames).not.includes("op_d");
-      expect(actionNames).includes("tab_a");
+      expect(actionNames).includes("schema.tab_a");
     });
 
     test("prune actions with --actions with dependencies", () => {


### PR DESCRIPTION
Name is still used in the wrapper function, and required for the tests

I made some progress removing the deprecated name instances but it's a pretty massive job; have that PR on the backburner.