### PR TITLE
fix missing include dependents

### DIFF
--- a/cli/index.ts
+++ b/cli/index.ts
@@ -569,6 +569,7 @@ export function runCli() {
           actionsOption,
           tagsOption,
           includeDepsOption,
+          includeDependentsOption,
           schemaSuffixOverrideOption,
           credentialsOption,
           jsonOutputOption,

--- a/version.bzl
+++ b/version.bzl
@@ -1,3 +1,3 @@
 # NOTE: If you change the format of this line, you must change the bash command
 # in /scripts/publish to extract the version string correctly.
-DF_VERSION = "2.3.1"
+DF_VERSION = "2.3.2"


### PR DESCRIPTION
I noticed this option was missing from the help output.