### PR TITLE
Enabling Application Default Credentials for BigQuery

### DIFF
--- a/api/dbadapters/bigquery.ts
+++ b/api/dbadapters/bigquery.ts
@@ -312,18 +312,15 @@ export class BigQueryDbAdapter implements IDbAdapter {
   private getClient(projectId?: string) {
     projectId = projectId || this.bigQueryCredentials.projectId;
     if (!this.clients.has(projectId)) {
-      let bigQueryOptions = {
-        projectId,
-        scopes: EXTRA_GOOGLE_SCOPES,
-        location: this.bigQueryCredentials.location,
-        credentials: <any>this.bigQueryCredentials.credentials,
-      };
-      if (bigQueryOptions.credentials !== "") {
-        bigQueryOptions.credentials = JSON.parse(this.bigQueryCredentials.credentials);
-      }
       this.clients.set(
         projectId,
-        new BigQuery(bigQueryOptions)
+        new BigQuery({
+          projectId,
+          scopes: EXTRA_GOOGLE_SCOPES,
+          location: this.bigQueryCredentials.location,
+          credentials: this.bigQueryCredentials.credentials &&
+                       JSON.parse(this.bigQueryCredentials.credentials)
+        })
       );
     }
     return this.clients.get(projectId);

--- a/api/dbadapters/bigquery.ts
+++ b/api/dbadapters/bigquery.ts
@@ -312,14 +312,18 @@ export class BigQueryDbAdapter implements IDbAdapter {
   private getClient(projectId?: string) {
     projectId = projectId || this.bigQueryCredentials.projectId;
     if (!this.clients.has(projectId)) {
+      let bigQueryOptions = {
+        projectId,
+        scopes: EXTRA_GOOGLE_SCOPES,
+        location: this.bigQueryCredentials.location,
+        credentials: <any>this.bigQueryCredentials.credentials,
+      };
+      if (bigQueryOptions.credentials !== "") {
+        bigQueryOptions.credentials = JSON.parse(this.bigQueryCredentials.credentials);
+      }
       this.clients.set(
         projectId,
-        new BigQuery({
-          projectId,
-          credentials: JSON.parse(this.bigQueryCredentials.credentials),
-          scopes: EXTRA_GOOGLE_SCOPES,
-          location: this.bigQueryCredentials.location
-        })
+        new BigQuery(bigQueryOptions)
       );
     }
     return this.clients.get(projectId);

--- a/cli/credentials.ts
+++ b/cli/credentials.ts
@@ -19,10 +19,9 @@ export function getBigQueryCredentials(): dataform.IBigQuery {
     "JSON Key"
   ]);
   if (isApplicationDefaultOrJSONKeyIndex === 0)  {
-    const projectId = question("Enter your billing project:");
+    const projectId = question("Enter your billing project ID:");
     return {
       projectId: projectId,
-      credentials: "",
       location
     }
   }

--- a/cli/credentials.ts
+++ b/cli/credentials.ts
@@ -5,6 +5,27 @@ import { actuallyResolve } from "df/cli/util";
 import { dataform } from "df/protos/ts";
 
 export function getBigQueryCredentials(): dataform.IBigQuery {
+  const locationIndex = selectionQuestion("Enter the location of your datasets:", [
+    "US (default)",
+    "EU",
+    "other"
+  ]);
+  let location = locationIndex === 0 ? "US" : "EU";
+  if (locationIndex === 2) {
+    location = question("Enter the location's region name (e.g. 'asia-south1'):");
+  }
+  const isApplicationDefaultOrJSONKeyIndex = selectionQuestion("Do you wish to use Application Default Credentials or JSON Key:", [
+    "ADC (default)",
+    "JSON Key"
+  ]);
+  if (isApplicationDefaultOrJSONKeyIndex === 0)  {
+    const projectId = question("Enter your billing project:");
+    return {
+      projectId: projectId,
+      credentials: "",
+      location
+    }
+  }
   const cloudCredentialsPath = actuallyResolve(
     question(
       "Please follow the instructions at https://docs.dataform.co/dataform-cli#create-a-credentials-file/\n" +
@@ -17,15 +38,6 @@ export function getBigQueryCredentials(): dataform.IBigQuery {
     throw new Error(`Google Cloud private key file "${cloudCredentialsPath}" does not exist!`);
   }
   const cloudCredentials = JSON.parse(fs.readFileSync(cloudCredentialsPath, "utf8"));
-  const locationIndex = selectionQuestion("Enter the location of your datasets:", [
-    "US (default)",
-    "EU",
-    "other"
-  ]);
-  let location = locationIndex === 0 ? "US" : "EU";
-  if (locationIndex === 2) {
-    location = question("Enter the location's region name (e.g. 'asia-south1'):");
-  }
   return {
     projectId: cloudCredentials.project_id,
     credentials: fs.readFileSync(cloudCredentialsPath, "utf8"),

--- a/cli/credentials.ts
+++ b/cli/credentials.ts
@@ -21,7 +21,7 @@ export function getBigQueryCredentials(): dataform.IBigQuery {
   if (isApplicationDefaultOrJSONKeyIndex === 0)  {
     const projectId = question("Enter your billing project ID:");
     return {
-      projectId: projectId,
+      projectId,
       location
     }
   }

--- a/content/docs/getting-started-tutorial/set-up.md
+++ b/content/docs/getting-started-tutorial/set-up.md
@@ -33,7 +33,15 @@ For this this tutorial we’ll use BigQuery. Anyone with a Google Account can us
 
 ## Generate warehouse credentials
 
-In order for Dataform to connect to your BigQuery warehouse you’ll need to generate some credentials. Dataform will connect to BigQuery using a service account. You’ll need to create a service account from your Google Cloud Console and assign it permissions to access BigQuery.
+In order for Dataform to connect to your BigQuery warehouse you’ll need to use Application Default Credentials or a service account and JSON key.
+
+### Using Application Default Credentials
+
+If running on GCE or GKE this will be automatically available. If not, then use `[gcloud auth application-default](https://cloud.google.com/sdk/gcloud/reference/auth/application-default)` to authenticate.
+
+### Create a service account with JSON key
+
+You’ll need to create a service account from your Google Cloud Console and assign it permissions to access BigQuery.
 
 1. To create a new service account in Google Cloud Console you need to:
 

--- a/content/docs/warehouses/bigquery.md
+++ b/content/docs/warehouses/bigquery.md
@@ -1,12 +1,20 @@
 ---
 title: Google BigQuery
-subtitle: Authentification, configuration options, and content for BigQuery.
+subtitle: Authentication, configuration options, and content for BigQuery.
 priority: 1
 ---
 
-## Authentification
+## Authentication
 
-Dataform will connect to BigQuery using a service account. You’ll need to create a service account from your Google Cloud Console and assign it permissions to access BigQuery.
+Dataform will connect to BigQuery using Application Default Credentials or using a service account.
+
+### Application Default Credentials
+
+If using Application Default Credentials ensure that the service account or user has `BigQuery Admin` role or equivalent. (Dataform requires access to create queries and list tables.) Read <a target="_blank" rel="noopener" href="https://cloud.google.com/iam/docs/granting-roles-to-service-accounts#granting_access_to_a_service_account_for_a_resource">this</a> if you need help.
+
+### Service Account
+
+You’ll need to create a service account from your Google Cloud Console and assign it permissions to access BigQuery.
 
 1. Follow <a target="_blank" rel="noopener" href="https://cloud.google.com/iam/docs/creating-managing-service-accounts#creating_a_service_account">these instructions</a> to create a new service account in Google Cloud Console.
 2. Grant the new account the `BigQuery Admin` role. (Admin access is required by Dataform so that it can create queries and list tables.) Read

--- a/content/docs/warehouses/bigquery.md
+++ b/content/docs/warehouses/bigquery.md
@@ -17,7 +17,7 @@ If using Application Default Credentials ensure that the service account or user
 You’ll need to create a service account from your Google Cloud Console and assign it permissions to access BigQuery.
 
 1. Follow <a target="_blank" rel="noopener" href="https://cloud.google.com/iam/docs/creating-managing-service-accounts#creating_a_service_account">these instructions</a> to create a new service account in Google Cloud Console.
-2. Grant the new account the `BigQuery Admin` role. (Admin access is required by Dataform so that it can create queries and list tables.) Read
+2. Grant the new account the `BigQuery Admin` role. (Admin access is required by Dataform so that it can create datasets and list tables.) Read
    <a target="_blank" rel="noopener" href="https://cloud.google.com/iam/docs/granting-roles-to-service-accounts#granting_access_to_a_service_account_for_a_resource">this</a> if you need help.
 3. Create a key for your new service account (in JSON format). You will upload this file to Dataform. Read
    <a target="_blank" rel="noopener" href="https://cloud.google.com/iam/docs/creating-managing-service-account-keys#creating_service_account_keys">this</a> if you need help.

--- a/core/adapters/index.ts
+++ b/core/adapters/index.ts
@@ -50,8 +50,7 @@ export function supportsCancel(warehouseType: WarehouseType) {
 }
 
 const requiredBigQueryWarehouseProps: Array<keyof dataform.IBigQuery> = [
-  "projectId",
-  "credentials"
+  "projectId"
 ];
 const requiredJdbcWarehouseProps: Array<keyof dataform.IJDBC> = [
   "host",

--- a/protos/profiles.proto
+++ b/protos/profiles.proto
@@ -43,6 +43,7 @@ message Snowflake {
 
 message BigQuery {
   string project_id = 1;
+  // If credentials are unset, then the library will use the application default credentials
   string credentials = 3;
   // Options are listed here: https://cloud.google.com/bigquery/docs/locations
   string location = 4;

--- a/tests/api/api.spec.ts
+++ b/tests/api/api.spec.ts
@@ -930,7 +930,7 @@ select \${foo}
       );
     });
 
-    [{}, { wrongProperty: "" }, { projectId: "" }].forEach(bigquery => {
+    [{}, { wrongProperty: ""}].forEach(bigquery => {
       test("bigquery_properties_check", () => {
         expect(() =>
           credentials.coerce("bigquery", JSON.parse(JSON.stringify(bigquery)))

--- a/version.bzl
+++ b/version.bzl
@@ -1,3 +1,3 @@
 # NOTE: If you change the format of this line, you must change the bash command
 # in /scripts/publish to extract the version string correctly.
-DF_VERSION = "1.18.0"
+DF_VERSION = "1.19.0"


### PR DESCRIPTION
This does the following -
 - Prompt the user whether they want to use application default credentials or JSON key
 - If ADC, then only the projectId is requested (for billing) and credentials are an empty string
 - On BigQuery() connection creation, credentials are left as empty string (use ADC) and otherwise JSON parsed.

This has been tested successfully by hand using ADC. The unit tests fail due to permission denied decrypting a key.