### PR TITLE
Fix `@dataform/core` on Windows.

### DIFF
--- a/core/main.ts
+++ b/core/main.ts
@@ -45,7 +45,7 @@ export function main(encodedCoreExecutionRequest: string): string {
 
   // Require "includes" *.js files.
   compileRequest.compileConfig.filePaths
-    .filter(path => path.startsWith("includes/"))
+    .filter(path => path.startsWith(`includes${utils.pathSeperator}`))
     .filter(path => path.endsWith(".js"))
     .forEach(includePath => {
       try {
@@ -65,7 +65,7 @@ export function main(encodedCoreExecutionRequest: string): string {
 
   // Require all "definitions" files (attaching them to the session).
   compileRequest.compileConfig.filePaths
-    .filter(path => path.startsWith("definitions/"))
+    .filter(path => path.startsWith(`definitions${utils.pathSeperator}`))
     .filter(path => path.endsWith(".js") || path.endsWith(".sqlx"))
     .forEach(definitionPath => {
       try {

--- a/core/utils.ts
+++ b/core/utils.ts
@@ -7,7 +7,7 @@ import { IActionProto, Session } from "df/core/session";
 import { Table } from "df/core/table";
 import { dataform } from "df/protos/ts";
 
-const pathSeperator = (() => {
+export const pathSeperator = (() => {
   if (typeof process !== "undefined") {
     return process.platform === "win32" ? "\\" : "/";
   }
@@ -271,13 +271,17 @@ export function tableTypeEnumToString(enumType: dataform.TableType) {
 }
 
 export function setOrValidateTableEnumType(table: dataform.ITable) {
-  let enumTypeFromStr: dataform.TableType|null = null;
+  let enumTypeFromStr: dataform.TableType | null = null;
   if (table.type !== "" && table.type !== undefined) {
     enumTypeFromStr = tableTypeStringToEnum(table.type, true);
   }
   if (table.enumType === dataform.TableType.UNKNOWN_TYPE || table.enumType === undefined) {
     table.enumType = enumTypeFromStr!;
   } else if (enumTypeFromStr !== null && table.enumType !== enumTypeFromStr) {
-    throw new Error(`Table str type "${table.type}" and enumType "${tableTypeEnumToString(table.enumType)}" are not equivalent.`);
+    throw new Error(
+      `Table str type "${table.type}" and enumType "${tableTypeEnumToString(
+        table.enumType
+      )}" are not equivalent.`
+    );
   }
 }

--- a/version.bzl
+++ b/version.bzl
@@ -1,3 +1,3 @@
 # NOTE: If you change the format of this line, you must change the bash command
 # in /scripts/publish to extract the version string correctly.
-DF_VERSION = "2.6.3"
+DF_VERSION = "2.6.4"


### PR DESCRIPTION
Turns out the old version of `glob` we were using (now fixed in https://github.com/dataform-co/dataform/pull/1525), coupled with the incorrect code fixed in this PR, broke `main` compilation on Windows.