### PR TITLE
Initialize 'decoders' after all Message classes have been declared.

### DIFF
--- a/protoc-gen-ts/README.md
+++ b/protoc-gen-ts/README.md
@@ -11,6 +11,7 @@
 
 - Cleanup:
   - Transpiler code determines whether a field is a Map in several places; this should be consolidated
+  - `DECODERS_SINGLETON` members should have correct typing (instead of `any`)
 - Features:
   - `toJson()` is supported, but `fromJson()` is not
   - `toJson()` support for "special" protobuf types e.g. `Any`

--- a/protoc-gen-ts/runtime/serialize.ts
+++ b/protoc-gen-ts/runtime/serialize.ts
@@ -286,13 +286,12 @@ export class Deserializer {
   }
 }
 
-interface IRepeatedFieldDecoder<T> {
-  decode(reader: BytesReader, currentValue: T[]): T[];
-  single(): IDecoder<T>;
+export interface IDecoder<T> {
+  decode(reader: BytesReader, currentValue?: T): T;
 }
 
-interface IDecoder<T> {
-  decode(reader: BytesReader, currentValue?: T): T;
+interface IRepeatedFieldDecoder<T> extends IDecoder<T[]> {
+  single(): IDecoder<T>;
 }
 
 abstract class NotPackedFieldDecoder<T> implements IRepeatedFieldDecoder<T> {

--- a/protoc-gen-ts/transpiler.ts
+++ b/protoc-gen-ts/transpiler.ts
@@ -210,7 +210,10 @@ ${indent(
     return newProto;
   }
 
-  private static readonly decoders = {
+  private static readonly decoders = ${this.type.typescriptType.name}.initializeDecoders();
+
+  private static initializeDecoders() {
+    return {
 ${indent(
   [
     ...this.type.protobufType.fields.map(
@@ -235,9 +238,10 @@ ${indent(
       )
       .flat()
   ].join(",\n"),
-  2
+  3
 )}
-  };
+    };
+  }
 
 ${indent(
   [

--- a/protoc-gen-ts/transpiler.ts
+++ b/protoc-gen-ts/transpiler.ts
@@ -210,10 +210,11 @@ ${indent(
     return newProto;
   }
 
-  private static readonly decoders = ${this.type.typescriptType.name}.initializeDecoders();
+  private static DECODERS_SINGLETON: any;
 
-  private static initializeDecoders() {
-    return {
+  private static get decoders() {
+    if (!${this.type.typescriptType.name}.DECODERS_SINGLETON) {
+      ${this.type.typescriptType.name}.DECODERS_SINGLETON = {
 ${indent(
   [
     ...this.type.protobufType.fields.map(
@@ -238,9 +239,11 @@ ${indent(
       )
       .flat()
   ].join(",\n"),
-  3
+  4
 )}
-    };
+      };
+    }
+    return ${this.type.typescriptType.name}.DECODERS_SINGLETON;
   }
 
 ${indent(


### PR DESCRIPTION
(required to be able to use this for `core.proto`)