### PR TITLE
Add new parameters runnerNotificationPeriodMillis to the run API

### DIFF
--- a/api/commands/run.ts
+++ b/api/commands/run.ts
@@ -22,7 +22,7 @@ export interface IExecutedAction {
   executionAction: dataform.IExecutionAction;
   actionResult: dataform.IActionResult;
 }
-// dummy comment
+
 export function run(
   dbadapter: dbadapters.IDbAdapter,
   graph: dataform.IExecutionGraph,

--- a/api/commands/run.ts
+++ b/api/commands/run.ts
@@ -22,7 +22,7 @@ export interface IExecutedAction {
   executionAction: dataform.IExecutionAction;
   actionResult: dataform.IActionResult;
 }
-//dummy comment
+
 export function run(
   dbadapter: dbadapters.IDbAdapter,
   graph: dataform.IExecutionGraph,

--- a/api/commands/run.ts
+++ b/api/commands/run.ts
@@ -22,7 +22,7 @@ export interface IExecutedAction {
   executionAction: dataform.IExecutionAction;
   actionResult: dataform.IActionResult;
 }
-
+// dummy comment
 export function run(
   dbadapter: dbadapters.IDbAdapter,
   graph: dataform.IExecutionGraph,

--- a/api/commands/run.ts
+++ b/api/commands/run.ts
@@ -10,7 +10,7 @@ import { targetsAreEqual, targetStringifier } from "df/core/targets";
 import { dataform } from "df/protos/ts";
 
 const CANCEL_EVENT = "jobCancel";
-let flags = {
+const flags = {
   runnerNotificationPeriodMillis: Flags.number("runner-notification-period-millis", 5000)
 };
 

--- a/api/commands/run.ts
+++ b/api/commands/run.ts
@@ -22,7 +22,7 @@ export interface IExecutedAction {
   executionAction: dataform.IExecutionAction;
   actionResult: dataform.IActionResult;
 }
-
+//dummy comment
 export function run(
   dbadapter: dbadapters.IDbAdapter,
   graph: dataform.IExecutionGraph,


### PR DESCRIPTION
Adding a new parameters to the run API:

runnerNotificationPeriodMillis (default: 5000): This optional parameter takes in the number of milliseconds the runner should wait before pushing the next run's result in order to reduce noise.

This is useful when we to stream and visualize a run's result as each action begins running.