### PR TITLE
remove `where()`

### DIFF
--- a/content/docs/guides/javascript/js-api.md
+++ b/content/docs/guides/javascript/js-api.md
@@ -112,7 +112,6 @@ publish("example").query(ctx => `SELECT * FROM ${ctx.ref("other_table")}`);
 The following methods and configuration options accept a function taking a `Contextable` argument as in the above example:
 
 - `query()`
-- `where()`
 - `preOps()`
 - `postOps()`
 


### PR DESCRIPTION
Should we do this (to avoid directing people at old stuff), or keep it in for completeness?