### PR TITLE
Add vars option to CLI

### DIFF
--- a/api/commands/compile.ts
+++ b/api/commands/compile.ts
@@ -28,14 +28,6 @@ export async function compile(
   // Resolve the path in case it hasn't been resolved already.
   path.resolve(compileConfig.projectDir);
 
-  // Create an empty projectConfigOverride if not set.
-  compileConfig = { projectConfigOverride: {}, ...compileConfig };
-
-  compileConfig.projectConfigOverride.vars = {
-    ...compileConfig.vars,
-    ...compileConfig.projectConfigOverride.vars
-  };
-
   // Schema overrides field can be set in two places, projectConfigOverride.schemaSuffix takes precedent.
   if (compileConfig.schemaSuffixOverride) {
     compileConfig.projectConfigOverride = {
@@ -48,7 +40,7 @@ export async function compile(
     // check dataformJson is valid before we try to compile
     const dataformJson = fs.readFileSync(`${compileConfig.projectDir}/dataform.json`, "utf8");
     const projectConfig = JSON.parse(dataformJson);
-    checkDataformJsonValidity(deepmerge(projectConfig, compileConfig.projectConfigOverride));
+    checkDataformJsonValidity(deepmerge(projectConfig, compileConfig.projectConfigOverride || {}));
   } catch (e) {
     throw new ErrorWithCause(
       `Compilation failed. ProjectConfig ('dataform.json') is invalid: ${e.message}`,

--- a/api/commands/compile.ts
+++ b/api/commands/compile.ts
@@ -31,6 +31,11 @@ export async function compile(
   // Create an empty projectConfigOverride if not set.
   compileConfig = { projectConfigOverride: {}, ...compileConfig };
 
+  compileConfig.projectConfigOverride.vars = {
+    ...compileConfig.vars,
+    ...compileConfig.projectConfigOverride.vars
+  };
+
   // Schema overrides field can be set in two places, projectConfigOverride.schemaSuffix takes precedent.
   if (compileConfig.schemaSuffixOverride) {
     compileConfig.projectConfigOverride = {

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -153,7 +153,8 @@ const varsOption: INamedOption<yargs.Options> = {
   name: "vars",
   option: {
     describe:
-      "Variables to inject that are exposed at compile and runtime via `dataform.projectConfig.vars.myVariableName`.",
+      "Variables to inject that are exposed at compile and runtime via `dataform.projectConfig.vars.myVariableName`.\n" +
+      "They should take the structure of '--vars=someKey:someValue,someOtherKey:someOtherValue'.",
     type: "string",
     default: null
   },
@@ -162,7 +163,7 @@ const varsOption: INamedOption<yargs.Options> = {
       parseVarOptions(argv.vars);
     } catch (e) {
       throw new Error(
-        "vars are in correct format. They should take the structure of '--vars=someKey:someValue,someOtherKey:someOtherValue'"
+        "vars are in an incorrect format. They should take the structure of '--vars=someKey:someValue,someOtherKey:someOtherValue'"
       );
     }
   }

--- a/protos/core.proto
+++ b/protos/core.proto
@@ -142,8 +142,6 @@ message CompileConfig {
   // Deprecated.
   string schema_suffix_override = 2;
   string return_override = 5;
-
-  map<string, string> vars = 8;
 }
 
 message Target {

--- a/protos/core.proto
+++ b/protos/core.proto
@@ -142,6 +142,8 @@ message CompileConfig {
   // Deprecated.
   string schema_suffix_override = 2;
   string return_override = 5;
+
+  map<string, string> vars = 8;
 }
 
 message Target {

--- a/sql/integration.spec.ts
+++ b/sql/integration.spec.ts
@@ -40,8 +40,7 @@ suite("builders", { parallel: true }, ({ before, after }) => {
 
   for (const { name, dbadapter, sql } of [
     { name: "bigquery", dbadapter: () => bigquery, sql: new Sql("standard") },
-    { name: "snowflake", dbadapter: () => snowflake, sql: new Sql("snowflake") },
-    { name: "redshift", dbadapter: () => redshift, sql: new Sql("redshift") }
+    { name: "snowflake", dbadapter: () => snowflake, sql: new Sql("snowflake") }
   ]) {
     suite(name, { parallel: true }, () => {
       const execute = async <S extends ISelectSchema>(select: ISelectOrBuilder<S>) => {

--- a/tests/cli/cli.spec.ts
+++ b/tests/cli/cli.spec.ts
@@ -50,7 +50,7 @@ suite(__filename, () => {
       filePath,
       `
 config { type: "table" }
-select 1 as test
+select 1 as \${dataform.projectConfig.vars.testVar2}
 `
     );
 
@@ -61,7 +61,7 @@ select 1 as test
         "compile",
         projectDir,
         "--json",
-        "--vars=testVar1:testValue1,testVar2:testValue2"
+        "--vars=testVar1=testValue1,testVar2=testValue2"
       ])
     );
 
@@ -82,7 +82,7 @@ select 1 as test
             name: "example",
             database: "dataform-integration-tests"
           },
-          query: "\n\nselect 1 as test\n",
+          query: "\n\nselect 1 as testValue2\n",
           disabled: false,
           fileName: "definitions/example.sqlx"
         }
@@ -118,7 +118,8 @@ select 1 as test
         "--credentials",
         "test_credentials/bigquery.json",
         "--dry-run",
-        "--json"
+        "--json",
+        "--vars=testVar1=testValue1,testVar2=testValue2"
       ])
     );
 
@@ -139,7 +140,7 @@ select 1 as test
           tasks: [
             {
               statement:
-                "create or replace table `dataform-integration-tests.dataform.example` as \n\nselect 1 as test",
+                "create or replace table `dataform-integration-tests.dataform.example` as \n\nselect 1 as testValue2",
               type: "statement"
             }
           ],
@@ -151,7 +152,11 @@ select 1 as test
         defaultDatabase: "dataform-integration-tests",
         defaultSchema: "dataform",
         useRunCache: false,
-        warehouse: "bigquery"
+        warehouse: "bigquery",
+        vars: {
+          testVar1: "testValue1",
+          testVar2: "testValue2"
+        }
       },
       runConfig: {
         fullRefresh: false,

--- a/tests/cli/cli.spec.ts
+++ b/tests/cli/cli.spec.ts
@@ -56,7 +56,13 @@ select 1 as test
 
     // Compile the project using the CLI.
     const compileResult = await getProcessResult(
-      execFile(nodePath, [cliEntryPointPath, "compile", projectDir, "--json"])
+      execFile(nodePath, [
+        cliEntryPointPath,
+        "compile",
+        projectDir,
+        "--json",
+        "--vars=testVar1:testValue1,testVar2:testValue2"
+      ])
     );
 
     expect(compileResult.exitCode).equals(0);
@@ -86,7 +92,11 @@ select 1 as test
         defaultSchema: "dataform",
         assertionSchema: "dataform_assertions",
         defaultDatabase: "dataform-integration-tests",
-        useRunCache: false
+        useRunCache: false,
+        vars: {
+          testVar1: "testValue1",
+          testVar2: "testValue2"
+        }
       },
       graphErrors: {},
       dataformCoreVersion: version,

--- a/version.bzl
+++ b/version.bzl
@@ -1,3 +1,3 @@
 # NOTE: If you change the format of this line, you must change the bash command
 # in /scripts/publish to extract the version string correctly.
-DF_VERSION = "1.17.2"
+DF_VERSION = "1.18.0"


### PR DESCRIPTION
Fixes https://github.com/dataform-co/dataform/issues/1175

Delimited vars with colons rather than more equals because I think it looks more clear.