### PR TITLE
overwrite filter strategy

### DIFF
--- a/core/adapters/bigquery.ts
+++ b/core/adapters/bigquery.ts
@@ -94,7 +94,7 @@ export class BigQueryAdapter extends Adapter implements IAdapter {
     }
     if (table.bigquery && table.bigquery.partitionBy && table.bigquery.requirePartitionFilter){
       options.push(`require_partition_filter=${table.bigquery.requirePartitionFilter}`)
-    }  
+    }
     if(table.bigquery && table.bigquery.additionalOptions){
       for(const [optionName, optionValue] of Object.entries(table.bigquery.additionalOptions)){
         options.push(`${optionName}=${optionValue}`)
@@ -102,7 +102,7 @@ export class BigQueryAdapter extends Adapter implements IAdapter {
     }
 
     return `create or replace ${
-      table.materialized 
+      table.materialized
       ? "materialized "
       : ""
     }${this.tableTypeAsSql(

--- a/protos/core.proto
+++ b/protos/core.proto
@@ -179,6 +179,8 @@ message Table {
   string where = 8 [deprecated = true];
   string incremental_query = 26;
   repeated string unique_key = 30;
+  string strategy = 36;
+  string overwrite_filter = 37;
 
   // Pre/post operations.
   repeated string pre_ops = 13;

--- a/tests/cli/cli.spec.ts
+++ b/tests/cli/cli.spec.ts
@@ -48,8 +48,8 @@ suite(__filename, () => {
     fs.ensureFileSync(filePath);
     fs.writeFileSync(
       filePath,
-      `
-config { type: "table" }
+      `config { type: "table", schema: \`\${dataform.projectConfig.vars.testVar1}\` }
+
 select 1 as \${dataform.projectConfig.vars.testVar2}
 `
     );
@@ -73,11 +73,11 @@ select 1 as \${dataform.projectConfig.vars.testVar2}
           type: "table",
           target: {
             database: "dataform-integration-tests",
-            schema: "dataform",
+            schema: "testValue1",
             name: "example"
           },
           canonicalTarget: {
-            schema: "dataform",
+            schema: "testValue1",
             name: "example",
             database: "dataform-integration-tests"
           },
@@ -102,7 +102,7 @@ select 1 as \${dataform.projectConfig.vars.testVar2}
       targets: [
         {
           database: "dataform-integration-tests",
-          schema: "dataform",
+          schema: "testValue1",
           name: "example"
         }
       ]
@@ -133,7 +133,7 @@ select 1 as \${dataform.projectConfig.vars.testVar2}
           target: {
             database: "dataform-integration-tests",
             name: "example",
-            schema: "dataform"
+            schema: "testValue1"
           },
           tasks: [
             {


### PR DESCRIPTION
Goal - Bring more flexibility/strategies into incremental models. updatePartitionFilter is not enough.
Additional insert-overwrite strategy with DML (delete) before model execution. Delete statement should select partitions dynamically or based on static input. 

Why it's needed:
Customers are calculating expensive aggregates. Sometimes there are  no unique keys in input and output - incremental model is append only and leveraging pre-statement is error prone. 

Solution suggested:
Adapter for incremental tables should support:
- Append only (especially if no keys are provided)
- Merge statement if keys are provided
- Insert overwrite via delete from and insert

Partitioning should not be enforced, some SCD tables, like in data vault can be clustered only. 

Insert overwrite strategy allows setting a overwrite_filter:
-  Default (empty) - when partition_by is used, then there will be DML invoked that is running DELETE from based on columns used with partition_by, otherwise it will fail
- Custom like overwrite_filter = "current_date()" or  overwrite_filter=`${dataform.projectConfig.vars.date}`




