### PR TITLE
Add geography primitive type to BQ and Flake

### DIFF
--- a/api/dbadapters/bigquery.ts
+++ b/api/dbadapters/bigquery.ts
@@ -548,6 +548,8 @@ function convertFieldType(type: string) {
       return dataform.Field.Primitive.TIME;
     case "BYTES":
       return dataform.Field.Primitive.BYTES;
+    case "GEOGRAPHY":
+      return dataform.Field.Primitive.GEOGRAPHY;
     default:
       return dataform.Field.Primitive.UNKNOWN;
   }

--- a/api/dbadapters/snowflake.ts
+++ b/api/dbadapters/snowflake.ts
@@ -440,6 +440,8 @@ function convertFieldType(type: string) {
     case "ARRAY":
     case "OBJECT":
       return dataform.Field.Primitive.ANY;
+    case "GEOGRAPHY":
+      return dataform.Field.Primitive.GEOGRAPHY;
     default:
       return dataform.Field.Primitive.UNKNOWN;
   }

--- a/protos/core.proto
+++ b/protos/core.proto
@@ -519,6 +519,7 @@ message Field {
     BYTES = 10;
     // Semi structured data from Snowflake has no strong schema, and could therefore be anything.
     ANY = 11;
+    GEOGRAPHY = 12;
   }
 
   enum Flag {


### PR DESCRIPTION
Some follow up work I noticed:

* We don't currently handle the [ARRAY type in BQ](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#array_type). Could be quite complex (you can have arrays of structs).

* We should assign a specific primitive type for RECORD and STRUCT, so that the glossary can show those types ([currently puts nothing](https://source.cloud.google.com/tada-analytics/github_dataform-co_dataform-co/+/master:ts/app/glossary/table.tsx;drc=5886f5c57f349b00541d8e1a22271cefb5adafd1;l=165)).

* Remove `primitiveDeprecated`?

Related to https://github.com/dataform-co/dataform-co/pull/7925