### PR TITLE
Hide snowflake hidden schemas in search

### DIFF
--- a/api/dbadapters/snowflake.ts
+++ b/api/dbadapters/snowflake.ts
@@ -208,7 +208,6 @@ where LOWER(table_schema) != 'information_schema'`,
           and tables.table_name = columns.table_name
         where tables.table_catalog ilike :1 or tables.table_schema ilike :1 or tables.table_name ilike :1 or tables.comment ilike :1
           or columns.column_name ilike :1 or columns.comment ilike :1
-          and LOWER(tables.table_schema) != 'information_schema' and LOWER(tables.table_schema) != 'pg_catalog' and LOWER(tables.table_schema) != 'pg_internal'
         group by 1, 2, 3
       ) where LOWER(table_schema) != 'information_schema'
        `,

--- a/api/dbadapters/snowflake.ts
+++ b/api/dbadapters/snowflake.ts
@@ -186,9 +186,7 @@ export class SnowflakeDbAdapter implements IDbAdapter {
       `
 select table_name, table_schema, table_catalog
 from information_schema.tables
-where LOWER(table_schema) != 'information_schema'
-  and LOWER(table_schema) != 'pg_catalog'
-  and LOWER(table_schema) != 'pg_internal'`,
+where LOWER(table_schema) != 'information_schema'`,
       { rowLimit: 10000 }
     );
     return rows.map(row => ({
@@ -213,8 +211,6 @@ where LOWER(table_schema) != 'information_schema'
           and LOWER(tables.table_schema) != 'information_schema' and LOWER(tables.table_schema) != 'pg_catalog' and LOWER(tables.table_schema) != 'pg_internal'
         group by 1, 2, 3
       ) where LOWER(table_schema) != 'information_schema'
-      and LOWER(table_schema) != 'pg_catalog'
-      and LOWER(table_schema) != 'pg_internal'
        `,
       {
         binds: [`%${searchText}%`],


### PR DESCRIPTION
Fixes https://github.com/dataform-co/dataform-co/issues/8418

Information schemas aren't being hidden by the search query for the Snowflake API adapter, though they are hidden in the tableList query.

Can be replicated using our test snowflake project with this search:

<img width="935" alt="Screenshot 2020-10-28 at 11 31 11" src="https://user-images.githubusercontent.com/13434377/97430926-77cd1700-1911-11eb-89a6-4758d96b4f7a.png">
