### PR TITLE
Add full support for SQLX compilation to single-query compile requests.

### DIFF
--- a/api/commands/query.ts
+++ b/api/commands/query.ts
@@ -50,8 +50,6 @@ export async function compile(
   // Resolve the path in case it hasn't been resolved already.
   const projectDir = path.resolve(compileConfig.projectDir);
 
-  query = query.replace(/\\/g, "\\\\").replace(/`/g, "\\`");
-
   return await CompileChildProcess.forkProcess().compile({
     ...compileConfig,
     projectDir,

--- a/core/compilers.ts
+++ b/core/compilers.ts
@@ -4,7 +4,10 @@ import { TableContext } from "df/core/table";
 import * as utils from "df/core/utils";
 import { SyntaxTreeNode, SyntaxTreeNodeType } from "df/sqlx/lexer";
 
-export function compile(code: string, path: string) {
+export function compile(code: string, path?: string) {
+  if (!path) {
+    return compileStandaloneSqlxQuery(code);
+  }
   if (path.endsWith(".sqlx")) {
     return compileSqlx(SyntaxTreeNode.create(code), path);
   }
@@ -90,8 +93,101 @@ export function extractJsBlocks(code: string): { sql: string; js: string } {
   };
 }
 
+function compileStandaloneSqlxQuery(code: string) {
+  const { config, js, sql, incremental, preOperations, postOperations, inputs } = extractSqlxParts(
+    SyntaxTreeNode.create(code)
+  );
+  if (config) {
+    throw new Error(`Standalone SQLX queries may not define 'config' code blocks.`);
+  }
+  if (incremental) {
+    throw new Error(`Standalone SQLX queries may not define 'incremental_where' code blocks.`);
+  }
+  if (preOperations.length > 0) {
+    throw new Error(`Standalone SQLX queries may not define 'pre_operations' code blocks.`);
+  }
+  if (postOperations.length > 0) {
+    throw new Error(`Standalone SQLX queries may not define 'post_operations' code blocks.`);
+  }
+  if (inputs.length > 0) {
+    throw new Error(`Standalone SQLX queries may not define 'input' code blocks.`);
+  }
+  return `
+    const ref = dataform.resolve.bind(dataform);
+    const resolve = dataform.resolve.bind(dataform);
+    ${js}
+    return \`${sql}\`;
+  `;
+}
+
 function compileSqlx(rootNode: SyntaxTreeNode, path: string) {
-  let config = "{}";
+  const { config, js, sql, incremental, preOperations, postOperations, inputs } = extractSqlxParts(
+    rootNode
+  );
+
+  const contextFunctions = ["self", "ref", "resolve", "name", "when", "incremental"]
+    .map(name => `const ${name} = ctx.${name} ? ctx.${name}.bind(ctx) : undefined;`)
+    .join("\n");
+
+  return `dataform.sqlxAction({
+  sqlxConfig: {
+    name: "${utils.baseFilename(path)}",
+    type: "operations",
+    ...${config || "{}"}
+  },
+  sqlStatementCount: ${sql.length},
+  sqlContextable: (ctx) => {
+    ${contextFunctions}
+    ${js}
+    return [${sql.map(sqlOp => `\`${sqlOp}\``)}];
+  },
+  incrementalWhereContextable: ${
+    !!incremental
+      ? `(ctx) => {
+    ${contextFunctions}
+    ${js}
+    return \`${incremental}\`
+  }`
+      : "undefined"
+  },
+  preOperationsContextable: ${
+    preOperations.length > 0
+      ? `(ctx) => {
+    ${contextFunctions}
+    ${js}
+    return [${preOperations.map(preOpSql => `\`${preOpSql}\``)}];
+  }`
+      : "undefined"
+  },
+  postOperationsContextable: ${
+    postOperations.length > 0
+      ? `(ctx) => {
+    ${contextFunctions}
+    ${js}
+    return [${postOperations.map(postOpSql => `\`${postOpSql}\``)}];
+  }`
+      : "undefined"
+  },
+  inputContextables: [
+    ${inputs
+      .map(
+        ({ labelParts, value }) =>
+          `{
+            refName: [${labelParts.map(labelPart => `"${labelPart}"`).join(", ")}],
+            contextable: (ctx) => {
+              ${js}
+              return \`${value}\`;
+            }
+          }`
+      )
+      .join(",")}
+  ]
+});
+`;
+}
+
+function extractSqlxParts(rootNode: SyntaxTreeNode) {
+  let config = "";
   let js = "";
   rootNode
     .children()
@@ -122,8 +218,8 @@ function compileSqlx(rootNode: SyntaxTreeNode, path: string) {
   );
 
   let incremental = "";
-  let preOperations = [""];
-  let postOperations = [""];
+  let preOperations: string[] = [];
+  let postOperations: string[] = [];
   const inputs: Array<{
     labelParts: string[];
     value: string;
@@ -174,65 +270,15 @@ function compileSqlx(rootNode: SyntaxTreeNode, path: string) {
       }
     });
 
-  const contextFunctions = ["self", "ref", "resolve", "name", "when", "incremental"]
-    .map(name => `const ${name} = ctx.${name} ? ctx.${name}.bind(ctx) : undefined;`)
-    .join("\n");
-
-  return `dataform.sqlxAction({
-  sqlxConfig: {
-    name: "${utils.baseFilename(path)}",
-    type: "operations",
-    ...${config}
-  },
-  sqlStatementCount: ${sql.length},
-  sqlContextable: (ctx) => {
-    ${contextFunctions}
-    ${js}
-    return [${sql.map(sqlOp => `\`${sqlOp}\``)}];
-  },
-  incrementalWhereContextable: ${
-    !!incremental
-      ? `(ctx) => {
-    ${contextFunctions}
-    ${js}
-    return \`${incremental}\`
-  }`
-      : "undefined"
-  },
-  preOperationsContextable: ${
-    preOperations.length > 1 || preOperations[0] !== ""
-      ? `(ctx) => {
-    ${contextFunctions}
-    ${js}
-    return [${preOperations.map(preOpSql => `\`${preOpSql}\``)}];
-  }`
-      : "undefined"
-  },
-  postOperationsContextable: ${
-    postOperations.length > 1 || postOperations[0] !== ""
-      ? `(ctx) => {
-    ${contextFunctions}
-    ${js}
-    return [${postOperations.map(postOpSql => `\`${postOpSql}\``)}];
-  }`
-      : "undefined"
-  },
-  inputContextables: [
-    ${inputs
-      .map(
-        ({ labelParts, value }) =>
-          `{
-            refName: [${labelParts.map(labelPart => `"${labelPart}"`).join(", ")}],
-            contextable: (ctx) => {
-              ${js}
-              return \`${value}\`;
-            }
-          }`
-      )
-      .join(",")}
-  ]
-});
-`;
+  return {
+    config,
+    js,
+    sql,
+    incremental,
+    preOperations,
+    postOperations,
+    inputs
+  };
 }
 
 function getFunctionPropertyNames(prototype: any) {

--- a/core/compilers.ts
+++ b/core/compilers.ts
@@ -4,10 +4,7 @@ import { TableContext } from "df/core/table";
 import * as utils from "df/core/utils";
 import { SyntaxTreeNode, SyntaxTreeNodeType } from "df/sqlx/lexer";
 
-export function compile(code: string, path?: string) {
-  if (!path) {
-    return compileStandaloneSqlxQuery(code);
-  }
+export function compile(code: string, path: string) {
   if (path.endsWith(".sqlx")) {
     return compileSqlx(SyntaxTreeNode.create(code), path);
   }
@@ -93,7 +90,7 @@ export function extractJsBlocks(code: string): { sql: string; js: string } {
   };
 }
 
-function compileStandaloneSqlxQuery(code: string) {
+export function compileStandaloneSqlxQuery(code: string) {
   const { config, js, sql, incremental, preOperations, postOperations, inputs } = extractSqlxParts(
     SyntaxTreeNode.create(code)
   );

--- a/core/gen_index.ts
+++ b/core/gen_index.ts
@@ -26,13 +26,15 @@ export function genIndex(base64EncodedConfig: string): string {
     dataform.ProjectConfig.create(config.compileConfig.projectConfigOverride).toJSON()
   );
 
+  const escapedQuery = config.compileConfig.query
+    .replace(/\\/g, "\\\\")
+    .replace(/`/g, "\\`")
+    .replace(/\${/g, "\\${");
   const returnValue = config.compileConfig.compileSingleQuery
     ? `(function() {
       try {
-        const ref = global.dataform.resolve.bind(global.dataform);
-        const resolve = global.dataform.resolve.bind(global.dataform);
-        const self = () => "";
-        return \`${config.compileConfig.query}\`;
+        const compiled = require("@dataform/core").compiler(\`${escapedQuery}\`);
+        return new Function(compiled)();
       } catch (e) {
         return e.message;
       }

--- a/core/gen_index.ts
+++ b/core/gen_index.ts
@@ -33,7 +33,7 @@ export function genIndex(base64EncodedConfig: string): string {
   const returnValue = config.compileConfig.compileSingleQuery
     ? `(function() {
       try {
-        const compiled = require("@dataform/core").compiler(\`${escapedQuery}\`);
+        const compiled = require("@dataform/core").compileStandaloneSqlxQuery(\`${escapedQuery}\`);
         return new Function(compiled)();
       } catch (e) {
         return e.message;

--- a/core/index.ts
+++ b/core/index.ts
@@ -19,3 +19,6 @@ function globalSession() {
   return (global as any)._DF_SESSION as Session;
 }
 export const session = globalSession();
+
+// Used by generated index.js file.
+export const compileStandaloneSqlxQuery = compilers.compileStandaloneSqlxQuery;

--- a/tests/api/api.spec.ts
+++ b/tests/api/api.spec.ts
@@ -876,6 +876,22 @@ suite("@dataform/api", () => {
       });
       expect(compiledQuery).equals("");
     });
+    test("example with JS block", async () => {
+      const compiledQuery = await query.compile(
+        `
+js {
+  const foo = "bar";
+}
+
+select \${foo}
+`,
+        {
+          projectDir: "examples/common_v1",
+          projectConfigOverride: { warehouse: "bigquery", defaultDatabase: "tada-analytics" }
+        }
+      );
+      expect(compiledQuery.trim()).equals("select bar");
+    });
   });
 
   suite("credentials_config", () => {

--- a/version.bzl
+++ b/version.bzl
@@ -1,3 +1,3 @@
 # NOTE: If you change the format of this line, you must change the bash command
 # in /scripts/publish to extract the version string correctly.
-DF_VERSION = "1.16.5"
+DF_VERSION = "1.17.0"


### PR DESCRIPTION
fixes https://github.com/dataform-co/dataform-co/issues/8925

A bit of explanation:
- in order to properly support various JS constructs, we really need to lex the query string, which is why the generated `index.js` file now calls into `compilers.ts`
- the generated `index.js` file then "calls" the compiled result inside a dynamically-constructed `Function`. (note that this is not strictly necessary, we could just `eval` the result, but `Function` makes it easier to handle multiple lines of query code)
- this means that it's possible to have full support for arbitrary JavaScript, and even `js {}` blocks
- note that the majority of the changes in `compilers.ts` is just moving code around, specifically everything inside `extractSqlxParts`; only `compileStandaloneSqlxQuery` is new

**NOTE**: this PR introduces a backwards-incompatible change. Certain kinds of specific queries that compiled before will no longer be compilable (until the user upgrades `@dataform/core` past this change); specifically, those that contain literal backslashes or backticks. I can't really see a way around this. On the plus side, this PR fully moves single-query compilation inside `@dataform/core`, so that future changes can be more safe across the `api` <-> `core` boundary.