### PR TITLE
Append a compile error when `resolve()` is unable to resolve the given reference to an action.

### DIFF
--- a/core/main.ts
+++ b/core/main.ts
@@ -54,7 +54,13 @@ export function main(coreExecutionRequest: Uint8Array | string): Uint8Array | st
   // Initialize the compilation session.
   const session = nativeRequire("@dataform/core").session as Session;
 
-  session.init(compileRequest.compileConfig.projectDir, projectConfig, originalProjectConfig);
+  session.init(
+    compileRequest.compileConfig.projectDir,
+    projectConfig, originalProjectConfig,
+    // `main.ts` compilation does not support compiling plain ".sql" files.
+    // (They are not require()d, and thus not attached to the session / compiled.)
+    false /* supportSqlFileCompilation */,
+  );
 
   // Allow "includes" files to use the current session object.
   globalAny.dataform = session;

--- a/core/session.ts
+++ b/core/session.ts
@@ -60,6 +60,7 @@ export class Session {
 
   public config: dataform.IProjectConfig;
   public canonicalConfig: dataform.IProjectConfig;
+  public supportSqlFileCompilation: boolean;
 
   public actions: Action[];
   public indexedActions: ActionIndex;
@@ -70,21 +71,24 @@ export class Session {
   constructor(
     rootDir?: string,
     projectConfig?: dataform.IProjectConfig,
-    originalProjectConfig?: dataform.IProjectConfig
+    originalProjectConfig?: dataform.IProjectConfig,
+    supportSqlFileCompilation?: boolean,
   ) {
-    this.init(rootDir, projectConfig, originalProjectConfig);
+    this.init(rootDir, projectConfig, originalProjectConfig, supportSqlFileCompilation);
   }
 
   public init(
     rootDir: string,
     projectConfig?: dataform.IProjectConfig,
-    originalProjectConfig?: dataform.IProjectConfig
+    originalProjectConfig?: dataform.IProjectConfig,
+    supportSqlFileCompilation: boolean = true,
   ) {
     this.rootDir = rootDir;
     this.config = projectConfig || DEFAULT_CONFIG;
     this.canonicalConfig = getCanonicalProjectConfig(
       originalProjectConfig || projectConfig || DEFAULT_CONFIG
     );
+    this.supportSqlFileCompilation = supportSqlFileCompilation;
     this.actions = [];
     this.tests = {};
     this.graphErrors = { compilationErrors: [] };
@@ -223,6 +227,7 @@ export class Session {
     const allResolved = this.indexedActions.find(utils.resolvableAsTarget(ref));
     if (allResolved.length > 1) {
       this.compileError(new Error(utils.ambiguousActionNameMsg(ref, allResolved)));
+      return "";
     }
     const resolved = allResolved.length > 0 ? allResolved[0] : undefined;
 
@@ -235,6 +240,7 @@ export class Session {
       this.compileError(
         new Error("Actions cannot resolve operations which do not produce output.")
       );
+      return "";
     }
 
     if (resolved) {
@@ -250,6 +256,12 @@ export class Session {
         name: this.finalizeName(resolved.proto.target.name),
       });
     }
+
+    if (!this.supportSqlFileCompilation) {
+      this.compileError(new Error(`Could not resolve "${ref}"`));
+      return "";
+    }
+
     // TODO: Here we allow 'ref' to go unresolved. This is for backwards compatibility with projects
     // that use .sql files. In these projects, this session may not know about all actions (yet), and
     // thus we need to fall back to assuming that the target *will* exist in the future. Once we break

--- a/tests/core/core.spec.ts
+++ b/tests/core/core.spec.ts
@@ -991,6 +991,14 @@ suite("@dataform/core", () => {
         });
       }
     );
+
+    test("throws error for unknown action with .sql file compilation unsupported", () => {
+      const session = new Session(path.dirname(__filename), TestConfigs.bigquery, undefined, false);
+      const graph = session.compile();
+      expect(session.resolve("whatever")).to.be.empty;
+      expect(graph.graphErrors.compilationErrors[0].message).deep
+        .equals('Could not resolve "whatever"');
+    });
   });
 
   suite("operate", () => {

--- a/tests/core/core.spec.ts
+++ b/tests/core/core.spec.ts
@@ -995,7 +995,7 @@ suite("@dataform/core", () => {
     test("throws error for unknown action with .sql file compilation unsupported", () => {
       const session = new Session(path.dirname(__filename), TestConfigs.bigquery, undefined, false);
       const graph = session.compile();
-      expect(session.resolve("whatever")).to.be.empty;
+      expect(session.resolve("whatever")).to.equal("");
       expect(graph.graphErrors.compilationErrors[0].message).deep
         .equals('Could not resolve "whatever"');
     });

--- a/version.bzl
+++ b/version.bzl
@@ -1,3 +1,3 @@
 # NOTE: If you change the format of this line, you must change the bash command
 # in /scripts/publish to extract the version string correctly.
-DF_VERSION = "2.8.1"
+DF_VERSION = "2.8.2"


### PR DESCRIPTION
See https://issuetracker.google.com/issues/317289296 for further details.