### PR TITLE
Disable docker node warnings to prevent futzing of docker output

### DIFF
--- a/cli/BUILD
+++ b/cli/BUILD
@@ -55,6 +55,9 @@ container_image(
     base = ":image_with_dataform_cli_commit.tar",
     cmd = [],
     entrypoint = ["dataform"],
+    env = {
+        "NODE_NO_WARNINGS": "1",
+    },
     tags = [
         "no-remote",
     ],


### PR DESCRIPTION
This was putting

```
(node:25544) NOTE: The AWS SDK for JavaScript (v2) will be put into maintenance mode in 2023.

Please migrate your code to use AWS SDK for JavaScript (v3).
For more information, check the migration guide at https://a.co/7PzMCcy
(Use `node --trace-warnings ...` to show where the warning was created)
```

in the output - fine for most things, but could break workflows using things like `--json`

Fixes https://github.com/dataform-co/dataform/issues/1458