### PR TITLE
Fixing bug for target name not escaped

### DIFF
--- a/core/compilers.ts
+++ b/core/compilers.ts
@@ -32,7 +32,7 @@ function compileTableSql(code: string, path: string) {
   );
 
   return `
-  publish("${utils.baseFilename(path)}").query(ctx => {
+  publish("${utils.getEscapedFileName(path)}").query(ctx => {
     ${functionsBindings.join("\n")}
     ${js}
     return \`${sql}\`;
@@ -46,7 +46,7 @@ function compileOperationSql(code: string, path: string) {
   );
 
   return `
-  operate("${utils.baseFilename(path)}").queries(ctx => {
+  operate("${utils.getEscapedFileName(path)}").queries(ctx => {
     ${functionsBindings.join("\n")}
     ${js}
     return \`${sql}\`.split("\\n---\\n");
@@ -60,7 +60,7 @@ function compileAssertionSql(code: string, path: string) {
   );
 
   return `
-  assert("${utils.baseFilename(path)}").query(ctx => {
+  assert("${utils.getEscapedFileName(path)}").query(ctx => {
     ${functionsBindings.join("\n")}
     ${js}
     return \`${sql}\`;
@@ -128,7 +128,7 @@ function compileSqlx(rootNode: SyntaxTreeNode, path: string) {
 
   return `dataform.sqlxAction({
   sqlxConfig: {
-    name: "${utils.baseFilename(path)}",
+    name: "${utils.getEscapedFileName(path)}",
     type: "operations",
     ...${config || "{}"}
   },

--- a/core/utils.ts
+++ b/core/utils.ts
@@ -33,6 +33,10 @@ export function baseFilename(fullPath: string) {
     .split(".")[0];
 }
 
+export function getEscapedFileName(path: string) {
+  return baseFilename(path).replace(/\\/g, '\\\\')
+}
+
 export function matchPatterns(patterns: string[], values: string[]) {
   const fullyQualifiedActions: string[] = [];
   patterns.forEach(pattern => {
@@ -269,6 +273,7 @@ export function tableTypeStringToEnum(type: string, throwIfUnknown: boolean) {
 export function tableTypeEnumToString(enumType: dataform.TableType) {
   return dataform.TableType[enumType].toLowerCase();
 }
+
 
 export function setOrValidateTableEnumType(table: dataform.ITable) {
   let enumTypeFromStr: dataform.TableType | null = null;


### PR DESCRIPTION
Fixing bug for filenames not escaped in compiled graph target and canonical target : b/281045260
Testing: Could not add integration test file with a backslash because build rules doesn't allow it, but have tested manually the object: https://screenshot.googleplex.com/B4jrhURyKiyxozB