### PR TITLE
Adds a flag 'track' to allow users to configure analytics with flags

### DIFF
--- a/cli/analytics.ts
+++ b/cli/analytics.ts
@@ -17,6 +17,7 @@ export const noTrackOption: INamedOption<yargs.Options> = {
 const analytics = new Analytics("eR24ln3MniE3TKZXkvAkOGkiSN02xXqw");
 
 let currentCommand: string;
+let allowAnonymousAnalytics: boolean;
 
 export async function maybeConfigureAnalytics(noTrack: boolean) {
   const settings = await getConfigSettings();
@@ -25,13 +26,11 @@ export async function maybeConfigureAnalytics(noTrack: boolean) {
     return;
   }
   if (settings.allowAnonymousAnalytics !== undefined) {
+    allowAnonymousAnalytics = settings.allowAnonymousAnalytics;
     return;
   }
   if (noTrack) {
-    await upsertConfigSettings({
-      allowAnonymousAnalytics: false,
-      anonymousUserId: uuidv4()
-    });
+    allowAnonymousAnalytics = false;
     return;
   }
 
@@ -47,12 +46,13 @@ Would you like to opt-in to anonymous usage and error tracking?`,
     allowAnonymousAnalytics: optInResponse,
     anonymousUserId: uuidv4()
   });
+  allowAnonymousAnalytics = optInResponse;
 }
 
 export async function trackCommand(command: string) {
   currentCommand = command;
   const config = await getConfigSettings();
-  if (!config.allowAnonymousAnalytics) {
+  if (!allowAnonymousAnalytics) {
     return;
   }
   await new Promise(resolve => {
@@ -74,7 +74,7 @@ export async function trackCommand(command: string) {
 
 export async function trackError() {
   const config = await getConfigSettings();
-  if (!config.allowAnonymousAnalytics) {
+  if (!allowAnonymousAnalytics) {
     return;
   }
   await new Promise(resolve => {

--- a/cli/analytics.ts
+++ b/cli/analytics.ts
@@ -1,9 +1,10 @@
-import Analytics from "analytics-node";
-import { getConfigSettings, getConfigSettingsPath, upsertConfigSettings } from "df/cli/config";
-import { ynQuestion } from "df/cli/console";
-import {INamedOption} from "df/cli/yargswrapper";
-import { v4 as uuidv4 } from "uuid";
 import yargs from "yargs";
+
+import Analytics from "analytics-node";
+import {getConfigSettings, getConfigSettingsPath, upsertConfigSettings} from "df/cli/config";
+import {ynQuestion} from "df/cli/console";
+import {INamedOption} from "df/cli/yargswrapper";
+import {v4 as uuidv4} from "uuid";
 
 export const noTrackOption: INamedOption<yargs.Options> = {
   name: "no-track",

--- a/cli/analytics.ts
+++ b/cli/analytics.ts
@@ -20,7 +20,7 @@ let currentCommand: string;
 let allowAnonymousAnalytics: boolean;
 let anonymousUserId: string;
 
-export async function maybeConfigureAnalytics(track: boolean) {
+export async function maybeConfigureAnalytics(track?: boolean) {
   const settings = await getConfigSettings();
   if (track !== undefined) {
     allowAnonymousAnalytics = track;

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -8,7 +8,7 @@ import { build, compile, credentials, init, install, run, table, test } from "df
 import { CREDENTIALS_FILENAME } from "df/api/commands/credentials";
 import * as dbadapters from "df/api/dbadapters";
 import { prettyJsonStringify } from "df/api/utils";
-import {trackError, noTrackOption} from "df/cli/analytics";
+import {noTrackOption, trackError} from "df/cli/analytics";
 import {
   print,
   printCompiledGraph,

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -8,7 +8,7 @@ import { build, compile, credentials, init, install, run, table, test } from "df
 import { CREDENTIALS_FILENAME } from "df/api/commands/credentials";
 import * as dbadapters from "df/api/dbadapters";
 import { prettyJsonStringify } from "df/api/utils";
-import {noTrackOption, trackError} from "df/cli/analytics";
+import {trackError, trackOption} from "df/cli/analytics";
 import {
   print,
   printCompiledGraph,
@@ -242,7 +242,7 @@ export function runCli() {
         description: "Create a new dataform project.",
         positionalOptions: [warehouseOption, projectDirOption],
         options: [
-          noTrackOption,
+          trackOption,
           {
             name: defaultDatabaseOptionName,
             option: {
@@ -317,7 +317,7 @@ export function runCli() {
         format: `install [${projectDirMustExistOption.name}]`,
         description: "Install a project's NPM dependencies.",
         positionalOptions: [projectDirMustExistOption],
-        options: [noTrackOption],
+        options: [trackOption],
         processFn: async argv => {
           print("Installing NPM dependencies...\n");
           await install(argv[projectDirMustExistOption.name]);
@@ -330,7 +330,7 @@ export function runCli() {
         description: `Create a ${credentials.CREDENTIALS_FILENAME} file for Dataform to use when accessing your warehouse.`,
         positionalOptions: [warehouseOption, projectDirMustExistOption],
         options: [
-          noTrackOption,
+          trackOption,
           {
             name: testConnectionOptionName,
             option: {
@@ -417,7 +417,7 @@ export function runCli() {
           jsonOutputOption,
           varsOption,
           timeoutOption,
-          noTrackOption
+          trackOption
         ],
         processFn: async argv => {
           const projectDir = argv[projectDirMustExistOption.name];
@@ -506,7 +506,7 @@ export function runCli() {
         format: `test [${projectDirMustExistOption.name}]`,
         description: "Run the dataform project's unit tests on the configured data warehouse.",
         positionalOptions: [projectDirMustExistOption],
-        options: [credentialsOption, varsOption, timeoutOption, noTrackOption],
+        options: [credentialsOption, varsOption, timeoutOption, trackOption],
         processFn: async argv => {
           print("Compiling...\n");
           const compiledGraph = await compile({
@@ -578,7 +578,7 @@ export function runCli() {
           jsonOutputOption,
           varsOption,
           timeoutOption,
-          noTrackOption
+          trackOption
         ],
         processFn: async argv => {
           if (!argv[jsonOutputOption.name]) {
@@ -696,7 +696,7 @@ export function runCli() {
         format: `format [${projectDirMustExistOption.name}]`,
         description: "Format the dataform project's files.",
         positionalOptions: [projectDirMustExistOption],
-        options: [noTrackOption],
+        options: [trackOption],
         processFn: async argv => {
           const filenames = glob.sync("{definitions,includes}/**/*.{js,sqlx}", {
             cwd: argv[projectDirMustExistOption.name]
@@ -726,7 +726,7 @@ export function runCli() {
         format: `listtables <${warehouseOption.name}>`,
         description: "List tables on the configured data warehouse.",
         positionalOptions: [warehouseOption],
-        options: [credentialsOption, noTrackOption],
+        options: [credentialsOption, trackOption],
         processFn: async argv => {
           const readCredentials = credentials.read(
             argv[warehouseOption.name],
@@ -761,7 +761,7 @@ export function runCli() {
             }
           }
         ],
-        options: [credentialsOption, noTrackOption],
+        options: [credentialsOption, trackOption],
         processFn: async argv => {
           const readCredentials = credentials.read(
             argv[warehouseOption.name],

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -8,7 +8,7 @@ import { build, compile, credentials, init, install, run, table, test } from "df
 import { CREDENTIALS_FILENAME } from "df/api/commands/credentials";
 import * as dbadapters from "df/api/dbadapters";
 import { prettyJsonStringify } from "df/api/utils";
-import { trackError } from "df/cli/analytics";
+import {trackError, noTrackOption} from "df/cli/analytics";
 import {
   print,
   printCompiledGraph,
@@ -242,6 +242,7 @@ export function runCli() {
         description: "Create a new dataform project.",
         positionalOptions: [warehouseOption, projectDirOption],
         options: [
+          noTrackOption,
           {
             name: defaultDatabaseOptionName,
             option: {
@@ -316,7 +317,7 @@ export function runCli() {
         format: `install [${projectDirMustExistOption.name}]`,
         description: "Install a project's NPM dependencies.",
         positionalOptions: [projectDirMustExistOption],
-        options: [],
+        options: [noTrackOption],
         processFn: async argv => {
           print("Installing NPM dependencies...\n");
           await install(argv[projectDirMustExistOption.name]);
@@ -329,6 +330,7 @@ export function runCli() {
         description: `Create a ${credentials.CREDENTIALS_FILENAME} file for Dataform to use when accessing your warehouse.`,
         positionalOptions: [warehouseOption, projectDirMustExistOption],
         options: [
+          noTrackOption,
           {
             name: testConnectionOptionName,
             option: {
@@ -414,7 +416,8 @@ export function runCli() {
           schemaSuffixOverrideOption,
           jsonOutputOption,
           varsOption,
-          timeoutOption
+          timeoutOption,
+          noTrackOption
         ],
         processFn: async argv => {
           const projectDir = argv[projectDirMustExistOption.name];
@@ -503,7 +506,7 @@ export function runCli() {
         format: `test [${projectDirMustExistOption.name}]`,
         description: "Run the dataform project's unit tests on the configured data warehouse.",
         positionalOptions: [projectDirMustExistOption],
-        options: [credentialsOption, varsOption, timeoutOption],
+        options: [credentialsOption, varsOption, timeoutOption, noTrackOption],
         processFn: async argv => {
           print("Compiling...\n");
           const compiledGraph = await compile({
@@ -574,7 +577,8 @@ export function runCli() {
           credentialsOption,
           jsonOutputOption,
           varsOption,
-          timeoutOption
+          timeoutOption,
+          noTrackOption
         ],
         processFn: async argv => {
           if (!argv[jsonOutputOption.name]) {
@@ -692,7 +696,7 @@ export function runCli() {
         format: `format [${projectDirMustExistOption.name}]`,
         description: "Format the dataform project's files.",
         positionalOptions: [projectDirMustExistOption],
-        options: [],
+        options: [noTrackOption],
         processFn: async argv => {
           const filenames = glob.sync("{definitions,includes}/**/*.{js,sqlx}", {
             cwd: argv[projectDirMustExistOption.name]
@@ -722,7 +726,7 @@ export function runCli() {
         format: `listtables <${warehouseOption.name}>`,
         description: "List tables on the configured data warehouse.",
         positionalOptions: [warehouseOption],
-        options: [credentialsOption],
+        options: [credentialsOption, noTrackOption],
         processFn: async argv => {
           const readCredentials = credentials.read(
             argv[warehouseOption.name],
@@ -757,7 +761,7 @@ export function runCli() {
             }
           }
         ],
-        options: [credentialsOption],
+        options: [credentialsOption, noTrackOption],
         processFn: async argv => {
           const readCredentials = credentials.read(
             argv[warehouseOption.name],

--- a/cli/yargswrapper.ts
+++ b/cli/yargswrapper.ts
@@ -1,6 +1,6 @@
 import yargs from "yargs";
 
-import { maybeConfigureAnalytics, trackCommand } from "df/cli/analytics";
+import {maybeConfigureAnalytics, trackCommand, noTrackOption} from "df/cli/analytics";
 
 export interface ICli {
   commands: ICommand[];
@@ -28,7 +28,7 @@ export function createYargsCli(cli: ICli) {
       command.description,
       (yargsChainer: yargs.Argv) => createOptionsChain(yargsChainer, command),
       async (argv: { [argumentName: string]: any }) => {
-        await maybeConfigureAnalytics();
+        await maybeConfigureAnalytics(argv[noTrackOption.name]);
         const analyticsTrack = trackCommand(command.format.split(" ")[0]);
         const exitCode = await command.processFn(argv);
         let timer: NodeJS.Timer;

--- a/cli/yargswrapper.ts
+++ b/cli/yargswrapper.ts
@@ -1,6 +1,6 @@
 import yargs from "yargs";
 
-import {maybeConfigureAnalytics, trackCommand, noTrackOption} from "df/cli/analytics";
+import {maybeConfigureAnalytics, noTrackOption, trackCommand} from "df/cli/analytics";
 
 export interface ICli {
   commands: ICommand[];

--- a/cli/yargswrapper.ts
+++ b/cli/yargswrapper.ts
@@ -1,6 +1,6 @@
 import yargs from "yargs";
 
-import {maybeConfigureAnalytics, noTrackOption, trackCommand} from "df/cli/analytics";
+import {maybeConfigureAnalytics, trackCommand, trackOption} from "df/cli/analytics";
 
 export interface ICli {
   commands: ICommand[];
@@ -28,7 +28,7 @@ export function createYargsCli(cli: ICli) {
       command.description,
       (yargsChainer: yargs.Argv) => createOptionsChain(yargsChainer, command),
       async (argv: { [argumentName: string]: any }) => {
-        await maybeConfigureAnalytics(argv[noTrackOption.name]);
+        await maybeConfigureAnalytics(argv[trackOption.name]);
         const analyticsTrack = trackCommand(command.format.split(" ")[0]);
         const exitCode = await command.processFn(argv);
         let timer: NodeJS.Timer;

--- a/version.bzl
+++ b/version.bzl
@@ -1,3 +1,3 @@
 # NOTE: If you change the format of this line, you must change the bash command
 # in /scripts/publish to extract the version string correctly.
-DF_VERSION = "2.4.0"
+DF_VERSION = "2.4.1"


### PR DESCRIPTION
Usage: `dataform [command] --track=false`