### PR TITLE
Adds error handling when query statement is empty

### DIFF
--- a/api/dbadapters/bigquery.ts
+++ b/api/dbadapters/bigquery.ts
@@ -66,6 +66,10 @@ export class BigQueryDbAdapter implements IDbAdapter {
     if (options?.interactive && options?.bigquery?.labels) {
       throw new Error("BigQuery job labels may not be set for interactive queries.");
     }
+
+    if (!statement) {
+      throw new Error("Query string cannot be empty");
+    }
     return this.pool
       .addSingleTask({
         generator: () =>


### PR DESCRIPTION
If I throw an error in the BQ adapter then I assume we correctly handle it, as opposed to an uncaught exception.