### PR TITLE
Remove @dataform/core's dependency on NodeJS

### DIFF
--- a/cli/index.ts
+++ b/cli/index.ts
@@ -361,7 +361,7 @@ export function runCli() {
             const compiledGraph = await compile({
               projectDir,
               schemaSuffixOverride,
-              projectConfigOverride: { vars },
+              projectConfigOverride: { vars }
             });
             printCompiledGraph(compiledGraph, argv.json);
             if (compiledGraphHasErrors(compiledGraph)) {

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -361,7 +361,7 @@ export function runCli() {
             const compiledGraph = await compile({
               projectDir,
               schemaSuffixOverride,
-              projectConfigOverride: { vars }
+              projectConfigOverride: { vars },
             });
             printCompiledGraph(compiledGraph, argv.json);
             if (compiledGraphHasErrors(compiledGraph)) {

--- a/common/protos/BUILD
+++ b/common/protos/BUILD
@@ -10,7 +10,6 @@ ts_library(
     deps = [
         "//:modules-fix",
         "//common/strings",
-        "@npm//@types/node",
         "@npm//protobufjs",
     ],
 )

--- a/core/BUILD
+++ b/core/BUILD
@@ -27,7 +27,6 @@ ts_library(
         "//common/strings",
         "//protos:ts",
         "//sqlx",
-        "@npm//@types/node",
         "@npm//@types/semver",
         "@npm//protobufjs",
         "@npm//semver",

--- a/core/index.ts
+++ b/core/index.ts
@@ -16,7 +16,7 @@ export { adapters };
 // be the same, regardless of the @dataform/core package that is running.
 function globalSession() {
   if (!(global as any)._DF_SESSION) {
-    (global as any)._DF_SESSION = new Session(process.cwd());
+    (global as any)._DF_SESSION = new Session();
   }
   return (global as any)._DF_SESSION as Session;
 }

--- a/core/session.ts
+++ b/core/session.ts
@@ -66,7 +66,7 @@ export class Session {
   public graphErrors: dataform.IGraphErrors;
 
   constructor(
-    rootDir: string,
+    rootDir?: string,
     projectConfig?: dataform.IProjectConfig,
     originalProjectConfig?: dataform.IProjectConfig
   ) {

--- a/core/utils.ts
+++ b/core/utils.ts
@@ -1,5 +1,3 @@
-import * as path from "path";
-
 import { adapters } from "df/core";
 import { Assertion } from "df/core/assertion";
 import { Resolvable } from "df/core/common";
@@ -9,12 +7,19 @@ import { IActionProto, Session } from "df/core/session";
 import { Table } from "df/core/table";
 import { dataform } from "df/protos/ts";
 
+const pathSeperator = (() => {
+  if (typeof process !== "undefined") {
+    return process.platform === "win32" ? "\\" : "/";
+  }
+  return "/";
+})();
+
 function relativePath(fullPath: string, base: string) {
   if (base.length === 0) {
     return fullPath;
   }
   const stripped = fullPath.substr(base.length);
-  if (stripped.startsWith(path.sep)) {
+  if (stripped.startsWith(pathSeperator)) {
     return stripped.substr(1);
   } else {
     return stripped;
@@ -22,7 +27,10 @@ function relativePath(fullPath: string, base: string) {
 }
 
 export function baseFilename(fullPath: string) {
-  return path.basename(fullPath).split(".")[0];
+  return fullPath
+    .split(pathSeperator)
+    .slice(-1)[0]
+    .split(".")[0];
 }
 
 export function matchPatterns(patterns: string[], values: string[]) {
@@ -65,8 +73,8 @@ export function getCallerFile(rootDir: string) {
     lastfile = nextLastfile;
     if (
       !(
-        nextLastfile.includes(`definitions${path.sep}`) ||
-        nextLastfile.includes(`models${path.sep}`)
+        nextLastfile.includes(`definitions${pathSeperator}`) ||
+        nextLastfile.includes(`models${pathSeperator}`)
       )
     ) {
       continue;

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "jsdoc": "^3.6.7",
     "json-stable-stringify": "^1.0.1",
     "lodash": "^4.17.21",
+    "long": "^4.0.0",
     "minimist": "^1.2.3",
     "moo": "^0.5.0",
     "mssql": "^7.1.0",

--- a/packages/@dataform/cli/BUILD
+++ b/packages/@dataform/cli/BUILD
@@ -77,6 +77,7 @@ pkg_bundle(
     name = "bundle",
     args = ["--banner='#!/usr/bin/env node'"],
     entry_point = "index.ts",
+    allow_node_builtins = True,
     externals = externals,
     deps = [
         ":cli",
@@ -87,6 +88,7 @@ pkg_bundle(
     name = "worker_bundle",
     args = ["--banner='#!/usr/bin/env node'"],
     entry_point = "worker.ts",
+    allow_node_builtins = True,
     externals = externals,
     deps = [
         ":cli",

--- a/packages/@dataform/core/BUILD
+++ b/packages/@dataform/core/BUILD
@@ -17,6 +17,7 @@ externals = [
     "tarjan-graph",
     "semver",
     "moo",
+    "long",
 ]
 
 pkg_json(

--- a/packages/index.bzl
+++ b/packages/index.bzl
@@ -27,10 +27,13 @@ def pkg_json(name, package_name, description, version, external_deps = [], layer
         ),
     )
 
-def pkg_bundle(deps, externals, args = [], **kwargs):
+def pkg_bundle(deps, externals, allow_node_builtins = False, args = [], **kwargs):
+    base_args = ["--external={}".format(",".join(externals))]
+    if allow_node_builtins:
+        base_args.append("--environment=ALLOW_NODE_BUILTINS")
     rollup_bundle(
         config_file = "//packages:rollup.config.js",
-        args = ["--external={}".format(",".join(externals))] + args,
+        args = base_args + args,
         format = "cjs",
         sourcemap = "false",
         deps = [

--- a/packages/rollup.config.js
+++ b/packages/rollup.config.js
@@ -1,7 +1,16 @@
 import resolve from "@rollup/plugin-node-resolve";
 
+function convertToRegex(pattern) {
+  if (pattern instanceof RegExp) {
+    return pattern;
+  }
+  // If it's a string, turn it into a regex, by escaping any regex characters in the string.
+  const normalized = pattern.replace(/[\\^$*+?.()|[\]{}]/g, "\\$&");
+  return new RegExp(`^${normalized}$`);
+}
+
 // Add new node built ins here if they are used.
-const knownBuiltIns = [
+const knownNodeBuiltins = [
   "path",
   "fs",
   "os",
@@ -12,22 +21,16 @@ const knownBuiltIns = [
   "long",
   "https",
   "net"
-];
+].map(moduleName => convertToRegex(moduleName));
 
 const importsToBundle = ["df", /df\/.*$/, /^bazel\-.*$/];
 
 const checkImports = imports => {
-  const allowedImports = [...imports, ...knownBuiltIns].map(pattern => {
-    if (pattern instanceof RegExp) {
-      return pattern;
-    }
-    // If it's a string, turn it into a regex, by escaping any regex characters in the string.
-    const normalized = pattern.replace(/[\\^$*+?.()|[\]{}]/g, "\\$&");
-    return new RegExp(`^${normalized}$`);
-  });
+  const allowedImports = [...imports].map(pattern => convertToRegex(pattern));
 
   // We're going to read these from the arguments.
   let externals = [];
+  let allowNodeBuiltins = process.env.ALLOW_NODE_BUILTINS;
 
   return {
     buildStart(options) {
@@ -37,7 +40,8 @@ const checkImports = imports => {
       // Either this is an internal import, or explicitly listed in externals or we fail.
       if (
         allowedImports.some(pattern => pattern.test(source)) ||
-        externals.some(external => source === external || source.startsWith(`${external}/`))
+        externals.some(external => source === external || source.startsWith(`${external}/`)) ||
+        (allowNodeBuiltins && knownNodeBuiltins.some(pattern => pattern.test(source)))
       ) {
         return null;
       }


### PR DESCRIPTION
- Make sure there are no known NodeJS built-ins being used when bundling the core package with rollup.
- Add a replacement for our usage of `basename` and `sep` from the `path`  built in module that works outside of Node environments.