### PR TITLE
Bump BQ version past fix for 'Job Already Exists' error.

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@blueprintjs/core": "^3.22.3",
     "@blueprintjs/icons": "^3.13.0",
     "@blueprintjs/select": "^3.8.0",
-    "@google-cloud/bigquery": "^5.3.0",
+    "@google-cloud/bigquery": "^5.4.0",
     "@google-cloud/storage": "^5.1.1",
     "@mapbox/rehype-prism": "^0.4.0",
     "@nivo/bar": "^0.61.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1090,16 +1090,16 @@
     classnames "^2.2"
     tslib "~1.10.0"
 
-"@google-cloud/bigquery@^5.3.0":
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/@google-cloud/bigquery/-/bigquery-5.3.0.tgz#87db58ed6538d0be5dd146901ffd636d6b9fead0"
-  integrity sha512-IxHd7dWJygQgExdnwS7D8zMswe3VG5akKSLTkdl5ky1Xn6VHiXg30c8zK99jqRafA7kU023W/+L9F9zIQp1qiA==
+"@google-cloud/bigquery@^5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@google-cloud/bigquery/-/bigquery-5.4.0.tgz#e9b3ddb2d7b5a04a5224a5c0cd95d549bbdde4ff"
+  integrity sha512-efdNr+S0SMJ0ZpYhtKC8tdMqCIUsL0oVImFz+WJM8Coq37WuGvLk6gX7rd5J/L5chDYW0sg7PSIF2izmi0Uplg==
   dependencies:
     "@google-cloud/common" "^3.1.0"
     "@google-cloud/paginator" "^3.0.0"
     "@google-cloud/promisify" "^2.0.0"
     arrify "^2.0.1"
-    big.js "^5.2.2"
+    big.js "^6.0.0"
     duplexify "^4.0.0"
     extend "^3.0.2"
     is "^3.3.0"
@@ -3427,6 +3427,11 @@ big.js@^5.2.2:
   version "5.2.2"
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
   integrity sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==
+
+big.js@^6.0.0:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/big.js/-/big.js-6.0.2.tgz#af54d7678630aa4ce5d62f43ed44d1a3c9faf803"
+  integrity sha512-5PQYFp5ZrznQwD7cNgUHZwpC0gm/Pmh2GiUMSW4KurSXEtjLUVAXnmxYnM2W1X0Dx9JFAcvYJ4IQ+dchanp5VA==
 
 bignumber.js@^2.4.0:
   version "2.4.0"


### PR DESCRIPTION
The BQ lib now has a fix (https://github.com/googleapis/nodejs-bigquery/pull/864) for https://github.com/googleapis/nodejs-bigquery/issues/857.