### PR TITLE
Remove code which always executes auto-assertions.

### DIFF
--- a/api/commands/prune.ts
+++ b/api/commands/prune.ts
@@ -115,14 +115,5 @@ function computeIncludedActionNames(
     }
   }
 
-  // Add auto assertions
-  [...compiledGraph.assertions].forEach(assertion => {
-    if (!!assertion.parentAction) {
-      if (includedActionNames.has(targetAsReadableString(assertion.parentAction))) {
-        includedActionNames.add(targetAsReadableString(assertion.target));
-      }
-    }
-  });
-
   return includedActionNames;
 }

--- a/tests/api/api.spec.ts
+++ b/tests/api/api.spec.ts
@@ -404,7 +404,6 @@ suite("@dataform/api", () => {
       ];
       expect(actionNames).includes("schema.a");
       expect(actionNames).includes("schema.b");
-      expect(actionNames).includes("schema.d");
     });
 
     test("prune actions with --actions without dependencies", () => {


### PR DESCRIPTION
This is a partial reversion of https://github.com/dataform-co/dataform/pull/959, motivated by:
1) parity with GCP Dataform
2) https://github.com/dataform-co/dataform/pull/1406 is a better way of implementing this requirement

(Cleanup, related to https://github.com/dataform-co/dataform/issues/1423)