### PR TITLE
Prevent non bq warehouse from being set in workflow settings

### DIFF
--- a/core/main_test.ts
+++ b/core/main_test.ts
@@ -16,7 +16,6 @@ defaultDatabase: dataform
 
 const VALID_DATAFORM_JSON = `
 {
-  "warehouse": "bigquery",
   "defaultDatabase": "dataform"
 }
 `;
@@ -133,6 +132,84 @@ suite("@dataform/core", ({ afterEach }) => {
 
       expect(() => runMainInVm(coreExecutionRequest)).to.throw(
         "Workflow settings error: unexpected key 'notAProjectConfigField'"
+      );
+    });
+
+    test(`main succeeds when dataform.json specifies BigQuery as the warehouse`, () => {
+      const projectDir = tmpDirFixture.createNewTmpDir();
+      // tslint:disable-next-line: tsr-detect-non-literal-fs-filename
+      fs.writeFileSync(
+        path.join(projectDir, "dataform.json"),
+        `{"warehouse": "bigquery", "defaultDatabase": "dataform"}`
+      );
+      const coreExecutionRequest = dataform.CoreExecutionRequest.create({
+        compile: { compileConfig: { projectDir } }
+      });
+
+      const result = runMainInVm(coreExecutionRequest);
+
+      expect(asPlainObject(result.compile.compiledGraph.projectConfig)).deep.equals(
+        asPlainObject({
+          warehouse: "bigquery",
+          defaultDatabase: "dataform"
+        })
+      );
+    });
+
+    test(`main fails when dataform.json specifies non-BigQuery as the warehouse`, () => {
+      const projectDir = tmpDirFixture.createNewTmpDir();
+      // tslint:disable-next-line: tsr-detect-non-literal-fs-filename
+      fs.writeFileSync(
+        path.join(projectDir, "dataform.json"),
+        `{"warehouse": "redshift", "defaultDatabase": "dataform"}`
+      );
+      const coreExecutionRequest = dataform.CoreExecutionRequest.create({
+        compile: { compileConfig: { projectDir } }
+      });
+
+      expect(() => runMainInVm(coreExecutionRequest)).to.throw(
+        "Workflow settings error: the warehouse field is deprecated"
+      );
+    });
+
+    test(`main succeeds when workflow_settings.yaml specifies BigQuery as the warehouse`, () => {
+      const projectDir = tmpDirFixture.createNewTmpDir();
+      // tslint:disable-next-line: tsr-detect-non-literal-fs-filename
+      fs.writeFileSync(
+        path.join(projectDir, "workflow_settings.yaml"),
+        `
+warehouse: bigquery
+defaultDatabase: dataform`
+      );
+      const coreExecutionRequest = dataform.CoreExecutionRequest.create({
+        compile: { compileConfig: { projectDir } }
+      });
+
+      const result = runMainInVm(coreExecutionRequest);
+
+      expect(asPlainObject(result.compile.compiledGraph.projectConfig)).deep.equals(
+        asPlainObject({
+          warehouse: "bigquery",
+          defaultDatabase: "dataform"
+        })
+      );
+    });
+
+    test(`main fails when workflow_settings.yaml specifies non-BigQuery as the warehouse`, () => {
+      const projectDir = tmpDirFixture.createNewTmpDir();
+      // tslint:disable-next-line: tsr-detect-non-literal-fs-filename
+      fs.writeFileSync(
+        path.join(projectDir, "workflow_settings.yaml"),
+        `
+warehouse: redshift
+defaultDatabase: dataform`
+      );
+      const coreExecutionRequest = dataform.CoreExecutionRequest.create({
+        compile: { compileConfig: { projectDir } }
+      });
+
+      expect(() => runMainInVm(coreExecutionRequest)).to.throw(
+        "Workflow settings error: the warehouse field is deprecated"
       );
     });
 

--- a/core/workflow_settings.ts
+++ b/core/workflow_settings.ts
@@ -55,7 +55,7 @@ function verifyWorkflowSettingsAsJson(workflowSettingsAsJson: object): dataform.
     projectConfig.warehouse = "bigquery";
   }
   // tslint:disable-next-line: no-string-literal
-  if (projectConfig.warehouse != "bigquery") {
+  if (projectConfig.warehouse !== "bigquery") {
     throw Error("Workflow settings error: the warehouse field is deprecated");
   }
   return projectConfig;

--- a/core/workflow_settings.ts
+++ b/core/workflow_settings.ts
@@ -50,8 +50,13 @@ function verifyWorkflowSettingsAsJson(workflowSettingsAsJson: object): dataform.
   }
   // tslint:disable-next-line: no-string-literal
   if (!projectConfig.warehouse) {
+    // The warehouse field still set, though deprecated, to simplify compatability with dependents.
     // tslint:disable-next-line: no-string-literal
     projectConfig.warehouse = "bigquery";
+  }
+  // tslint:disable-next-line: no-string-literal
+  if (projectConfig.warehouse != "bigquery") {
+    throw Error("Workflow settings error: the warehouse field is deprecated");
   }
   return projectConfig;
 }


### PR DESCRIPTION
Some more context: as detailed in the design doc for v3, pushing SQL templating out of Core means that the warehouse option is deprecated, as it will no longer have an effect.

It's kept as an exported option for now to avoid the additional work of removing it.