### PR TITLE
Make it possible to compile single queries that use ref/resolve's 'rest' argument form.

### DIFF
--- a/core/session.ts
+++ b/core/session.ts
@@ -19,6 +19,7 @@ import {
 } from "df/core/table";
 import * as test from "df/core/test";
 import * as utils from "df/core/utils";
+import { toResolvable } from "df/core/utils";
 import { version as dataformCoreVersion } from "df/core/version";
 import { dataform } from "df/protos/ts";
 
@@ -216,7 +217,8 @@ export class Session {
     }
   }
 
-  public resolve(ref: Resolvable): string {
+  public resolve(ref: Resolvable | string[], ...rest: string[]): string {
+    ref = toResolvable(ref, rest);
     const allResolved = this.findActions(utils.resolvableAsTarget(ref));
     if (allResolved.length > 1) {
       this.compileError(new Error(utils.ambiguousActionNameMsg(ref, allResolved)));

--- a/tests/api/api.spec.ts
+++ b/tests/api/api.spec.ts
@@ -835,6 +835,18 @@ suite("@dataform/api", () => {
         "select 1 from `tada-analytics.df_integration_test.example_view`"
       );
     });
+    test("bigquery_example with explicit schema", async () => {
+      const compiledQuery = await query.compile(
+        'select 1 from ${ref("df_integration_test", "example_view")}',
+        {
+          projectDir: "examples/common_v1",
+          projectConfigOverride: { warehouse: "bigquery", defaultDatabase: "tada-analytics" }
+        }
+      );
+      expect(compiledQuery).equals(
+        "select 1 from `tada-analytics.df_integration_test.example_view`"
+      );
+    });
     test("bigquery example with input backticks", async () => {
       const compiledQuery = await query.compile(
         "select 1 from `tada-analytics.df_integration_test.example_view`",

--- a/version.bzl
+++ b/version.bzl
@@ -1,3 +1,3 @@
 # NOTE: If you change the format of this line, you must change the bash command
 # in /scripts/publish to extract the version string correctly.
-DF_VERSION = "1.16.4"
+DF_VERSION = "1.16.5"


### PR DESCRIPTION
fixes https://github.com/dataform-co/dataform-co/issues/8923