### PR TITLE
Refactored name() function to finalize name

### DIFF
--- a/core/assertion.ts
+++ b/core/assertion.ts
@@ -187,7 +187,9 @@ export class AssertionContext implements ICommonContext {
   }
 
   public name(): string {
-    return this.assertion.proto.target.name;
+    return this.assertion.session.finalizeName(
+      this.assertion.proto.target.name
+    );
   }
 
   public ref(ref: Resolvable | string[], ...rest: string[]) {

--- a/core/operation.ts
+++ b/core/operation.ts
@@ -219,7 +219,9 @@ export class OperationContext implements ICommonContext {
   }
 
   public name(): string {
-    return this.operation.proto.target.name;
+    return this.operation.session.finalizeName(
+      this.operation.proto.target.name
+    );
   }
 
   public ref(ref: Resolvable | string[], ...rest: string[]) {

--- a/core/table.ts
+++ b/core/table.ts
@@ -772,7 +772,9 @@ export class TableContext implements ITableContext {
   }
 
   public name(): string {
-    return this.table.proto.target.name;
+    return this.table.session.finalizeName(
+      this.table.proto.target.name
+    );
   }
 
   public ref(ref: Resolvable | string[], ...rest: string[]): string {


### PR DESCRIPTION
* Refactored instances of `name()` to use the newly added `finalize*()` methods in `Session`
* Added corresponding tests

Fixes #1436 