### PR TITLE
Tighten semantics around `require()`-ing `includes` files.

### DIFF
--- a/core/main.ts
+++ b/core/main.ts
@@ -43,18 +43,23 @@ export function main(encodedCoreExecutionRequest: string): string {
   // Allow "includes" files to use the current session object.
   globalAny.dataform = session;
 
-  // Require "includes" *.js files.
+  // Require "includes/*.js" files, attaching them (by file basename) to the `global` object.
+  // We delay attaching them to `global` until after all have been required, to prevent
+  // "includes" files from implicitly depending on other "includes" files.
+  const topLevelIncludes: {[key: string]: any} = {};
   compileRequest.compileConfig.filePaths
     .filter(path => path.startsWith(`includes${utils.pathSeperator}`))
+    .filter(path => path.split(utils.pathSeperator).length === 2)
     .filter(path => path.endsWith(".js"))
     .forEach(includePath => {
       try {
         // tslint:disable-next-line: tsr-detect-non-literal-require
-        globalAny[utils.baseFilename(includePath)] = require(includePath);
+        topLevelIncludes[utils.baseFilename(includePath)] = require(includePath);
       } catch (e) {
         session.compileError(e, includePath);
       }
     });
+  Object.assign(globalAny, topLevelIncludes);
 
   // Bind various @dataform/core APIs to the 'global' object.
   globalAny.publish = session.publish.bind(session);

--- a/core/main.ts
+++ b/core/main.ts
@@ -49,7 +49,7 @@ export function main(encodedCoreExecutionRequest: string): string {
   const topLevelIncludes: {[key: string]: any} = {};
   compileRequest.compileConfig.filePaths
     .filter(path => path.startsWith(`includes${utils.pathSeperator}`))
-    .filter(path => path.split(utils.pathSeperator).length === 2)
+    .filter(path => path.split(utils.pathSeperator).length === 2) // Only include top-level "includes" files.
     .filter(path => path.endsWith(".js"))
     .forEach(includePath => {
       try {

--- a/examples/common_v2/definitions/example_table.sqlx
+++ b/examples/common_v2/definitions/example_table.sqlx
@@ -6,7 +6,7 @@ select * from ${ref("df_integration_test", "sample_data")}
 /* ${"another"} ` backtick ` containing ```comment */
 
 post_operations {
-    GRANT SELECT ON ${self()} TO GROUP "allusers@dataform.co"
+    GRANT SELECT ON ${self()} TO GROUP "${constants.allUsersEmailAddress}"
     ---
     GRANT SELECT ON ${self()} TO GROUP "otherusers@dataform.co"
 }

--- a/examples/common_v2/includes/constants.js
+++ b/examples/common_v2/includes/constants.js
@@ -1,0 +1,3 @@
+module.exports = {
+  allUsersEmailAddress: "allusers@dataform.co"
+};

--- a/version.bzl
+++ b/version.bzl
@@ -1,3 +1,3 @@
 # NOTE: If you change the format of this line, you must change the bash command
 # in /scripts/publish to extract the version string correctly.
-DF_VERSION = "2.6.5"
+DF_VERSION = "2.6.6"


### PR DESCRIPTION
- prevent `includes` files from implicitly depending on other `includes` files
- only `require()` top-level `includes` files