### PR TITLE
Make number of columns in masonry view customizeable

### DIFF
--- a/components/card.scss
+++ b/components/card.scss
@@ -107,7 +107,6 @@
 }
 
 .cardMasonry {
-  columns: 2 200px;
   column-gap: 20px;
   margin: 10px 20px 10px;
 }

--- a/components/card.tsx
+++ b/components/card.tsx
@@ -122,19 +122,25 @@ export const CardList = ({
 
 export interface ICardMasonryProps {
   columns?: number;
+  minCardWidth?: number;
 }
 
 export const CardMasonry = ({
   children,
   className,
   columns,
+  minCardWidth,
   ...rest
 }: ICardMasonryProps & React.PropsWithChildren<{}> & React.HTMLAttributes<HTMLDivElement>) => {
+  const numOfColumns = columns || 2;
   return (
     <div
       className={[styles.cardMasonry, className].join(" ")}
       {...rest}
-      style={{ columns: `${String(columns || 2)} 200px`, ...rest.style }}
+      style={{
+        columns: `${numOfColumns} ${numOfColumns * (minCardWidth || 100)}px`,
+        ...rest.style
+      }}
     >
       {children}
     </div>

--- a/components/card.tsx
+++ b/components/card.tsx
@@ -120,13 +120,22 @@ export const CardList = ({
   );
 };
 
+export interface ICardMasonryProps {
+  columns?: number;
+}
+
 export const CardMasonry = ({
   children,
   className,
+  columns,
   ...rest
-}: ICardGridProps & React.PropsWithChildren<{}> & React.HTMLAttributes<HTMLDivElement>) => {
+}: ICardMasonryProps & React.PropsWithChildren<{}> & React.HTMLAttributes<HTMLDivElement>) => {
   return (
-    <div className={[styles.cardMasonry, className].join(" ")} {...rest}>
+    <div
+      className={[styles.cardMasonry, className].join(" ")}
+      {...rest}
+      style={{ columns: `${String(columns || 2)} 200px`, ...rest.style }}
+    >
       {children}
     </div>
   );


### PR DESCRIPTION
Continues to downsize number of columns if the screen size is too small