### PR TITLE
remove BQ audit logs package from docs

### DIFF
--- a/docs/content_tree.ts
+++ b/docs/content_tree.ts
@@ -53,11 +53,6 @@ async function getPackageTrees(): Promise<Array<Tree<IExtraAttributes>>> {
       },
       {
         owner: "dataform-co",
-        repo: "dataform-bq-audit-logs",
-        title: "BigQuery Audit Logs"
-      },
-      {
-        owner: "dataform-co",
         repo: "dataform-scd",
         title: "Slowly changing dimensions"
       },


### PR DESCRIPTION
The audit logs package is no longer necessary since the release of jobs information schema on BigQuery: https://cloud.google.com/bigquery/docs/information-schema-jobs