### PR TITLE
Add support for publishing pre-release/next packages (and stage 2.8.0-beta.1)

### DIFF
--- a/scripts/publish
+++ b/scripts/publish
@@ -15,14 +15,24 @@ fi
 
 bazel test //... --build_tests_only -- -tests/integration:snowflake.spec
 
-bazel run packages/@dataform/cli:package.publish
-bazel run packages/@dataform/core:package.publish
+VERSION=$(cat version.bzl | grep DF_VERSION | awk '{ print $3 }' | sed "s/\"//g")
+
+TAG=next
+
+# If the version is a normal release (1.2.3) and not pre-release e.g (1.2.3-alpha.1) then publish with the 'latest' tag.
+if [[ "$VERSION" =~ [0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    TAG=latest
+fi
+
+echo "Publishing as '$TAG' based on version: $VERSION"
+
+bazel run packages/@dataform/cli:package.publish --tag=$TAG
+bazel run packages/@dataform/core:package.publish --tag=$TAG
 bazel run cli:push
 
-VERSION=$(cat version.bzl | grep DF_VERSION | awk '{ print $3 }' | sed "s/\"//g")
 git tag $VERSION
 git push origin $VERSION
 
 docker pull dataformco/dataform:$VERSION
-docker tag dataformco/dataform:$VERSION dataformco/dataform:latest
+docker tag dataformco/dataform:$VERSION dataformco/dataform:$TAG
 docker push dataformco/dataform:latest

--- a/scripts/publish
+++ b/scripts/publish
@@ -35,4 +35,4 @@ git push origin $VERSION
 
 docker pull dataformco/dataform:$VERSION
 docker tag dataformco/dataform:$VERSION dataformco/dataform:$TAG
-docker push dataformco/dataform:latest
+docker push dataformco/dataform:$TAG

--- a/scripts/publish
+++ b/scripts/publish
@@ -26,8 +26,8 @@ fi
 
 echo "Publishing as '$TAG' based on version: $VERSION"
 
-bazel run packages/@dataform/cli:package.publish --tag=$TAG
-bazel run packages/@dataform/core:package.publish --tag=$TAG
+bazel run packages/@dataform/cli:package.publish -- --tag=$TAG
+bazel run packages/@dataform/core:package.publish -- --tag=$TAG
 bazel run cli:push
 
 git tag $VERSION

--- a/version.bzl
+++ b/version.bzl
@@ -1,3 +1,3 @@
 # NOTE: If you change the format of this line, you must change the bash command
 # in /scripts/publish to extract the version string correctly.
-DF_VERSION = "2.8.0"
+DF_VERSION = "2.8.0-beta.1"


### PR DESCRIPTION
If we publish an alpha, beta package we don't want to mark our docker image or our npm packages as `latest` as they will then get installed by accident.

Both get marked with the `next` tag so you only get them if you explicitly ask for them.