### PR TITLE
Bump gcloud version to 318.0.0

### DIFF
--- a/tools/gcloud/repository_rules.bzl
+++ b/tools/gcloud/repository_rules.bzl
@@ -11,6 +11,6 @@ def _gcloud_sdk_impl(ctx):
 gcloud_sdk = repository_rule(
     implementation = _gcloud_sdk_impl,
     attrs = {
-        "version": attr.string(default = "293.0.0"),
+        "version": attr.string(default = "318.0.0"),
     },
 )


### PR DESCRIPTION
Fixes issues with `AttributeError: module 'importlib' has no attribute 'util'` when running on system using Python 3.9+.

This does now spit out the error

```
Error in atexit._run_exitfuncs:
...
ValueError: Could not find Python executable.
```

but it doesn't have an effect on actual running as it's an exit func