### PR TITLE
fix missing include dependents option for `run`

### DIFF
--- a/cli/index.ts
+++ b/cli/index.ts
@@ -562,6 +562,7 @@ export function runCli() {
           actionsOption,
           tagsOption,
           includeDepsOption,
+          includeDependentsOption,
           schemaSuffixOverrideOption,
           credentialsOption,
           jsonOutputOption,

--- a/version.bzl
+++ b/version.bzl
@@ -1,3 +1,3 @@
 # NOTE: If you change the format of this line, you must change the bash command
 # in /scripts/publish to extract the version string correctly.
-DF_VERSION = "1.22.1"
+DF_VERSION = "1.22.2"


### PR DESCRIPTION
I noticed this option was missing from the help output. 

I tried running the tests as per the guide but I got back a parsing error for `bazel test` . I'm reading docs to see what I'm doing wrong, and I'll update this PR as needed
