### PR TITLE
Make it possible to escape dollar-brace in SQLX.

### DIFF
--- a/core/compilers.ts
+++ b/core/compilers.ts
@@ -263,20 +263,20 @@ function createEscapedStatements(nodes: Array<string | SyntaxTreeNode>) {
   return results;
 }
 
+const escapeJavaScriptTemplateStringCharacters = (str: string) =>
+  str.replace(/\\(?!\${)/g, "\\\\").replace(/\`/g, "\\`");
+
 const SQL_STATEMENT_ESCAPERS = new Map([
   [
     SyntaxTreeNodeType.SQL_COMMENT,
     (str: string) => str.replace(/`/g, "\\`").replace(/\${/g, "\\${")
   ],
-  [
-    SyntaxTreeNodeType.SQL_LITERAL_STRING,
-    (str: string) => str.replace(/\\/g, "\\\\").replace(/\`/g, "\\`")
-  ]
+  [SyntaxTreeNodeType.SQL_LITERAL_STRING, escapeJavaScriptTemplateStringCharacters]
 ]);
 
 function escapeNode(node: string | SyntaxTreeNode) {
   if (typeof node === "string") {
-    return SQL_STATEMENT_ESCAPERS.get(SyntaxTreeNodeType.SQL_LITERAL_STRING)(node);
+    return escapeJavaScriptTemplateStringCharacters(node);
   }
   return node.concatenate(SQL_STATEMENT_ESCAPERS);
 }

--- a/sqlx/lexer.ts
+++ b/sqlx/lexer.ts
@@ -257,7 +257,6 @@ function buildSqlxLexer(): { [x: string]: moo.Rules } {
     push: LEXER_STATE_NAMES.INNER_SQL_BLOCK
   };
   sqlLexer[SQL_LEXER_TOKEN_NAMES.START_INPUT] = {
-    // tslint:disable-next-line: tsr-detect-unsafe-regexp
     match: /input "[a-zA-Z0-9_-]+"(?:,\s*"[a-zA-Z0-9_-]+")* {/,
     push: LEXER_STATE_NAMES.INNER_SQL_BLOCK
   };
@@ -265,7 +264,7 @@ function buildSqlxLexer(): { [x: string]: moo.Rules } {
   sqlLexer[SQL_LEXER_TOKEN_NAMES.SINGLE_LINE_COMMENT] = /--.*?$/;
   sqlLexer[SQL_LEXER_TOKEN_NAMES.MULTI_LINE_COMMENT] = /\/\*[\s\S]*?\*\//;
   sqlLexer[SQL_LEXER_TOKEN_NAMES.START_JS_PLACEHOLDER] = {
-    match: "${",
+    match: /(?<!\\)\${/,
     push: LEXER_STATE_NAMES.JS_BLOCK
   };
   sqlLexer[SQL_LEXER_TOKEN_NAMES.BACKTICK] = "`";
@@ -305,7 +304,7 @@ function buildSqlxLexer(): { [x: string]: moo.Rules } {
   jsTemplateStringLexer[JS_TEMPLATE_STRING_LEXER_TOKEN_NAMES.ESCAPED_BACKSLASH] = /\\\\/;
   jsTemplateStringLexer[JS_TEMPLATE_STRING_LEXER_TOKEN_NAMES.ESCAPED_DOLLAR_BRACE] = /\\\${`/;
   jsTemplateStringLexer[JS_TEMPLATE_STRING_LEXER_TOKEN_NAMES.START_JS_BLOCK] = {
-    match: "${",
+    match: /(?<!\\)\${/,
     push: LEXER_STATE_NAMES.JS_BLOCK
   };
   jsTemplateStringLexer[JS_TEMPLATE_STRING_LEXER_TOKEN_NAMES.CLOSE_STRING] = { match: "`", pop: 1 };
@@ -321,7 +320,7 @@ function buildSqlxLexer(): { [x: string]: moo.Rules } {
   innerSqlBlockLexer[INNER_SQL_BLOCK_LEXER_TOKEN_NAMES.SINGLE_LINE_COMMENT] = /--.*?$/;
   innerSqlBlockLexer[INNER_SQL_BLOCK_LEXER_TOKEN_NAMES.MULTI_LINE_COMMENT] = /\/\*[\s\S]*?\*\//;
   innerSqlBlockLexer[INNER_SQL_BLOCK_LEXER_TOKEN_NAMES.START_JS_PLACEHOLDER] = {
-    match: "${",
+    match: /(?<!\\)\${/,
     push: LEXER_STATE_NAMES.JS_BLOCK
   };
   innerSqlBlockLexer[INNER_SQL_BLOCK_LEXER_TOKEN_NAMES.CLOSE_BLOCK] = {
@@ -346,7 +345,7 @@ function buildSqlxLexer(): { [x: string]: moo.Rules } {
   innerSingleQuoteLexer[SQL_SINGLE_QUOTE_STRING_LEXER_TOKEN_NAMES.ESCAPED_BACKSLASH] = "\\\\";
   innerSingleQuoteLexer[SQL_SINGLE_QUOTE_STRING_LEXER_TOKEN_NAMES.ESCAPED_QUOTE] = "\\'";
   innerSingleQuoteLexer[SQL_SINGLE_QUOTE_STRING_LEXER_TOKEN_NAMES.START_JS_PLACEHOLDER] = {
-    match: "${",
+    match: /(?<!\\)\${/,
     push: LEXER_STATE_NAMES.JS_BLOCK
   };
   innerSingleQuoteLexer[SQL_SINGLE_QUOTE_STRING_LEXER_TOKEN_NAMES.CLOSE_QUOTE] = {
@@ -364,7 +363,7 @@ function buildSqlxLexer(): { [x: string]: moo.Rules } {
     match: '\\"'
   };
   innerSingleQuoteLexer[SQL_DOUBLE_QUOTE_STRING_LEXER_TOKEN_NAMES.START_JS_PLACEHOLDER] = {
-    match: "${",
+    match: /(?<!\\)\${/,
     push: LEXER_STATE_NAMES.JS_BLOCK
   };
   innerDoubleQuoteLexer[SQL_DOUBLE_QUOTE_STRING_LEXER_TOKEN_NAMES.CLOSE_QUOTE] = {

--- a/sqlx/tslint.json
+++ b/sqlx/tslint.json
@@ -1,7 +1,8 @@
 {
   "extends": ["../tslint.json"],
   "rules": {
+    "tsr-detect-non-literal-fs-filename": false,
     "tsr-detect-possible-timing-attacks": false,
-    "tsr-detect-non-literal-fs-filename": false
+    "tsr-detect-unsafe-regexp": false
   }
 }

--- a/tests/core/core.spec.ts
+++ b/tests/core/core.spec.ts
@@ -990,5 +990,13 @@ select '\${\`bar\`}'
         await fs.readFile("tests/core/js-placeholder-strings-inside-sql-strings.js.test", "utf8")
       );
     });
+    test("can escape dollar-brace", async () => {
+      expect(
+        compilers.compile(
+          `select \\\${outOfQuotes.whatever}, "\\\${inQuotes.whatever}"`,
+          "file.sqlx"
+        )
+      ).eql(await fs.readFile("tests/core/escaped-dollar-brace.js.test", "utf8"));
+    });
   });
 });

--- a/tests/core/core.spec.ts
+++ b/tests/core/core.spec.ts
@@ -992,10 +992,7 @@ select '\${\`bar\`}'
     });
     test("can escape dollar-brace", async () => {
       expect(
-        compilers.compile(
-          `select \\\${outOfQuotes.whatever}, "\\\${inQuotes.whatever}"`,
-          "file.sqlx"
-        )
+        compilers.compile('select \\${outOfQuotes.whatever}, "\\${inQuotes.whatever}"', "file.sqlx")
       ).eql(await fs.readFile("tests/core/escaped-dollar-brace.js.test", "utf8"));
     });
   });

--- a/tests/core/escaped-dollar-brace.js.test
+++ b/tests/core/escaped-dollar-brace.js.test
@@ -1,0 +1,24 @@
+dataform.sqlxAction({
+  sqlxConfig: {
+    name: "file",
+    type: "operations",
+    ...{}
+  },
+  sqlStatementCount: 1,
+  sqlContextable: (ctx) => {
+    const self = ctx.self ? ctx.self.bind(ctx) : undefined;
+const ref = ctx.ref ? ctx.ref.bind(ctx) : undefined;
+const resolve = ctx.resolve ? ctx.resolve.bind(ctx) : undefined;
+const name = ctx.name ? ctx.name.bind(ctx) : undefined;
+const when = ctx.when ? ctx.when.bind(ctx) : undefined;
+const incremental = ctx.incremental ? ctx.incremental.bind(ctx) : undefined;
+    
+    return [`select \${outOfQuotes.whatever}, "\${inQuotes.whatever}"`];
+  },
+  incrementalWhereContextable: undefined,
+  preOperationsContextable: undefined,
+  postOperationsContextable: undefined,
+  inputContextables: [
+    
+  ]
+});


### PR DESCRIPTION
fixes https://github.com/dataform-co/dataform/issues/997

- treat `\${` as plain text, i.e. the parser should not jump to a new state when seeing a `${` preceded by a `\`
- when escaping `\`, only escape if it is not followed by a `${`, i.e. `\${` should be left as-is