### PR TITLE
Fix error piping from VM when using mac CLI

### DIFF
--- a/api/commands/compile.ts
+++ b/api/commands/compile.ts
@@ -89,22 +89,17 @@ export class CompileChildProcess {
 
   public async compile(compileConfig: dataform.ICompileConfig) {
     const compileInChildProcess = new Promise<string>(async (resolve, reject) => {
-      let encodedCompiledGraph: string;
-      // Handle any Error caused by spawning the child process, or sent directly from the child process.
       this.childProcess.on("error", (e: Error) => reject(coerceAsError(e)));
+
       this.childProcess.on("message", (messageOrError: string | Error) => {
         if (typeof messageOrError === "string") {
-          encodedCompiledGraph = messageOrError;
-          return;
+          resolve(messageOrError);
         }
         reject(coerceAsError(messageOrError));
       });
 
-      // When the child process closes all stdio streams, return the compiled result.
       this.childProcess.on("close", exitCode => {
-        if (exitCode === 0) {
-          resolve(encodedCompiledGraph);
-        } else {
+        if (exitCode !== 0) {
           reject(new Error(`Compilation child process exited with exit code ${exitCode}.`));
         }
       });

--- a/api/commands/compile.ts
+++ b/api/commands/compile.ts
@@ -89,30 +89,21 @@ export class CompileChildProcess {
 
   public async compile(compileConfig: dataform.ICompileConfig) {
     const compileInChildProcess = new Promise<string>(async (resolve, reject) => {
+      let encodedCompiledGraph: string;
       // Handle any Error caused by spawning the child process, or sent directly from the child process.
       this.childProcess.on("error", (e: Error) => reject(coerceAsError(e)));
-      this.childProcess.on("message", (e: Error) => reject(coerceAsError(e)));
-
-      // Handle UTF-8 string chunks returned by the child process.
-      const pipe = this.childProcess.stdio[4] as Readable;
-      const chunks: Buffer[] = [];
-      pipe?.on("readable", () => {
-        let buffer: Buffer = pipe.read();
-        while (buffer) {
-          chunks.push(buffer);
-          buffer = pipe.read();
+      this.childProcess.on("message", (messageOrError: string | Error) => {
+        if (typeof messageOrError === "string") {
+          encodedCompiledGraph = messageOrError;
+          return;
         }
-      });
-      pipe?.on("data", chunk => {
-        if (chunk.includes("Error compiling in child process")) {
-          reject(new Error(chunk));
-        }
+        reject(coerceAsError(messageOrError));
       });
 
       // When the child process closes all stdio streams, return the compiled result.
       this.childProcess.on("close", exitCode => {
         if (exitCode === 0) {
-          resolve(Buffer.concat(chunks).toString("utf8"));
+          resolve(encodedCompiledGraph);
         } else {
           reject(new Error(`Compilation child process exited with exit code ${exitCode}.`));
         }

--- a/api/commands/compile.ts
+++ b/api/commands/compile.ts
@@ -94,6 +94,7 @@ export class CompileChildProcess {
       this.childProcess.on("message", (messageOrError: string | Error) => {
         if (typeof messageOrError === "string") {
           resolve(messageOrError);
+          return;
         }
         reject(coerceAsError(messageOrError));
       });

--- a/api/commands/compile.ts
+++ b/api/commands/compile.ts
@@ -103,6 +103,11 @@ export class CompileChildProcess {
           buffer = pipe.read();
         }
       });
+      pipe?.on("data", chunk => {
+        if (chunk.includes("Error compiling in child process")) {
+          reject(new Error(chunk));
+        }
+      });
 
       // When the child process closes all stdio streams, return the compiled result.
       this.childProcess.on("close", exitCode => {

--- a/api/vm/compile.ts
+++ b/api/vm/compile.ts
@@ -68,13 +68,6 @@ export function compile(compileConfig: dataform.ICompileConfig) {
 
 export function listenForCompileRequest() {
   process.on("message", (compileConfig: dataform.ICompileConfig) => {
-    const serializeError = (e: any) => {
-      const serializableError = {};
-      for (const prop of Object.getOwnPropertyNames(e)) {
-        (serializableError as any)[prop] = e[prop];
-      }
-      return serializableError;
-    };
     // Initializing writer here results in a `uv_pipe_open` error.
     let writer: net.Socket;
     try {

--- a/api/vm/compile.ts
+++ b/api/vm/compile.ts
@@ -71,14 +71,13 @@ export function listenForCompileRequest() {
   process.on("message", (compileConfig: dataform.ICompileConfig) => {
     try {
       const compiledResult = compile(compileConfig);
-      process.send(compiledResult, () => process.exit());
+      process.send(compiledResult);
     } catch (e) {
       const serializableError = {};
       for (const prop of Object.getOwnPropertyNames(e)) {
         (serializableError as any)[prop] = e[prop];
       }
       process.send(serializableError);
-      process.exit();
     }
   });
 }

--- a/api/vm/compile.ts
+++ b/api/vm/compile.ts
@@ -71,15 +71,15 @@ export function listenForCompileRequest() {
   process.on("message", (compileConfig: dataform.ICompileConfig) => {
     try {
       const compiledResult = compile(compileConfig);
-      process.send(compiledResult);
+      process.send(compiledResult, () => process.exit());
     } catch (e) {
       const serializableError = {};
       for (const prop of Object.getOwnPropertyNames(e)) {
         (serializableError as any)[prop] = e[prop];
       }
       process.send(serializableError);
+      process.exit();
     }
-    process.exit();
   });
 }
 

--- a/version.bzl
+++ b/version.bzl
@@ -1,3 +1,3 @@
 # NOTE: If you change the format of this line, you must change the bash command
 # in /scripts/publish to extract the version string correctly.
-DF_VERSION = "1.17.1"
+DF_VERSION = "1.17.2"


### PR DESCRIPTION
[This PR](https://github.com/dataform-co/dataform/commit/2b3ef4c1b28ba0e129b52fe629539ae74e55d689) caused a conflict between socket on fd:4 and process.send.

Instead swap to just using `process.send` for all IPC.

