### PR TITLE
Run all tasks in ExecutionActions using a single DB client (where applicable).

### DIFF
--- a/api/dbadapters/bigquery.ts
+++ b/api/dbadapters/bigquery.ts
@@ -3,7 +3,7 @@ import { PromisePoolExecutor } from "promise-pool-executor";
 
 import { BigQuery, TableField, TableMetadata } from "@google-cloud/bigquery";
 import { Credentials } from "df/api/commands/credentials";
-import { IDbAdapter, IExecutionResult, OnCancel } from "df/api/dbadapters/index";
+import { IDbAdapter, IDbClient, IExecutionResult, OnCancel } from "df/api/dbadapters/index";
 import { parseBigqueryEvalError } from "df/api/utils/error_parsing";
 import { LimitedResultSet } from "df/api/utils/results";
 import {
@@ -74,6 +74,10 @@ export class BigQueryDbAdapter implements IDbAdapter {
               )
       })
       .promise();
+  }
+
+  public async withClientLock<T>(callback: (client: IDbClient) => Promise<T>) {
+    return await callback(this);
   }
 
   public async evaluate(queryOrAction: QueryOrAction, projectConfig?: dataform.ProjectConfig) {

--- a/api/dbadapters/index.ts
+++ b/api/dbadapters/index.ts
@@ -33,15 +33,6 @@ export interface IDbClient {
 }
 
 export interface IDbAdapter extends IDbClient {
-  execute(
-    statement: string,
-    options?: {
-      onCancel?: OnCancel;
-      interactive?: boolean;
-      rowLimit?: number;
-      byteLimit?: number;
-    }
-  ): Promise<IExecutionResult>;
   withClientLock<T>(callback: (client: IDbClient) => Promise<T>): Promise<T>;
 
   evaluate(

--- a/api/dbadapters/index.ts
+++ b/api/dbadapters/index.ts
@@ -20,7 +20,7 @@ export interface IExecutionResult {
   metadata: dataform.IExecutionMetadata;
 }
 
-export interface IDbAdapter {
+export interface IDbClient {
   execute(
     statement: string,
     options?: {
@@ -30,17 +30,31 @@ export interface IDbAdapter {
       byteLimit?: number;
     }
   ): Promise<IExecutionResult>;
+}
+
+export interface IDbAdapter extends IDbClient {
+  execute(
+    statement: string,
+    options?: {
+      onCancel?: OnCancel;
+      interactive?: boolean;
+      rowLimit?: number;
+      byteLimit?: number;
+    }
+  ): Promise<IExecutionResult>;
+  withClientLock<T>(callback: (client: IDbClient) => Promise<T>): Promise<T>;
+
   evaluate(
     queryOrAction: QueryOrAction,
     projectConfig?: dataform.IProjectConfig
   ): Promise<dataform.IQueryEvaluation[]>;
-  preview(target: dataform.ITarget, limitRows?: number): Promise<any[]>;
 
   schemas(database: string): Promise<string[]>;
   createSchema(database: string, schema: string): Promise<void>;
 
   tables(): Promise<dataform.ITarget[]>;
   table(target: dataform.ITarget): Promise<dataform.ITableMetadata>;
+  preview(target: dataform.ITarget, limitRows?: number): Promise<any[]>;
 
   setMetadata(action: dataform.IExecutionAction): Promise<void>;
 

--- a/api/dbadapters/postgres.ts
+++ b/api/dbadapters/postgres.ts
@@ -67,28 +67,27 @@ export class PostgresDbAdapter implements IDbAdapter {
   }
 
   public async withClientLock<T>(callback: (client: IDbClient) => Promise<T>) {
-    return await this.queryExecutor.withClientLock(
-      async client =>
-        await callback({
-          execute: async (
-            statement: string,
-            options: {
-              rowLimit?: number;
-              byteLimit?: number;
-              includeQueryInError?: boolean;
-            } = { rowLimit: 1000, byteLimit: 1024 * 1024 }
-          ) => {
-            try {
-              const rows = await client.execute(statement, options);
-              return { rows, metadata: {} };
-            } catch (e) {
-              if (options.includeQueryInError) {
-                throw new Error(`Error encountered while running "${statement}": ${e.message}`);
-              }
-              throw new ErrorWithCause(`Error executing postgres query: ${e.message}`, e);
+    return await this.queryExecutor.withClientLock(client =>
+      callback({
+        execute: async (
+          statement: string,
+          options: {
+            rowLimit?: number;
+            byteLimit?: number;
+            includeQueryInError?: boolean;
+          } = { rowLimit: 1000, byteLimit: 1024 * 1024 }
+        ) => {
+          try {
+            const rows = await client.execute(statement, options);
+            return { rows, metadata: {} };
+          } catch (e) {
+            if (options.includeQueryInError) {
+              throw new Error(`Error encountered while running "${statement}": ${e.message}`);
             }
+            throw new ErrorWithCause(`Error executing postgres query: ${e.message}`, e);
           }
-        })
+        }
+      })
     );
   }
 

--- a/api/dbadapters/redshift.ts
+++ b/api/dbadapters/redshift.ts
@@ -1,7 +1,7 @@
 import * as pg from "pg";
 
 import { Credentials } from "df/api/commands/credentials";
-import { IDbAdapter } from "df/api/dbadapters/index";
+import { IDbAdapter, IDbClient } from "df/api/dbadapters/index";
 import { SSHTunnelProxy } from "df/api/ssh_tunnel_proxy";
 import { parseRedshiftEvalError } from "df/api/utils/error_parsing";
 import { convertFieldType, PgPoolExecutor } from "df/api/utils/postgres";
@@ -63,15 +63,33 @@ export class RedshiftDbAdapter implements IDbAdapter {
       includeQueryInError?: boolean;
     } = { rowLimit: 1000, byteLimit: 1024 * 1024 }
   ) {
-    try {
-      const rows = await this.queryExecutor.execute(statement, options);
-      return { rows, metadata: {} };
-    } catch (e) {
-      if (options.includeQueryInError) {
-        throw new Error(`Error encountered while running "${statement}": ${e.message}`);
-      }
-      throw new ErrorWithCause(`Error executing redshift query: ${e.message}`, e);
-    }
+    return await this.withClientLock(executor => executor.execute(statement, options));
+  }
+
+  public async withClientLock<T>(callback: (client: IDbClient) => Promise<T>) {
+    return await this.queryExecutor.withClientLock(
+      async client =>
+        await callback({
+          execute: async (
+            statement: string,
+            options: {
+              rowLimit?: number;
+              byteLimit?: number;
+              includeQueryInError?: boolean;
+            } = { rowLimit: 1000, byteLimit: 1024 * 1024 }
+          ) => {
+            try {
+              const rows = await client.execute(statement, options);
+              return { rows, metadata: {} };
+            } catch (e) {
+              if (options.includeQueryInError) {
+                throw new Error(`Error encountered while running "${statement}": ${e.message}`);
+              }
+              throw new ErrorWithCause(`Error executing redshift query: ${e.message}`, e);
+            }
+          }
+        })
+    );
   }
 
   public async evaluate(queryOrAction: QueryOrAction, projectConfig?: dataform.ProjectConfig) {

--- a/api/dbadapters/redshift.ts
+++ b/api/dbadapters/redshift.ts
@@ -67,28 +67,27 @@ export class RedshiftDbAdapter implements IDbAdapter {
   }
 
   public async withClientLock<T>(callback: (client: IDbClient) => Promise<T>) {
-    return await this.queryExecutor.withClientLock(
-      async client =>
-        await callback({
-          execute: async (
-            statement: string,
-            options: {
-              rowLimit?: number;
-              byteLimit?: number;
-              includeQueryInError?: boolean;
-            } = { rowLimit: 1000, byteLimit: 1024 * 1024 }
-          ) => {
-            try {
-              const rows = await client.execute(statement, options);
-              return { rows, metadata: {} };
-            } catch (e) {
-              if (options.includeQueryInError) {
-                throw new Error(`Error encountered while running "${statement}": ${e.message}`);
-              }
-              throw new ErrorWithCause(`Error executing redshift query: ${e.message}`, e);
+    return await this.queryExecutor.withClientLock(client =>
+      callback({
+        execute: async (
+          statement: string,
+          options: {
+            rowLimit?: number;
+            byteLimit?: number;
+            includeQueryInError?: boolean;
+          } = { rowLimit: 1000, byteLimit: 1024 * 1024 }
+        ) => {
+          try {
+            const rows = await client.execute(statement, options);
+            return { rows, metadata: {} };
+          } catch (e) {
+            if (options.includeQueryInError) {
+              throw new Error(`Error encountered while running "${statement}": ${e.message}`);
             }
+            throw new ErrorWithCause(`Error executing redshift query: ${e.message}`, e);
           }
-        })
+        }
+      })
     );
   }
 

--- a/api/dbadapters/snowflake.ts
+++ b/api/dbadapters/snowflake.ts
@@ -3,7 +3,7 @@ import * as PromisePool from "promise-pool-executor";
 import { Readable } from "stream";
 
 import { Credentials } from "df/api/commands/credentials";
-import { IDbAdapter, OnCancel } from "df/api/dbadapters/index";
+import { IDbAdapter, IDbClient, OnCancel } from "df/api/dbadapters/index";
 import { parseSnowflakeEvalError } from "df/api/utils/error_parsing";
 import { LimitedResultSet } from "df/api/utils/results";
 import { ErrorWithCause } from "df/common/errors/errors";
@@ -132,6 +132,10 @@ export class SnowflakeDbAdapter implements IDbAdapter {
         .promise(),
       metadata: {}
     };
+  }
+
+  public async withClientLock<T>(callback: (client: IDbClient) => Promise<T>) {
+    return await callback(this);
   }
 
   public async evaluate(queryOrAction: QueryOrAction, projectConfig?: dataform.ProjectConfig) {

--- a/api/dbadapters/sqldatawarehouse.ts
+++ b/api/dbadapters/sqldatawarehouse.ts
@@ -1,7 +1,7 @@
 import { ConnectionPool } from "mssql";
 
 import { Credentials } from "df/api/commands/credentials";
-import { IDbAdapter, IExecutionResult, OnCancel } from "df/api/dbadapters/index";
+import { IDbAdapter, IDbClient, IExecutionResult, OnCancel } from "df/api/dbadapters/index";
 import { parseAzureEvaluationError } from "df/api/utils/error_parsing";
 import { LimitedResultSet } from "df/api/utils/results";
 import { collectEvaluationQueries, QueryOrAction } from "df/core/adapters";
@@ -87,6 +87,10 @@ export class SQLDataWarehouseDBAdapter implements IDbAdapter {
       // tslint:disable-next-line: no-floating-promises
       request.query(statement);
     });
+  }
+
+  public async withClientLock<T>(callback: (client: IDbClient) => Promise<T>) {
+    return await callback(this);
   }
 
   public async evaluate(queryOrAction: QueryOrAction, projectConfig?: dataform.ProjectConfig) {

--- a/core/adapters/redshift.ts
+++ b/core/adapters/redshift.ts
@@ -147,22 +147,21 @@ export class RedshiftAdapter extends Adapter implements IAdapter {
     const finalTarget = this.resolveTarget(target);
     // Schema name not allowed for temporary tables.
     const tempTarget = `"${target.schema}__${target.name}_incremental_temp"`;
-    return (
-      Tasks.create()
-        .add(Task.statement(`drop table if exists ${tempTarget};`))
-        .add(Task.statement(`create temp table ${tempTarget} as select * from (${query}) as data;`))
-        // TODO: The next two statements should be run in a transaction.
-        .add(
-          Task.statement(
-            `delete from ${finalTarget} using ${tempTarget} where ${uniqueKey
-              .map(
-                uniqueKeyCol => `${finalTarget}."${uniqueKeyCol}" = ${tempTarget}."${uniqueKeyCol}"`
-              )
-              .join(` and `)};`
-          )
+    return Tasks.create()
+      .add(Task.statement(`drop table if exists ${tempTarget};`))
+      .add(Task.statement(`create temp table ${tempTarget} as select * from (${query}) as data;`))
+      .add(Task.statement(`begin transaction;`))
+      .add(
+        Task.statement(
+          `delete from ${finalTarget} using ${tempTarget} where ${uniqueKey
+            .map(
+              uniqueKeyCol => `${finalTarget}."${uniqueKeyCol}" = ${tempTarget}."${uniqueKeyCol}"`
+            )
+            .join(` and `)};`
         )
-        .add(Task.statement(`insert into ${finalTarget} select * from ${tempTarget};`))
-        .add(Task.statement(`drop table ${tempTarget};`))
-    );
+      )
+      .add(Task.statement(`insert into ${finalTarget} select * from ${tempTarget};`))
+      .add(Task.statement(`end transaction;`))
+      .add(Task.statement(`drop table ${tempTarget};`));
   }
 }

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "tarjan-graph": "^2.0.0",
     "tmp": "0.0.33",
     "ts-loader": "^5.3.1",
-    "ts-mockito": "^2.3.1",
+    "ts-mockito": "^2.6.1",
     "tslint": "^5.14.0",
     "tslint-config-prettier": "^1.18.0",
     "tslint-config-security": "^1.16.0",

--- a/tests/api/api.spec.ts
+++ b/tests/api/api.spec.ts
@@ -1,6 +1,6 @@
 import { assert, config, expect } from "chai";
 import Long from "long";
-import { anyFunction, anyString, anything, instance, mock, verify, when } from "ts-mockito";
+import { anyString, anything, instance, mock, verify, when } from "ts-mockito";
 
 import { Builder, credentials, prune, query, Runner } from "df/api";
 import { computeAllTransitiveInputs } from "df/api/commands/build";

--- a/yarn.lock
+++ b/yarn.lock
@@ -12149,10 +12149,10 @@ ts-loader@^5.3.1:
     micromatch "^3.1.4"
     semver "^5.0.1"
 
-ts-mockito@^2.3.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/ts-mockito/-/ts-mockito-2.3.1.tgz#4c3467a2ddeb207966000a740a0826c970125ed1"
-  integrity sha512-chcKw0sTApwJxTyKhzbWxI4BTUJ6RStZKUVh2/mfwYqFS09PYy5pvdXZwG35QSkqT5pkdXZlYKBX196RRvEZdQ==
+ts-mockito@^2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/ts-mockito/-/ts-mockito-2.6.1.tgz#bc9ee2619033934e6fad1c4455aca5b5ace34e73"
+  integrity sha512-qU9m/oEBQrKq5hwfbJ7MgmVN5Gu6lFnIGWvpxSjrqq6YYEVv+RwVFWySbZMBgazsWqv6ctAyVBpo9TmAxnOEKw==
   dependencies:
     lodash "^4.17.5"
 


### PR DESCRIPTION
fixes https://github.com/dataform-co/dataform/issues/980

- this only applies to redshift/postgres
- there is quite a lot of code surrounding execution of individual tasks; so I settled on the pattern of a method which takes a callback; the callback is called with a single client instance which is used for the duration of `ExecutionAction` execution
- with this, I could bring back transactionality to incremental merge