### PR TITLE
Make the state API only return cached metadata for required targets.

### DIFF
--- a/api/commands/state.ts
+++ b/api/commands/state.ts
@@ -1,4 +1,5 @@
 import { IDbAdapter } from "df/api/dbadapters";
+import { JSONObjectStringifier, StringifiedSet } from "df/common/strings/stringifier";
 import { dataform } from "df/protos/ts";
 
 export async function state(
@@ -18,7 +19,9 @@ export async function state(
 
   if (fetchPersistedMetadata) {
     try {
-      cachedStates = await dbadapter.persistedStateMetadata(defaultDatabase);
+      const allCachedStates = await dbadapter.persistedStateMetadata(defaultDatabase);
+      const targetSet = new StringifiedSet(JSONObjectStringifier.create(), targets);
+      cachedStates = allCachedStates.filter(cachedState => targetSet.has(cachedState.target));
     } catch (err) {
       // If the table doesn't exist or for some network error
       // cache state is not fetchable, then return empty array


### PR DESCRIPTION
Before this fix, we would return cached metadata for *all* targets in the user's DB, which wasn't a problem except that all of that gets attached to the `ExecutionGraph` which ends up being stored in persistent storage. That can end up being *a lot* of data, e.g. in the case of our project.

(Note that this only affected projects which are using run caching.)