### PR TITLE
windows compile fix

### DIFF
--- a/core/main.ts
+++ b/core/main.ts
@@ -47,14 +47,16 @@ export function main(encodedCoreExecutionRequest: string): string {
   // We delay attaching them to `global` until after all have been required, to prevent
   // "includes" files from implicitly depending on other "includes" files.
   const topLevelIncludes: {[key: string]: any} = {};
+  function localBaseFilename(fullPath) {
+    return fullPath.split("/").slice(-1)[0].split(".")[0];};
   compileRequest.compileConfig.filePaths
-    .filter(path => path.startsWith(`includes${utils.pathSeperator}`))
-    .filter(path => path.split(utils.pathSeperator).length === 2) // Only include top-level "includes" files.
+    .filter(path => path.startsWith(`includes/`))
+    .filter(path => path.split("/").length === 2) // Only include top-level "includes" files.
     .filter(path => path.endsWith(".js"))
     .forEach(includePath => {
       try {
         // tslint:disable-next-line: tsr-detect-non-literal-require
-        topLevelIncludes[utils.baseFilename(includePath)] = require(includePath);
+        topLevelIncludes[localBaseFilename(includePath)] = require(includePath);
       } catch (e) {
         session.compileError(e, includePath);
       }
@@ -70,7 +72,7 @@ export function main(encodedCoreExecutionRequest: string): string {
 
   // Require all "definitions" files (attaching them to the session).
   compileRequest.compileConfig.filePaths
-    .filter(path => path.startsWith(`definitions${utils.pathSeperator}`))
+    .filter(path => path.startsWith(`definitions/`))
     .filter(path => path.endsWith(".js") || path.endsWith(".sqlx"))
     .forEach(definitionPath => {
       try {

--- a/core/utils.ts
+++ b/core/utils.ts
@@ -73,8 +73,8 @@ export function getCallerFile(rootDir: string) {
     lastfile = nextLastfile;
     if (
       !(
-        nextLastfile.includes(`definitions${pathSeperator}`) ||
-        nextLastfile.includes(`models${pathSeperator}`)
+        nextLastfile.includes(`definitions/`) ||
+        nextLastfile.includes(`models/`)
       )
     ) {
       continue;


### PR DESCRIPTION
I've been using Dataform on Windows machine since v1.x.x and after a very early version (which I don't remember now), my compile stopped working. Exactly 1 year ago I tried the slack channel for some support with no reply, so I debugged bundle.js and coded myself a quick fix to continue using, and with every Dataform update, I had to "patch" bundle.js for it to continue to work for me.
Recently, when I upgraded to 2.6.4 (Fix `dataform compile` on Windows), my own patch stopped working as well, so I went back on debugging again to code my own fix.

I am NOWHERE NEAR a javascript dev, so I apologize in advance for any misconception. What I found was:
The code doesn't need to know which system you are in (and therefore which folder separator to use) during the execution, but only in the compiling step.

For this:
-  I rolled back the pathSeperator to the default "/" where it is system agnostic; and
-  In the main function, I coded a local function to get the baseFilename that would use the default "/" as the separator.