### PR TITLE
Add react router link to breadcrumb option

### DIFF
--- a/components/breadcrumb.tsx
+++ b/components/breadcrumb.tsx
@@ -14,13 +14,9 @@ export function BreadCrumb({ pathParts }: IBreadCrumbProps) {
       {pathParts.slice(0, -1).map((pathPart, index) => (
         <React.Fragment key={index}>
           <H6>
-            {!!pathPart.to ? (
-              <Link onClick={pathPart.onClick} to={pathPart.to}>
-                {pathPart.label}
-              </Link>
-            ) : (
-              <a onClick={pathPart.onClick}>{pathPart.label}</a>
-            )}
+            <Link onClick={pathPart.onClick} to={pathPart.to}>
+              {pathPart.label}
+            </Link>
           </H6>
           {"  >  "}
         </React.Fragment>

--- a/components/breadcrumb.tsx
+++ b/components/breadcrumb.tsx
@@ -1,10 +1,11 @@
 import { H6 } from "@blueprintjs/core";
 import * as React from "react";
+import { Link } from "react-router";
 
 import * as styles from "df/components/breadcrumb.css";
 
 export interface IBreadCrumbProps {
-  pathParts: Array<{ label: string; onClick: () => void }>;
+  pathParts: Array<{ label: string; onClick?: () => void; to?: string }>;
 }
 
 export function BreadCrumb({ pathParts }: IBreadCrumbProps) {
@@ -13,7 +14,13 @@ export function BreadCrumb({ pathParts }: IBreadCrumbProps) {
       {pathParts.slice(0, -1).map((pathPart, index) => (
         <React.Fragment key={index}>
           <H6>
-            <a onClick={pathPart.onClick}>{pathPart.label}</a>
+            {!!pathPart.to ? (
+              <Link onClick={pathPart.onClick} to={pathPart.to}>
+                {pathPart.label}
+              </Link>
+            ) : (
+              <a onClick={pathPart.onClick}>{pathPart.label}</a>
+            )}
           </H6>
           {"  >  "}
         </React.Fragment>


### PR DESCRIPTION
Intentionally haven't added `href` option because breadcrumbs should never point somewhere external