### PR TITLE
Revert "add the fivetran logs package to the docs"

### DIFF
--- a/docs/content_tree.ts
+++ b/docs/content_tree.ts
@@ -60,11 +60,6 @@ async function getPackageTrees(): Promise<Array<Tree<IExtraAttributes>>> {
         owner: "dataform-co",
         repo: "dataform-scd",
         title: "Slowly changing dimensions"
-      },
-      {
-        owner: "dataform-co",
-        repo: "dataform-fivetran-logs",
-        title: "Fivetran: Fivetran Logs"
       }
     ].map(async ({ owner, repo, title }) => {
       const tree = await new GitHubCms<IExtraAttributes>({


### PR DESCRIPTION
Reverts dataform-co/dataform#1023

fairly sure this is completely breaking the docs site

https://console.cloud.google.com/logs/query;query=resource.type%3D%22k8s_container%22%0Aresource.labels.project_id%3D%22tada-analytics%22%0Aresource.labels.location%3D%22europe-west1%22%0Aresource.labels.cluster_name%3D%22europe-west1-bulbasaur%22%0Aresource.labels.namespace_name%3D%22marketing%22%0Alabels.k8s-pod%2Fapp%3D%22docs-app%22?pageState=(%22savedViews%22:(%22i%22:%22c7dc7429d532444f8e0c785d6bc20b84%22,%22c%22:%5B%5D,%22n%22:%5B%5D))&project=tada-analytics