### PR TITLE
Remove database from metadata target equality test, and some tidying

### DIFF
--- a/api/commands/compile.ts
+++ b/api/commands/compile.ts
@@ -7,7 +7,10 @@ import { coerceAsError, ErrorWithCause } from "df/common/errors/errors";
 import { decode } from "df/common/protos";
 import { dataform } from "df/protos/ts";
 
+// Project config properties that are required.
 const mandatoryProps: Array<keyof dataform.IProjectConfig> = ["warehouse", "defaultSchema"];
+
+// Project config properties that require alphanumeric characters, hyphens or underscores.
 const simpleCheckProps: Array<keyof dataform.IProjectConfig> = [
   "assertionSchema",
   "databaseSuffix",

--- a/api/commands/prune.ts
+++ b/api/commands/prune.ts
@@ -34,8 +34,8 @@ function computeIncludedActionNames(
   const allActionsByName: { [name: string]: CompileAction } = {};
   allActions.forEach(action => (allActionsByName[action.name] = action));
 
-  const hasActionSelector = runConfig.actions && runConfig.actions.length > 0;
-  const hasTagSelector = runConfig.tags && runConfig.tags.length > 0;
+  const hasActionSelector = runConfig.actions?.length > 0;
+  const hasTagSelector = runConfig.tags?.length > 0;
 
   // If no selectors, return all actions.
   if (!hasActionSelector && !hasTagSelector) {
@@ -65,7 +65,7 @@ function computeIncludedActionNames(
       const actionName = queue.pop();
       const action = allActionsByName[actionName];
       const matchingDependencyNames =
-        action.dependencies && action.dependencies.length > 0
+        action.dependencies?.length > 0
           ? utils.matchPatterns(action.dependencies, allActionNames)
           : [];
       matchingDependencyNames.forEach(dependencyName => {

--- a/api/dbadapters/bigquery.ts
+++ b/api/dbadapters/bigquery.ts
@@ -176,7 +176,12 @@ export class BigQueryDbAdapter implements IDbAdapter {
       name: metadata.tableReference.tableId
     };
 
-    if (!equals(dataform.Target, target, metadataTarget)) {
+    // Database isn't checked for equality as it's not always presented to the compiled graph, but
+    // IS always available in the warehouse.
+    if (
+      metadata.tableReference.datasetId !== target.schema ||
+      metadata.tableReference.tableId !== target.name
+    ) {
       throw new Error(
         `Target ${JSON.stringify(metadataTarget)} does not match requested target ${JSON.stringify(
           target
@@ -288,9 +293,9 @@ export class BigQueryDbAdapter implements IDbAdapter {
         .dataset(target.schema)
         .table(target.name)
         .getMetadata();
-      return table && table[0];
+      return table?.[0];
     } catch (e) {
-      if (e && e.errors && e.errors[0] && e.errors[0].reason === "notFound") {
+      if (e?.errors?.[0]?.reason === "notFound") {
         // if the table can't be found, just return null
         return null;
       }

--- a/core/adapters/bigquery.ts
+++ b/core/adapters/bigquery.ts
@@ -68,7 +68,6 @@ export class BigQueryAdapter extends Adapter implements IAdapter {
     const target =
       assertion.target ||
       dataform.Target.create({
-        database: projectConfig.defaultDatabase,
         schema: projectConfig.assertionSchema,
         name: assertion.name
       });

--- a/core/adapters/bigquery.ts
+++ b/core/adapters/bigquery.ts
@@ -68,6 +68,7 @@ export class BigQueryAdapter extends Adapter implements IAdapter {
     const target =
       assertion.target ||
       dataform.Target.create({
+        database: projectConfig.defaultDatabase,
         schema: projectConfig.assertionSchema,
         name: assertion.name
       });

--- a/core/utils.ts
+++ b/core/utils.ts
@@ -159,14 +159,13 @@ export function target(
   adapter: adapters.IAdapter,
   config: dataform.IProjectConfig,
   name: string,
-  schema: string,
+  schema?: string,
   database?: string
 ): dataform.ITarget {
-  const resolvedDatabase = database || config.defaultDatabase;
   return dataform.Target.create({
     name: adapter.normalizeIdentifier(name),
     schema: adapter.normalizeIdentifier(schema || config.defaultSchema),
-    database: resolvedDatabase && adapter.normalizeIdentifier(resolvedDatabase)
+    database: adapter.normalizeIdentifier(database || config.defaultDatabase)
   });
 }
 

--- a/core/utils.ts
+++ b/core/utils.ts
@@ -165,7 +165,7 @@ export function target(
   return dataform.Target.create({
     name: adapter.normalizeIdentifier(name),
     schema: adapter.normalizeIdentifier(schema || config.defaultSchema),
-    database: adapter.normalizeIdentifier(database || config.defaultDatabase)
+    database: adapter.normalizeIdentifier(database || config.defaultDatabase || "")
   });
 }
 

--- a/core/utils.ts
+++ b/core/utils.ts
@@ -162,10 +162,12 @@ export function target(
   schema?: string,
   database?: string
 ): dataform.ITarget {
+  schema = schema || config.defaultSchema;
+  database = database || config.defaultDatabase;
   return dataform.Target.create({
     name: adapter.normalizeIdentifier(name),
-    schema: adapter.normalizeIdentifier(schema || config.defaultSchema),
-    database: adapter.normalizeIdentifier(database || config.defaultDatabase || "")
+    schema: !!schema ? adapter.normalizeIdentifier(schema || config.defaultSchema) : undefined,
+    database: !!database ? adapter.normalizeIdentifier(database) : undefined
   });
 }
 


### PR DESCRIPTION
Fixes https://github.com/dataform-co/dataform-co/issues/8902

We don't actually present the database to compilation by df core, whereas it is always available when retrieving metadata from BQ.

A solution here would be to always present the database for compilation, but this blurs the lines between the API and core, as the database is stored in the credentials with many of the warehouses.

For now just not comparing database, or even removing the equality, seems best
