### PR TITLE
Added enum for table's type field

### DIFF
--- a/api/commands/build.ts
+++ b/api/commands/build.ts
@@ -94,7 +94,7 @@ export class Builder {
     return {
       ...this.toPartialExecutionAction(table),
       type: "table",
-      tableType: table.type,
+      tableType: utils.tableEnumTypeToString(utils.tableTypeFromProto(table, true)),
       tasks: table.disabled
         ? []
         : this.adapter.publishTasks(table, runConfig, tableMetadata).build(),

--- a/api/commands/build.ts
+++ b/api/commands/build.ts
@@ -52,6 +52,7 @@ export class Builder {
       prunedGraph.projectConfig,
       prunedGraph.dataformCoreVersion || "1.0.0"
     );
+    prunedGraph.tables.forEach(utils.setOrValidateTableEnumType);
   }
 
   public build(): dataform.ExecutionGraph {
@@ -94,7 +95,7 @@ export class Builder {
     return {
       ...this.toPartialExecutionAction(table),
       type: "table",
-      tableType: utils.tableEnumTypeToString(utils.tableTypeFromProto(table, true)),
+      tableType: utils.tableTypeEnumToString(table.enumType),
       tasks: table.disabled
         ? []
         : this.adapter.publishTasks(table, runConfig, tableMetadata).build(),

--- a/api/commands/prune.ts
+++ b/api/commands/prune.ts
@@ -8,6 +8,7 @@ export function prune(
   compiledGraph: dataform.ICompiledGraph,
   runConfig: dataform.IRunConfig
 ): dataform.ICompiledGraph {
+  compiledGraph.tables.forEach(utils.setOrValidateTableEnumType);
   const includedActionNames = computeIncludedActionNames(compiledGraph, runConfig);
   return {
     ...compiledGraph,
@@ -28,7 +29,7 @@ function computeIncludedActionNames(
   runConfig: dataform.IRunConfig
 ): Set<string> {
   // Remove inline tables.
-  const filteredTables = compiledGraph.tables.filter(t => utils.tableTypeFromProto(t, false) !== dataform.TableType.INLINE);
+  const filteredTables = compiledGraph.tables.filter(t => t.enumType !== dataform.TableType.INLINE);
 
   // Union all tables, operations, assertions.
   const allActions: CompileAction[] = [].concat(

--- a/api/commands/prune.ts
+++ b/api/commands/prune.ts
@@ -28,7 +28,7 @@ function computeIncludedActionNames(
   runConfig: dataform.IRunConfig
 ): Set<string> {
   // Remove inline tables.
-  const filteredTables = compiledGraph.tables.filter(t => t.type !== "inline");
+  const filteredTables = compiledGraph.tables.filter(t => utils.tableTypeFromProto(t, false) !== dataform.TableType.INLINE);
 
   // Union all tables, operations, assertions.
   const allActions: CompileAction[] = [].concat(

--- a/cli/console.ts
+++ b/cli/console.ts
@@ -1,5 +1,6 @@
 import { IInitResult } from "df/api/commands/init";
 import { prettyJsonStringify } from "df/api/utils";
+import { tableEnumTypeToString, tableTypeFromProto } from "df/core/utils";
 import { dataform } from "df/protos/ts";
 import * as readlineSync from "readline-sync";
 
@@ -115,7 +116,7 @@ export function printCompiledGraph(graph: dataform.ICompiledGraph, verbose: bool
       writeStdOut(`${graph.tables.length} dataset(s):`);
       graph.tables.forEach(compiledTable => {
         writeStdOut(
-          `${datasetString(compiledTable.target, compiledTable.type, compiledTable.disabled)}`,
+          `${datasetString(compiledTable.target, tableEnumTypeToString(tableTypeFromProto(compiledTable, true)), compiledTable.disabled)}`,
           1
         );
       });

--- a/cli/console.ts
+++ b/cli/console.ts
@@ -1,6 +1,6 @@
 import { IInitResult } from "df/api/commands/init";
 import { prettyJsonStringify } from "df/api/utils";
-import { tableEnumTypeToString, tableTypeFromProto } from "df/core/utils";
+import { setOrValidateTableEnumType, tableTypeEnumToString } from "df/core/utils";
 import { dataform } from "df/protos/ts";
 import * as readlineSync from "readline-sync";
 
@@ -113,10 +113,11 @@ export function printCompiledGraph(graph: dataform.ICompiledGraph, verbose: bool
       (graph.operations ? graph.operations.length : 0);
     writeStdOut(successOutput(`Compiled ${actionCount} action(s).`));
     if (graph.tables && graph.tables.length) {
+      graph.tables.forEach(setOrValidateTableEnumType);
       writeStdOut(`${graph.tables.length} dataset(s):`);
       graph.tables.forEach(compiledTable => {
         writeStdOut(
-          `${datasetString(compiledTable.target, tableEnumTypeToString(tableTypeFromProto(compiledTable, true)), compiledTable.disabled)}`,
+          `${datasetString(compiledTable.target, tableTypeEnumToString(compiledTable.enumType), compiledTable.disabled)}`,
           1
         );
       });

--- a/core/adapters/base.ts
+++ b/core/adapters/base.ts
@@ -2,6 +2,7 @@ import * as semver from "semver";
 
 import { IAdapter } from "df/core/adapters";
 import { Task, Tasks } from "df/core/tasks";
+import { tableEnumTypeToString, tableTypeFromProto } from "df/core/utils"
 import { dataform } from "df/protos/ts";
 
 export abstract class Adapter implements IAdapter {
@@ -34,15 +35,15 @@ export abstract class Adapter implements IAdapter {
     }`;
   }
 
-  public baseTableType(type: string) {
-    switch (type) {
-      case "table":
-      case "incremental":
+  public baseTableType(enumType: dataform.TableType) {
+    switch (enumType) {
+      case dataform.TableType.TABLE:
+      case dataform.TableType.INCREMENTAL:
         return dataform.TableMetadata.Type.TABLE;
-      case "view":
+      case dataform.TableType.VIEW:
         return dataform.TableMetadata.Type.VIEW;
       default:
-        throw new Error(`Unexpected table type: ${type}`);
+        throw new Error(`Unexpected table type: ${tableEnumTypeToString(enumType)}`);
     }
   }
 
@@ -133,7 +134,7 @@ from (${query}) as insertions`;
     let preOps = table.preOps;
     if (
       semver.gt(this.dataformCoreVersion, "1.4.8") &&
-      table.type === "incremental" &&
+      tableTypeFromProto(table, true) === dataform.TableType.INCREMENTAL &&
       this.shouldWriteIncrementally(runConfig, tableMetadata)
     ) {
       preOps = table.incrementalPreOps;
@@ -149,7 +150,7 @@ from (${query}) as insertions`;
     let postOps = table.postOps;
     if (
       semver.gt(this.dataformCoreVersion, "1.4.8") &&
-      table.type === "incremental" &&
+      tableTypeFromProto(table, true) === dataform.TableType.INCREMENTAL &&
       this.shouldWriteIncrementally(runConfig, tableMetadata)
     ) {
       postOps = table.incrementalPostOps;

--- a/core/adapters/base.ts
+++ b/core/adapters/base.ts
@@ -2,7 +2,7 @@ import * as semver from "semver";
 
 import { IAdapter } from "df/core/adapters";
 import { Task, Tasks } from "df/core/tasks";
-import { tableEnumTypeToString, tableTypeFromProto } from "df/core/utils"
+import { tableTypeEnumToString } from "df/core/utils"
 import { dataform } from "df/protos/ts";
 
 export abstract class Adapter implements IAdapter {
@@ -43,7 +43,7 @@ export abstract class Adapter implements IAdapter {
       case dataform.TableType.VIEW:
         return dataform.TableMetadata.Type.VIEW;
       default:
-        throw new Error(`Unexpected table type: ${tableEnumTypeToString(enumType)}`);
+        throw new Error(`Unexpected table type: ${tableTypeEnumToString(enumType)}`);
     }
   }
 
@@ -134,7 +134,7 @@ from (${query}) as insertions`;
     let preOps = table.preOps;
     if (
       semver.gt(this.dataformCoreVersion, "1.4.8") &&
-      tableTypeFromProto(table, true) === dataform.TableType.INCREMENTAL &&
+      table.enumType === dataform.TableType.INCREMENTAL &&
       this.shouldWriteIncrementally(runConfig, tableMetadata)
     ) {
       preOps = table.incrementalPreOps;
@@ -150,7 +150,7 @@ from (${query}) as insertions`;
     let postOps = table.postOps;
     if (
       semver.gt(this.dataformCoreVersion, "1.4.8") &&
-      tableTypeFromProto(table, true) === dataform.TableType.INCREMENTAL &&
+      table.enumType === dataform.TableType.INCREMENTAL &&
       this.shouldWriteIncrementally(runConfig, tableMetadata)
     ) {
       postOps = table.incrementalPostOps;

--- a/core/adapters/bigquery.ts
+++ b/core/adapters/bigquery.ts
@@ -23,7 +23,7 @@ export class BigQueryAdapter extends Adapter implements IAdapter {
     this.preOps(table, runConfig, tableMetadata).forEach(statement => tasks.add(statement));
 
     const baseTableType = this.baseTableType(table.enumType);
-    if (tableMetadata && tableMetadata.type !== this.baseTableType(table.enumType)) {
+    if (tableMetadata && tableMetadata.type !== baseTableType) {
       tasks.add(
         Task.statement(this.dropIfExists(table.target, this.oppositeTableType(baseTableType)))
       );

--- a/core/adapters/index.ts
+++ b/core/adapters/index.ts
@@ -5,6 +5,7 @@ import { RedshiftAdapter } from "df/core/adapters/redshift";
 import { SnowflakeAdapter } from "df/core/adapters/snowflake";
 import { SQLDataWarehouseAdapter } from "df/core/adapters/sqldatawarehouse";
 import { concatenateQueries, Tasks } from "df/core/tasks";
+import { tableTypeFromProto } from "df/core/utils"
 import { dataform } from "df/protos/ts";
 
 export interface IAdapter {
@@ -21,7 +22,7 @@ export interface IAdapter {
   assertTasks(assertion: dataform.IAssertion, projectConfig: dataform.IProjectConfig): Tasks;
 
   dropIfExists(target: dataform.ITarget, type: dataform.TableMetadata.Type): string;
-  baseTableType(type: string): dataform.TableMetadata.Type;
+  baseTableType(enumType: dataform.TableType): dataform.TableMetadata.Type;
 
   indexAssertion(dataset: string, indexCols: string[]): string;
   rowConditionsAssertion(dataset: string, rowConditions: string[]): string;
@@ -135,7 +136,7 @@ export function collectEvaluationQueries(
   } else {
     try {
       if (queryOrAction instanceof dataform.Table) {
-        if (queryOrAction.type === "incremental") {
+        if (tableTypeFromProto(queryOrAction, true) === dataform.TableType.INCREMENTAL) {
           const incrementalTableQueries = queryOrAction.incrementalPreOps.concat(
             queryOrAction.incrementalQuery,
             queryOrAction.incrementalPostOps

--- a/core/adapters/index.ts
+++ b/core/adapters/index.ts
@@ -5,7 +5,6 @@ import { RedshiftAdapter } from "df/core/adapters/redshift";
 import { SnowflakeAdapter } from "df/core/adapters/snowflake";
 import { SQLDataWarehouseAdapter } from "df/core/adapters/sqldatawarehouse";
 import { concatenateQueries, Tasks } from "df/core/tasks";
-import { tableTypeFromProto } from "df/core/utils"
 import { dataform } from "df/protos/ts";
 
 export interface IAdapter {
@@ -136,7 +135,7 @@ export function collectEvaluationQueries(
   } else {
     try {
       if (queryOrAction instanceof dataform.Table) {
-        if (tableTypeFromProto(queryOrAction, true) === dataform.TableType.INCREMENTAL) {
+        if (queryOrAction.enumType === dataform.TableType.INCREMENTAL) {
           const incrementalTableQueries = queryOrAction.incrementalPreOps.concat(
             queryOrAction.incrementalQuery,
             queryOrAction.incrementalPostOps

--- a/core/adapters/presto.ts
+++ b/core/adapters/presto.ts
@@ -1,7 +1,6 @@
 import { IAdapter } from "df/core/adapters";
 import { Adapter } from "df/core/adapters/base";
 import { Task, Tasks } from "df/core/tasks";
-import { tableTypeFromProto } from "df/core/utils";
 import { dataform } from "df/protos/ts";
 
 export class PrestoAdapter extends Adapter implements IAdapter {
@@ -24,15 +23,14 @@ export class PrestoAdapter extends Adapter implements IAdapter {
 
     this.preOps(table, runConfig, tableMetadata).forEach(statement => tasks.add(statement));
 
-    const tableType = tableTypeFromProto(table, true);
-    const baseTableType = this.baseTableType(tableType);
+    const baseTableType = this.baseTableType(table.enumType);
     if (tableMetadata && tableMetadata.type !== baseTableType) {
       tasks.add(
         Task.statement(this.dropIfExists(table.target, this.oppositeTableType(baseTableType)))
       );
     }
 
-    if (tableType === dataform.TableType.INCREMENTAL) {
+    if (table.enumType === dataform.TableType.INCREMENTAL) {
       throw new Error("Incremental table types are not currently supported for Presto.");
     } else {
       tasks.add(Task.statement(this.createOrReplace(table)));

--- a/core/adapters/presto.ts
+++ b/core/adapters/presto.ts
@@ -1,6 +1,7 @@
 import { IAdapter } from "df/core/adapters";
 import { Adapter } from "df/core/adapters/base";
 import { Task, Tasks } from "df/core/tasks";
+import { tableTypeFromProto } from "df/core/utils";
 import { dataform } from "df/protos/ts";
 
 export class PrestoAdapter extends Adapter implements IAdapter {
@@ -23,14 +24,15 @@ export class PrestoAdapter extends Adapter implements IAdapter {
 
     this.preOps(table, runConfig, tableMetadata).forEach(statement => tasks.add(statement));
 
-    const baseTableType = this.baseTableType(table.type);
+    const tableType = tableTypeFromProto(table, true);
+    const baseTableType = this.baseTableType(tableType);
     if (tableMetadata && tableMetadata.type !== baseTableType) {
       tasks.add(
         Task.statement(this.dropIfExists(table.target, this.oppositeTableType(baseTableType)))
       );
     }
 
-    if (table.type === "incremental") {
+    if (tableType === dataform.TableType.INCREMENTAL) {
       throw new Error("Incremental table types are not currently supported for Presto.");
     } else {
       tasks.add(Task.statement(this.createOrReplace(table)));

--- a/core/adapters/snowflake.ts
+++ b/core/adapters/snowflake.ts
@@ -1,7 +1,6 @@
 import { IAdapter } from "df/core/adapters";
 import { Adapter } from "df/core/adapters/base";
 import { Task, Tasks } from "df/core/tasks";
-import { tableTypeFromProto } from "df/core/utils";
 import { dataform } from "df/protos/ts";
 
 export class SnowflakeAdapter extends Adapter implements IAdapter {
@@ -26,15 +25,14 @@ export class SnowflakeAdapter extends Adapter implements IAdapter {
 
     this.preOps(table, runConfig, tableMetadata).forEach(statement => tasks.add(statement));
 
-    const tableType = tableTypeFromProto(table, true);
-    const baseTableType = this.baseTableType(tableType);
+    const baseTableType = this.baseTableType(table.enumType);
     if (tableMetadata && tableMetadata.type !== baseTableType) {
       tasks.add(
         Task.statement(this.dropIfExists(table.target, this.oppositeTableType(baseTableType)))
       );
     }
 
-    if (tableType === dataform.TableType.INCREMENTAL) {
+    if (table.enumType === dataform.TableType.INCREMENTAL) {
       if (!this.shouldWriteIncrementally(runConfig, tableMetadata)) {
         tasks.add(Task.statement(this.createOrReplace(table)));
       } else {
@@ -82,7 +80,7 @@ export class SnowflakeAdapter extends Adapter implements IAdapter {
   }
 
   private createOrReplace(table: dataform.ITable) {
-    if (tableTypeFromProto(table, true) === dataform.TableType.VIEW) {
+    if (table.enumType === dataform.TableType.VIEW) {
       return this.createOrReplaceView(table.target, table.query, table.snowflake?.secure, table.materialized);
     }
     return `create or replace ${

--- a/core/adapters/sqldatawarehouse.ts
+++ b/core/adapters/sqldatawarehouse.ts
@@ -1,6 +1,7 @@
 import { IAdapter } from "df/core/adapters";
 import { Adapter } from "df/core/adapters/base";
 import { Task, Tasks } from "df/core/tasks";
+import { tableTypeFromProto } from "df/core/utils";
 import { dataform } from "df/protos/ts";
 
 export class SQLDataWarehouseAdapter extends Adapter implements IAdapter {
@@ -26,14 +27,15 @@ export class SQLDataWarehouseAdapter extends Adapter implements IAdapter {
 
     this.preOps(table, runConfig, tableMetadata).forEach(statement => tasks.add(statement));
 
-    const baseTableType = this.baseTableType(table.type);
+    const tableType = tableTypeFromProto(table, true);
+    const baseTableType = this.baseTableType(tableType);
     if (tableMetadata && tableMetadata.type !== baseTableType) {
       tasks.add(
         Task.statement(this.dropIfExists(table.target, this.oppositeTableType(baseTableType)))
       );
     }
 
-    if (table.type === "incremental") {
+    if (tableType === dataform.TableType.INCREMENTAL) {
       if (!this.shouldWriteIncrementally(runConfig, tableMetadata)) {
         tasks.addAll(this.createOrReplace(table, !!tableMetadata));
       } else {
@@ -90,7 +92,8 @@ from (${query}
   }
 
   private createOrReplace(table: dataform.ITable, alreadyExists: boolean) {
-    if (table.type === "view") {
+    const inputType = tableTypeFromProto(table, true);
+    if (inputType === dataform.TableType.VIEW) {
       return Tasks.create().add(
         Task.statement(
           `${alreadyExists ? "alter" : "create"} view ${this.resolveTarget(table.target)} as ${
@@ -105,7 +108,7 @@ from (${query}
     });
 
     return Tasks.create()
-      .add(Task.statement(this.dropIfExists(tempTableTarget, this.baseTableType(table.type))))
+      .add(Task.statement(this.dropIfExists(tempTableTarget, this.baseTableType(inputType))))
       .add(Task.statement(this.createTable(table, tempTableTarget)))
       .add(Task.statement(this.dropIfExists(table.target, dataform.TableMetadata.Type.TABLE)))
       .add(

--- a/core/adapters/sqldatawarehouse.ts
+++ b/core/adapters/sqldatawarehouse.ts
@@ -1,7 +1,6 @@
 import { IAdapter } from "df/core/adapters";
 import { Adapter } from "df/core/adapters/base";
 import { Task, Tasks } from "df/core/tasks";
-import { tableTypeFromProto } from "df/core/utils";
 import { dataform } from "df/protos/ts";
 
 export class SQLDataWarehouseAdapter extends Adapter implements IAdapter {
@@ -27,15 +26,14 @@ export class SQLDataWarehouseAdapter extends Adapter implements IAdapter {
 
     this.preOps(table, runConfig, tableMetadata).forEach(statement => tasks.add(statement));
 
-    const tableType = tableTypeFromProto(table, true);
-    const baseTableType = this.baseTableType(tableType);
+    const baseTableType = this.baseTableType(table.enumType);
     if (tableMetadata && tableMetadata.type !== baseTableType) {
       tasks.add(
         Task.statement(this.dropIfExists(table.target, this.oppositeTableType(baseTableType)))
       );
     }
 
-    if (tableType === dataform.TableType.INCREMENTAL) {
+    if (table.enumType === dataform.TableType.INCREMENTAL) {
       if (!this.shouldWriteIncrementally(runConfig, tableMetadata)) {
         tasks.addAll(this.createOrReplace(table, !!tableMetadata));
       } else {
@@ -92,8 +90,7 @@ from (${query}
   }
 
   private createOrReplace(table: dataform.ITable, alreadyExists: boolean) {
-    const inputType = tableTypeFromProto(table, true);
-    if (inputType === dataform.TableType.VIEW) {
+    if (table.enumType === dataform.TableType.VIEW) {
       return Tasks.create().add(
         Task.statement(
           `${alreadyExists ? "alter" : "create"} view ${this.resolveTarget(table.target)} as ${
@@ -108,7 +105,7 @@ from (${query}
     });
 
     return Tasks.create()
-      .add(Task.statement(this.dropIfExists(tempTableTarget, this.baseTableType(inputType))))
+      .add(Task.statement(this.dropIfExists(tempTableTarget, this.baseTableType(table.enumType))))
       .add(Task.statement(this.createTable(table, tempTableTarget)))
       .add(Task.statement(this.dropIfExists(table.target, dataform.TableMetadata.Type.TABLE)))
       .add(

--- a/core/session.ts
+++ b/core/session.ts
@@ -570,9 +570,7 @@ export class Session {
   private checkTableConfigValidity(tables: dataform.ITable[]) {
     tables.forEach(table => {
       // type
-      try {
-        setOrValidateTableEnumType(table);
-      } catch (e) {
+      if (table.enumType === dataform.TableType.UNKNOWN_TYPE) {
         this.compileError(
           `Wrong type of table detected. Should only use predefined types: ${joinQuoted(
             TableType

--- a/core/session.ts
+++ b/core/session.ts
@@ -19,7 +19,7 @@ import {
 import { targetAsReadableString, targetStringifier } from "df/core/targets";
 import * as test from "df/core/test";
 import * as utils from "df/core/utils";
-import { tableTypeFromProto, toResolvable } from "df/core/utils";
+import { setOrValidateTableEnumType, toResolvable } from "df/core/utils";
 import { version as dataformCoreVersion } from "df/core/version";
 import { dataform } from "df/protos/ts";
 
@@ -226,7 +226,7 @@ export class Session {
     }
     const resolved = allResolved.length > 0 ? allResolved[0] : undefined;
 
-    if (resolved && resolved instanceof Table && tableTypeFromProto(resolved.proto, true) === dataform.TableType.INLINE) {
+    if (resolved && resolved instanceof Table && resolved.proto.enumType === dataform.TableType.INLINE) {
       // TODO: Pretty sure this is broken as the proto.query value may not
       // be set yet as it happens during compilation. We should evalute the query here.
       return `(${resolved.proto.query})`;
@@ -497,7 +497,7 @@ export class Session {
           // We found a single matching target, and fully-qualify it if it's a normal dependency,
           // or add all of its dependencies to ours if it's an 'inline' table.
           const protoDep = possibleDeps[0].proto;
-          if (protoDep instanceof dataform.Table && tableTypeFromProto(protoDep, true) === dataform.TableType.INLINE) {
+          if (protoDep instanceof dataform.Table && protoDep.enumType === dataform.TableType.INLINE) {
             protoDep.dependencyTargets.forEach(inlineDep =>
               action.dependencyTargets.push(inlineDep)
             );
@@ -570,9 +570,8 @@ export class Session {
   private checkTableConfigValidity(tables: dataform.ITable[]) {
     tables.forEach(table => {
       // type
-      let tableType;
       try {
-        tableType = tableTypeFromProto(table, true);
+        setOrValidateTableEnumType(table);
       } catch (e) {
         this.compileError(
           `Wrong type of table detected. Should only use predefined types: ${joinQuoted(
@@ -586,7 +585,7 @@ export class Session {
       // materialized
       if (!!table.materialized) {
         if (
-          tableType !== dataform.TableType.VIEW ||
+          table.enumType !== dataform.TableType.VIEW ||
           (this.config.warehouse !== "snowflake" && this.config.warehouse !== "bigquery")
         ) {
           this.compileError(
@@ -599,7 +598,7 @@ export class Session {
 
       // snowflake config
       if (!!table.snowflake) {
-        if (table.snowflake.secure && tableType !== dataform.TableType.VIEW) {
+        if (table.snowflake.secure && table.enumType !== dataform.TableType.VIEW) {
           this.compileError(
             new Error(`The 'secure' option is only valid for Snowflake views`),
             table.fileName,
@@ -607,7 +606,7 @@ export class Session {
           );
         }
 
-        if (table.snowflake.transient && tableType !== dataform.TableType.TABLE) {
+        if (table.snowflake.transient && table.enumType !== dataform.TableType.TABLE) {
           this.compileError(
             new Error(`The 'transient' option is only valid for Snowflake tables`),
             table.fileName,
@@ -617,8 +616,8 @@ export class Session {
 
         if (
           table.snowflake.clusterBy?.length > 0 &&
-          tableType !== dataform.TableType.TABLE &&
-          tableType !== dataform.TableType.INCREMENTAL
+          table.enumType !== dataform.TableType.TABLE &&
+          table.enumType !== dataform.TableType.INCREMENTAL
         ) {
           this.compileError(
             new Error(`The 'clusterBy' option is only valid for Snowflake tables`),
@@ -711,7 +710,7 @@ export class Session {
             table.bigquery.clusterBy?.length ||
             table.bigquery.partitionExpirationDays ||
             table.bigquery.requirePartitionFilter) &&
-          tableType === dataform.TableType.VIEW
+          table.enumType === dataform.TableType.VIEW
         ) {
           this.compileError(
             `partitionBy/clusterBy/requirePartitionFilter/partitionExpirationDays are not valid for BigQuery views; they are only valid for tables`,
@@ -721,7 +720,7 @@ export class Session {
         } else if (
           !table.bigquery.partitionBy &&
           (table.bigquery.partitionExpirationDays || table.bigquery.requirePartitionFilter) &&
-          tableType === dataform.TableType.TABLE
+          table.enumType === dataform.TableType.TABLE
         ) {
           this.compileError(
             `requirePartitionFilter/partitionExpirationDays are not valid for non partitioned BigQuery tables`,
@@ -753,7 +752,7 @@ export class Session {
       }
 
       // Ignored properties
-      if (tableType === dataform.TableType.INLINE) {
+      if (table.enumType === dataform.TableType.INLINE) {
         Table.INLINE_IGNORED_PROPS.forEach(ignoredProp => {
           if (objectExistsOrIsNonEmpty(table[ignoredProp])) {
             this.compileError(

--- a/core/table.ts
+++ b/core/table.ts
@@ -17,6 +17,7 @@ import {
   resolvableAsTarget,
   setNameAndTarget,
   strictKeysOf,
+  strTableTypeToEnum,
   toResolvable,
   validateQueryString
 } from "df/core/utils";
@@ -378,10 +379,8 @@ export interface ITableContext extends ICommonContext {
  * @hidden
  */
 export class Table {
-  public static readonly IGNORED_PROPS: {
-    [tableType: string]: Array<keyof dataform.ITable>;
-  } = {
-    inline: [
+  public static readonly INLINE_IGNORED_PROPS: Array<keyof dataform.ITable> = 
+    [
       "bigquery",
       "redshift",
       "snowflake",
@@ -392,11 +391,11 @@ export class Table {
       "actionDescriptor",
       "disabled",
       "where"
-    ]
-  };
+    ];
 
   public proto: dataform.ITable = dataform.Table.create({
     type: "view",
+    enumType: dataform.TableType.VIEW,
     disabled: false,
     tags: []
   });
@@ -480,6 +479,7 @@ export class Table {
 
   public type(type: TableType) {
     this.proto.type = type;
+    this.proto.enumType = strTableTypeToEnum(type, false);
     return this;
   }
 
@@ -716,7 +716,7 @@ export class Table {
 
     this.proto.query = context.apply(this.contextableQuery);
 
-    if (this.proto.type === "incremental") {
+    if (this.proto.enumType === dataform.TableType.INCREMENTAL) {
       this.proto.incrementalQuery = incrementalContext.apply(this.contextableQuery);
 
       this.proto.incrementalPreOps = this.contextifyOps(this.contextablePreOps, incrementalContext);

--- a/core/table.ts
+++ b/core/table.ts
@@ -17,7 +17,7 @@ import {
   resolvableAsTarget,
   setNameAndTarget,
   strictKeysOf,
-  strTableTypeToEnum,
+  tableTypeStringToEnum,
   toResolvable,
   validateQueryString
 } from "df/core/utils";
@@ -479,7 +479,7 @@ export class Table {
 
   public type(type: TableType) {
     this.proto.type = type;
-    this.proto.enumType = strTableTypeToEnum(type, false);
+    this.proto.enumType = tableTypeStringToEnum(type, false);
     return this;
   }
 

--- a/core/test.ts
+++ b/core/test.ts
@@ -90,7 +90,7 @@ export class Test {
           new Error(`Dataset ${stringifyResolvable(this.datasetToTest)} could not be found.`),
           this.proto.fileName
         );
-      } else if (dataset.proto.type === "incremental") {
+      } else if (dataset.proto.enumType === dataform.TableType.INCREMENTAL) {
         this.session.compileError(
           new Error("Running tests on incremental datasets is not yet supported."),
           this.proto.fileName

--- a/core/utils.ts
+++ b/core/utils.ts
@@ -247,7 +247,7 @@ export function throwIfInvalid<T>(proto: T, verify: (proto: T) => string) {
   }
 }
 
-export function strTableTypeToEnum(type: string, throwIfUnknown: boolean) {
+export function tableTypeStringToEnum(type: string, throwIfUnknown: boolean) {
   switch (type) {
     case "table":
       return dataform.TableType.TABLE;
@@ -266,13 +266,18 @@ export function strTableTypeToEnum(type: string, throwIfUnknown: boolean) {
   }
 }
 
-export function tableTypeFromProto(table: dataform.ITable, throwIfUnknown: boolean) {
-  if (table.enumType !== dataform.TableType.UNKNOWN_TYPE && table.enumType !== undefined) {
-    return table.enumType;
-  }
-  return strTableTypeToEnum(table.type, throwIfUnknown);
+export function tableTypeEnumToString(enumType: dataform.TableType) {
+  return dataform.TableType[enumType].toLowerCase();
 }
 
-export function tableEnumTypeToString(enumType: dataform.TableType) {
-  return dataform.TableType[enumType].toLowerCase();
+export function setOrValidateTableEnumType(table: dataform.ITable) {
+  var enumTypeFromStr: dataform.TableType|null = null;
+  if (table.type !== "" && table.type !== undefined) {
+    enumTypeFromStr = tableTypeStringToEnum(table.type, true);
+  }
+  if (table.enumType === dataform.TableType.UNKNOWN_TYPE || table.enumType === undefined) {
+    table.enumType = enumTypeFromStr!;
+  } else if (enumTypeFromStr !== null && table.enumType !== enumTypeFromStr) {
+    throw new Error(`Table str type "${table.type}" and enumType "${tableTypeEnumToString(table.enumType)}" are not equivalent.`);
+  }
 }

--- a/core/utils.ts
+++ b/core/utils.ts
@@ -246,3 +246,33 @@ export function throwIfInvalid<T>(proto: T, verify: (proto: T) => string) {
     throw new Error(verifyError);
   }
 }
+
+export function strTableTypeToEnum(type: string, throwIfUnknown: boolean) {
+  switch (type) {
+    case "table":
+      return dataform.TableType.TABLE;
+    case "incremental":
+      return dataform.TableType.INCREMENTAL;
+    case "view":
+      return dataform.TableType.VIEW;
+    case "inline":
+      return dataform.TableType.INLINE;
+    default: {
+      if (throwIfUnknown) {
+        throw new Error(`Unexpected table type: ${type}`);
+      }
+      return dataform.TableType.UNKNOWN_TYPE;
+    }
+  }
+}
+
+export function tableTypeFromProto(table: dataform.ITable, throwIfUnknown: boolean) {
+  if (table.enumType !== dataform.TableType.UNKNOWN_TYPE && table.enumType !== undefined) {
+    return table.enumType;
+  }
+  return strTableTypeToEnum(table.type, throwIfUnknown);
+}
+
+export function tableEnumTypeToString(enumType: dataform.TableType) {
+  return dataform.TableType[enumType].toLowerCase();
+}

--- a/core/utils.ts
+++ b/core/utils.ts
@@ -271,7 +271,7 @@ export function tableTypeEnumToString(enumType: dataform.TableType) {
 }
 
 export function setOrValidateTableEnumType(table: dataform.ITable) {
-  var enumTypeFromStr: dataform.TableType|null = null;
+  let enumTypeFromStr: dataform.TableType|null = null;
   if (table.type !== "" && table.type !== undefined) {
     enumTypeFromStr = tableTypeStringToEnum(table.type, true);
   }

--- a/protos/core.proto
+++ b/protos/core.proto
@@ -159,6 +159,14 @@ message ColumnDescriptor {
   repeated string bigquery_policy_tags = 8;
 }
 
+enum TableType {
+  UNKNOWN_TYPE = 0;
+  TABLE = 1;
+  INCREMENTAL = 2;
+  VIEW = 3;
+  INLINE = 4;
+}
+
 message Table {
   Target target = 4;
   Target canonical_target = 32;
@@ -168,10 +176,11 @@ message Table {
 
   bool disabled = 6;
 
-  string type = 3;
+  string type = 3 [deprecated = true];
   string query = 5;
   bool protected = 9;
   bool materialized = 35;
+  TableType enum_type = 36;
 
   ActionDescriptor action_descriptor = 24;
 

--- a/tests/api/api.spec.ts
+++ b/tests/api/api.spec.ts
@@ -180,32 +180,19 @@ suite("@dataform/api", () => {
       });
     });
 
-    test("table_enum_and_string_types", () => {
+    test("table_enum_and_str_types_should_match", () => {
       const graph: dataform.ICompiledGraph = dataform.CompiledGraph.create({
         projectConfig: { warehouse: "bigquery" },
-        tables: [
-          { target: { schema: "schema", name: "a" }, enumType: dataform.TableType.TABLE },
-          {
-            target: { schema: "schema", name: "b" },
-            type: "incremental",
-            where: "test"
-          }
-        ]
+        tables: [{
+          target: { schema: "schema", name: "a" },
+          enumType: dataform.TableType.TABLE,
+          type: "incremental",
+        }]
       });
 
-      const builder = new Builder(graph, {}, TEST_STATE);
-      const executedGraph = builder.build();
-
-      expect(executedGraph.actions.length).greaterThan(0);
-
-      graph.tables.forEach((t: dataform.ITable) => {
-        const action = executedGraph.actions.find(item => targetsAreEqual(item.target, t.target));
-        expect(action).to.include({
-          type: "table",
-          target: t.target,
-          tableType: t.enumType !== undefined ? dataform.TableType[t.enumType].toLowerCase() : t.type,
-        });
-      });
+      expect(() => new Builder(graph, {}, TEST_STATE)).to.throw(
+        /Table str type "incremental" and enumType "table" are not equivalent/
+      );
     });
 
     suite("pre and post ops", () => {

--- a/tests/api/examples.spec.ts
+++ b/tests/api/examples.spec.ts
@@ -108,6 +108,7 @@ suite("examples", () => {
                 )
             );
             expect(exampleJsBlocks.type).equals("table");
+            expect(exampleJsBlocks.enumType).equals(dataform.TableType.TABLE);
             expect(exampleJsBlocks.query.trim()).equals("select 1 as foo");
 
             // Check we can import and use an external package.
@@ -221,6 +222,7 @@ suite("examples", () => {
                 )
             );
             expect(exampleInline.type).equals("inline");
+            expect(exampleInline.enumType).equals(dataform.TableType.INLINE);
             expect(exampleInline.query.trim()).equals(
               `select * from \`${dotJoined(
                 databaseWithSuffix("tada-analytics"),
@@ -246,6 +248,7 @@ suite("examples", () => {
                 )
             );
             expect(exampleUsingInline.type).equals("table");
+            expect(exampleUsingInline.enumType).equals(dataform.TableType.TABLE);
             expect(exampleUsingInline.query.trim()).equals(
               `select * from (\n\nselect * from \`${dotJoined(
                 databaseWithSuffix("tada-analytics"),
@@ -272,6 +275,7 @@ suite("examples", () => {
                 )
             );
             expect(exampleView.type).equals("view");
+            expect(exampleView.enumType).equals(dataform.TableType.VIEW);
             expect(exampleView.query.trim()).equals(
               `select * from \`${dotJoined(
                 databaseWithSuffix("tada-analytics"),
@@ -333,6 +337,7 @@ suite("examples", () => {
                 )
             );
             expect(exampleMaterializedView.type).equals("view");
+            expect(exampleMaterializedView.enumType).equals(dataform.TableType.VIEW);
             expect(exampleMaterializedView.materialized).equals(true);
             expect(exampleMaterializedView.query.trim()).equals(
               `select * from \`${dotJoined(
@@ -375,6 +380,7 @@ suite("examples", () => {
                 )
             );
             expect(exampleTable.type).equals("table");
+            expect(exampleTable.enumType).equals(dataform.TableType.TABLE);
             expect(exampleTable.query.trim()).equals(
               `select * from \`${dotJoined(
                 databaseWithSuffix("tada-analytics"),
@@ -481,6 +487,7 @@ suite("examples", () => {
                 )
             );
             expect(exampleSampleData.type).equals("view");
+            expect(exampleSampleData.enumType).equals(dataform.TableType.VIEW);
             expect(exampleSampleData.query.trim()).equals(
               "select 1 as sample union all\nselect 2 as sample union all\nselect 3 as sample"
             );
@@ -513,6 +520,7 @@ suite("examples", () => {
               databaseWithSuffix("override_database")
             );
             expect(exampleUsingOverriddenDatabase.type).equals("view");
+            expect(exampleUsingOverriddenDatabase.enumType).equals(dataform.TableType.VIEW);
             expect(exampleUsingOverriddenDatabase.query.trim()).equals(
               "select 1 as test_database_override"
             );
@@ -532,6 +540,7 @@ suite("examples", () => {
               schemaWithSuffix("override_schema")
             );
             expect(exampleUsingOverriddenSchema.type).equals("view");
+            expect(exampleUsingOverriddenSchema.enumType).equals(dataform.TableType.VIEW);
             expect(exampleUsingOverriddenSchema.query.trim()).equals(
               "select 1 as test_schema_override"
             );
@@ -551,6 +560,7 @@ suite("examples", () => {
               schemaWithSuffix("df_integration_test")
             );
             expect(exampleUsingOverriddenSchemaUnchanged.type).equals("view");
+            expect(exampleUsingOverriddenSchemaUnchanged.enumType).equals(dataform.TableType.VIEW);
             expect(exampleUsingOverriddenSchemaUnchanged.query.trim()).equals(
               "select 1 as test_schema_override"
             );

--- a/tests/cli/cli.spec.ts
+++ b/tests/cli/cli.spec.ts
@@ -73,6 +73,7 @@ select 1 as \${dataform.projectConfig.vars.testVar2}
       tables: [
         {
           type: "table",
+          enumType: "TABLE",
           target: {
             database: "dataform-integration-tests",
             schema: "dataform",

--- a/tests/core/core.spec.ts
+++ b/tests/core/core.spec.ts
@@ -95,6 +95,7 @@ suite("@dataform/core", () => {
           table => targetAsReadableString(table.target) === `schema.${tableWithPrefix("example")}`
         );
         expect(t.type).equals("table");
+        expect(t.enumType).equals(dataform.TableType.TABLE);
         expect(t.actionDescriptor).eql({
           description: "this is a table",
           columns: [
@@ -116,6 +117,7 @@ suite("@dataform/core", () => {
           table => targetAsReadableString(table.target) === `schema2.${tableWithPrefix("example")}`
         );
         expect(t2.type).equals("table");
+        expect(t2.enumType).equals(dataform.TableType.TABLE);
         expect(t2.actionDescriptor).eql({
           description: "test description"
         });
@@ -136,6 +138,7 @@ suite("@dataform/core", () => {
         expect((t3.target.name = `${tableWithPrefix("my_table")}`));
         expect((t3.target.schema = "test_schema"));
         expect(t3.type).equals("table");
+        expect(t3.enumType).equals(dataform.TableType.TABLE);
       });
     });
 
@@ -181,6 +184,7 @@ suite("@dataform/core", () => {
           table => targetAsReadableString(table.target) === `${schemaWithSuffix("schema")}.example`
         );
         expect(t.type).equals("table");
+        expect(t.enumType).equals(dataform.TableType.TABLE);
         expect(t.actionDescriptor).eql({
           description: "this is a table",
           columns: [
@@ -197,6 +201,7 @@ suite("@dataform/core", () => {
           table => targetAsReadableString(table.target) === `${schemaWithSuffix("schema2")}.example`
         );
         expect(t2.type).equals("table");
+        expect(t2.enumType).equals(dataform.TableType.TABLE);
         expect(t.actionDescriptor).eql({
           description: "this is a table",
           columns: [
@@ -219,6 +224,7 @@ suite("@dataform/core", () => {
         expect((t3.target.name = "my_table"));
         expect((t3.target.schema = schemaWithSuffix("test_schema")));
         expect(t3.type).equals("table");
+        expect(t3.enumType).equals(dataform.TableType.TABLE);
       });
     });
 
@@ -245,7 +251,8 @@ suite("@dataform/core", () => {
           incrementalQuery: "select true as incremental",
           disabled: false,
           fileName: path.basename(__filename),
-          type: "incremental"
+          type: "incremental",
+          enumType: "INCREMENTAL",
         }
       ]);
     });
@@ -706,6 +713,7 @@ suite("@dataform/core", () => {
         table => targetAsReadableString(table.target) === "schema.a"
       );
       expect(tableA.type).equals("table");
+      expect(tableA.enumType).equals(dataform.TableType.TABLE);
       expect(
         tableA.dependencyTargets.map(dependency => targetAsReadableString(dependency))
       ).deep.equals([]);
@@ -715,6 +723,7 @@ suite("@dataform/core", () => {
         table => targetAsReadableString(table.target) === "schema.b"
       );
       expect(tableB.type).equals("inline");
+      expect(tableB.enumType).equals(dataform.TableType.INLINE);
       expect(
         tableB.dependencyTargets.map(dependency => targetAsReadableString(dependency))
       ).includes("schema.a");
@@ -744,6 +753,7 @@ suite("@dataform/core", () => {
         table => targetAsReadableString(table.target) === "schema.c"
       );
       expect(tableC.type).equals("table");
+      expect(tableC.enumType).equals(dataform.TableType.TABLE);
       expect(
         tableC.dependencyTargets.map(dependency => targetAsReadableString(dependency))
       ).includes("schema.a");

--- a/tests/integration/bigquery.spec.ts
+++ b/tests/integration/bigquery.spec.ts
@@ -331,7 +331,7 @@ suite("@dataform/integration/bigquery", { parallel: true }, ({ before, after }) 
 
       let evaluations = await dbadapter.evaluate(
         dataform.Table.create({
-          type: "table",
+          enumType: dataform.TableType.TABLE,
           preOps: ["declare var string; set var = 'val';"],
           query: "select var as col;",
           target: target("example_valid_variable")
@@ -344,7 +344,7 @@ suite("@dataform/integration/bigquery", { parallel: true }, ({ before, after }) 
 
       evaluations = await dbadapter.evaluate(
         dataform.Table.create({
-          type: "table",
+          enumType: dataform.TableType.TABLE,
           query: "select var as col;",
           target: target("example_invalid_variable")
         })
@@ -358,7 +358,7 @@ suite("@dataform/integration/bigquery", { parallel: true }, ({ before, after }) 
     test("invalid table fails validation and error parsed correctly", async () => {
       const evaluations = await dbadapter.evaluate(
         dataform.Table.create({
-          type: "table",
+          enumType: dataform.TableType.TABLE,
           query: "selects\n1 as x",
           target: {
             name: "EXAMPLE_ILLEGAL_TABLE",
@@ -380,7 +380,7 @@ suite("@dataform/integration/bigquery", { parallel: true }, ({ before, after }) 
     test("incremental pre and post ops, core version <= 1.4.8", async () => {
       // 1.4.8 used `preOps` and `postOps` instead of `incrementalPreOps` and `incrementalPostOps`.
       const table: dataform.ITable = {
-        type: "incremental",
+        enumType: dataform.TableType.INCREMENTAL,
         query: "query",
         preOps: ["preop task1", "preop task2"],
         incrementalQuery: "",

--- a/tests/integration/postgres.spec.ts
+++ b/tests/integration/postgres.spec.ts
@@ -279,7 +279,7 @@ suite("@dataform/integration/postgres", { parallel: true }, ({ before, after }) 
     test("invalid table fails validation", async () => {
       const evaluations = await dbadapter.evaluate(
         dataform.Table.create({
-          type: "table",
+          enumType: dataform.TableType.TABLE,
           query: "thisisillegal",
           target: {
             schema: "df_integration_test",
@@ -299,7 +299,7 @@ suite("@dataform/integration/postgres", { parallel: true }, ({ before, after }) 
     test("incremental pre and post ops, core version <= 1.4.8", async () => {
       // 1.4.8 used `preOps` and `postOps` instead of `incrementalPreOps` and `incrementalPostOps`.
       const table: dataform.ITable = {
-        type: "incremental",
+        enumType: dataform.TableType.INCREMENTAL,
         query: "query",
         preOps: ["preop task1", "preop task2"],
         incrementalQuery: "",

--- a/tests/integration/redshift.spec.ts
+++ b/tests/integration/redshift.spec.ts
@@ -301,7 +301,7 @@ suite("@dataform/integration/redshift", { parallel: true }, ({ before, after }) 
     test("invalid table fails validation", async () => {
       const evaluations = await dbadapter.evaluate(
         dataform.Table.create({
-          type: "table",
+          enumType: dataform.TableType.TABLE,
           query: "thisisillegal",
           target: {
             schema: "df_integration_test",
@@ -321,7 +321,7 @@ suite("@dataform/integration/redshift", { parallel: true }, ({ before, after }) 
     test("incremental pre and post ops, core version <= 1.4.8", async () => {
       // 1.4.8 used `preOps` and `postOps` instead of `incrementalPreOps` and `incrementalPostOps`.
       const table: dataform.ITable = {
-        type: "incremental",
+        enumType: dataform.TableType.INCREMENTAL,
         query: "query",
         preOps: ["preop task1", "preop task2"],
         incrementalQuery: "",

--- a/tests/integration/snowflake.spec.ts
+++ b/tests/integration/snowflake.spec.ts
@@ -317,7 +317,7 @@ suite("@dataform/integration/snowflake", ({ before, after }) => {
     test("invalid table fails validation and error parsed correctly", async () => {
       const evaluations = await dbadapter.evaluate(
         dataform.Table.create({
-          type: "table",
+          enumType: dataform.TableType.TABLE,
           query: "selects\n1 as x",
           target: {
             name: "EXAMPLE_ILLEGAL_TABLE",
@@ -339,7 +339,7 @@ suite("@dataform/integration/snowflake", ({ before, after }) => {
     test("incremental pre and post ops, core version <= 1.4.8", async () => {
       // 1.4.8 used `preOps` and `postOps` instead of `incrementalPreOps` and `incrementalPostOps`.
       const table: dataform.ITable = {
-        type: "incremental",
+        enumType: dataform.TableType.INCREMENTAL,
         query: "query",
         preOps: ["preop task1", "preop task2"],
         incrementalQuery: "",

--- a/tests/integration/sqldatawarehouse.spec.ts
+++ b/tests/integration/sqldatawarehouse.spec.ts
@@ -196,7 +196,7 @@ suite("@dataform/integration/sqldatawarehouse", { parallel: true }, ({ before, a
     test("invalid table fails validation and error parsed correctly", async () => {
       const evaluations = await dbadapter.evaluate(
         dataform.Table.create({
-          type: "table",
+          enumType: dataform.TableType.TABLE,
           query: "selects\n1 as x",
           target: {
             schema: "df_integration_test",
@@ -219,7 +219,7 @@ suite("@dataform/integration/sqldatawarehouse", { parallel: true }, ({ before, a
     test("incremental pre and post ops, core version <= 1.4.8", async () => {
       // 1.4.8 used `preOps` and `postOps` instead of `incrementalPreOps` and `incrementalPostOps`.
       const table: dataform.ITable = {
-        type: "incremental",
+        enumType: dataform.TableType.INCREMENTAL,
         query: "query",
         preOps: ["preop task1", "preop task2"],
         incrementalQuery: "",

--- a/version.bzl
+++ b/version.bzl
@@ -1,3 +1,3 @@
 # NOTE: If you change the format of this line, you must change the bash command
 # in /scripts/publish to extract the version string correctly.
-DF_VERSION = "2.3.2"
+DF_VERSION = "2.4.0"


### PR DESCRIPTION
New enum field `enum_type` was added to `Table` proto message. The old field `type` marked deprecated. For backward compatibilty both fields are filled in the code when creating `CompliedGraph` representation.