### PR TITLE
Include multiline string literals when creating statements

### DIFF
--- a/core/compilers.ts
+++ b/core/compilers.ts
@@ -209,6 +209,7 @@ function extractSqlxParts(rootNode: SyntaxTreeNode) {
             SyntaxTreeNodeType.JAVASCRIPT_TEMPLATE_STRING_PLACEHOLDER,
             SyntaxTreeNodeType.SQL_COMMENT,
             SyntaxTreeNodeType.SQL_LITERAL_STRING,
+            SyntaxTreeNodeType.SQL_LITERAL_MULTILINE_STRING,
             SyntaxTreeNodeType.SQL_STATEMENT_SEPARATOR
           ].includes(node.type)
       )

--- a/tests/core/core.spec.ts
+++ b/tests/core/core.spec.ts
@@ -1319,11 +1319,19 @@ pre_operations {
         compilers.compile(
           `
 select
+  """
+  triple
+  quotes
+  """,
   "asd\\"123'def",
   'asd\\'123"def',
 
 post_operations {
   select
+    """
+    triple
+    quotes
+    """,
     "asd\\"123'def",
     'asd\\'123"def',
 }

--- a/tests/core/strings-act-literally.js.test
+++ b/tests/core/strings-act-literally.js.test
@@ -17,6 +17,10 @@ const database = ctx.database ? ctx.database.bind(ctx) : undefined;
     
     return [`
 select
+  """
+  triple
+  quotes
+  """,
   "asd\\"123'def",
   'asd\\'123"def',
 
@@ -37,6 +41,10 @@ const database = ctx.database ? ctx.database.bind(ctx) : undefined;
     
     return [`
   select
+    """
+    triple
+    quotes
+    """,
     "asd\\"123'def",
     'asd\\'123"def',
 `];

--- a/version.bzl
+++ b/version.bzl
@@ -1,3 +1,3 @@
 # NOTE: If you change the format of this line, you must change the bash command
 # in /scripts/publish to extract the version string correctly.
-DF_VERSION = "2.6.1"
+DF_VERSION = "2.6.2"


### PR DESCRIPTION
Currently (in version 2.6.1) we skip multiline string literals when creating statements in compilers.ts, and because of this in the compiled sqlx multiline strings are getting removed. 

