### PR TITLE
Add ignore js flag to format subcommand

### DIFF
--- a/cli/index.ts
+++ b/cli/index.ts
@@ -220,6 +220,8 @@ const runTestsOptionName = "run-tests";
 const schemaOptionName = "schema";
 const tableOptionName = "table";
 
+const fmtIgnoreJsOptionName = "ignore-js-files"
+
 const getCredentialsPath = (projectDir: string, credentialsPath: string) =>
   actuallyResolve(credentialsPath || path.join(projectDir, CREDENTIALS_FILENAME));
 
@@ -683,9 +685,18 @@ export function runCli() {
         format: `format [${projectDirMustExistOption.name}]`,
         description: "Format the dataform project's files.",
         positionalOptions: [projectDirMustExistOption],
-        options: [],
+        options: [
+          {
+            name: fmtIgnoreJsOptionName,
+            option: {
+              describe: "If set, the formatter will not consider javascript files (.js)",
+              type: "boolean"
+            }
+          }
+        ],
         processFn: async argv => {
-          const filenames = glob.sync("{definitions,includes}/**/*.{js,sqlx}", {
+          const extensions = argv[fmtIgnoreJsOptionName] ? "*.sqlx" : '*.{js,sqlx}'
+          const filenames = glob.sync(`{definitions,includes}/**/${extensions}`, {
             cwd: argv[projectDirMustExistOption.name]
           });
           const results = await Promise.all(


### PR DESCRIPTION
Hello

I figured this option may come in handy for users who have different linting/formatting rules for their javascript files but still want to leverage the `sqlx` formatter. (Which is the case for us)

I took a look at `/tests/sqlx/format.spec.ts` and the other files in general to see if there was somewhere I could add tests to but didn't find anything obvious. The file that I'm mentioning seems to specifically test the formatting output and not how the cli calls it. If we need to include tests for this addition, please point me in the right direction and I'll do the needful  