### PR TITLE
Consistently use the project's defaultDatabase for run caching metadata.

### DIFF
--- a/api/commands/build.ts
+++ b/api/commands/build.ts
@@ -56,7 +56,12 @@ export async function build(
   return new Builder(
     prunedGraph,
     runConfig,
-    await state(dbadapter, Array.from(allInvolvedTargets), runConfig.useRunCache),
+    await state(
+      compiledGraph.projectConfig.defaultDatabase,
+      dbadapter,
+      Array.from(allInvolvedTargets),
+      runConfig.useRunCache
+    ),
     transitiveInputsByTarget
   ).build();
 }

--- a/api/commands/run.ts
+++ b/api/commands/run.ts
@@ -169,6 +169,7 @@ export class Runner {
     if (this.graph.runConfig && this.graph.runConfig.useRunCache) {
       await Promise.all(this.metadataReadPromises);
       await this.dbadapter.persistStateMetadata(
+        this.graph.projectConfig.defaultDatabase,
         new StringifiedMap<
           dataform.ITarget,
           dataform.PersistedTableMetadata.ITransitiveInputMetadata

--- a/api/commands/state.ts
+++ b/api/commands/state.ts
@@ -2,6 +2,7 @@ import { IDbAdapter } from "df/api/dbadapters";
 import { dataform } from "df/protos/ts";
 
 export async function state(
+  defaultDatabase: string,
   dbadapter: IDbAdapter,
   targets: dataform.ITarget[],
   fetchPersistedMetadata: boolean
@@ -17,7 +18,7 @@ export async function state(
 
   if (fetchPersistedMetadata) {
     try {
-      cachedStates = await dbadapter.persistedStateMetadata();
+      cachedStates = await dbadapter.persistedStateMetadata(defaultDatabase);
     } catch (err) {
       // If the table doesn't exist or for some network error
       // cache state is not fetchable, then return empty array

--- a/api/dbadapters/index.ts
+++ b/api/dbadapters/index.ts
@@ -54,6 +54,7 @@ export interface IDbAdapter extends IDbClient {
   setMetadata(action: dataform.IExecutionAction): Promise<void>;
 
   persistStateMetadata(
+    database: string,
     transitiveInputMetadataByTarget: StringifiedMap<
       dataform.ITarget,
       dataform.PersistedTableMetadata.ITransitiveInputMetadata
@@ -64,7 +65,7 @@ export interface IDbAdapter extends IDbClient {
       onCancel: OnCancel;
     }
   ): Promise<void>;
-  persistedStateMetadata(): Promise<dataform.IPersistedTableMetadata[]>;
+  persistedStateMetadata(database: string): Promise<dataform.IPersistedTableMetadata[]>;
 
   close(): Promise<void>;
 }


### PR DESCRIPTION
This isn't very beautiful, but does ensure that the same database (`defaultDatabase`) is used for storage/retrieval of all run caching metadata. (And besides this is all going away soon in favour of internal storage.)