### PR TITLE
Add new targets utility functions before remove name & dependency fields

### DIFF
--- a/core/targets.ts
+++ b/core/targets.ts
@@ -1,0 +1,32 @@
+import { JSONObjectStringifier } from "df/common/strings/stringifier";
+import { dataform } from "df/protos/ts";
+
+/**
+ * Produces an unambigous mapping to and from a string representation.
+ */
+export const targetStringifier = JSONObjectStringifier.create<dataform.ITarget>();
+
+/**
+ * Returns true if both targets are equal.
+ */
+export function targetsAreEqual(a: dataform.ITarget, b: dataform.ITarget) {
+  return a.database === b.database && a.schema === b.schema && a.name === b.name;
+}
+
+/**
+ * Provides a readable string representation of the target which is used for e.g. specifying
+ * actions on the CLI or as part of schedule configs.
+ * This is effectively equivelant to an action "name".
+ * 
+ * This is an ambiguous transformation, multiple targets may map to the same string
+ * and it should not be used for indexing. Use {@code targetStringifier} instead.
+ */
+export function targetAsReadableString(
+  target: dataform.ITarget
+): string {
+  const nameParts = [target.name, target.schema];
+  if (!!target.database) {
+    nameParts.push(target.database);
+  }
+  return nameParts.reverse().join(".");
+}


### PR DESCRIPTION
This will replace `utils.targetToName` and will be used by dataform web before the original code and the proto fields themselves are removed in: https://github.com/dataform-co/dataform/pull/1278