### PR TITLE
Move common target constructor methods to the action builder

### DIFF
--- a/core/actions/assertion.ts
+++ b/core/actions/assertion.ts
@@ -1,5 +1,5 @@
 import { verifyObjectMatchesProto } from "df/common/protos";
-import { IActionBuilder } from "df/core/actions";
+import { ActionBuilder } from "df/core/actions";
 import {
   IActionConfig,
   ICommonContext,
@@ -63,7 +63,7 @@ export type AContextable<T> = T | ((ctx: AssertionContext) => T);
 /**
  * @hidden
  */
-export class Assertion implements IActionBuilder<dataform.Assertion> {
+export class Assertion extends ActionBuilder<dataform.Assertion> {
   // TODO(ekrekr): make this field private, to enforce proto update logic to happen in this class.
   public proto: dataform.IAssertion = dataform.Assertion.create();
 
@@ -72,6 +72,10 @@ export class Assertion implements IActionBuilder<dataform.Assertion> {
 
   // We delay contextification until the final compile step, so hold these here for now.
   private contextableQuery: AContextable<string>;
+
+  constructor(session?: Session) {
+    super(session);
+  }
 
   public config(config: IAssertionConfig) {
     checkExcessProperties(

--- a/core/actions/declaration.ts
+++ b/core/actions/declaration.ts
@@ -1,5 +1,5 @@
 import { verifyObjectMatchesProto } from "df/common/protos";
-import { IActionBuilder } from "df/core/actions";
+import { ActionBuilder } from "df/core/actions";
 import { ColumnDescriptors } from "df/core/column_descriptors";
 import {
   IColumnsDescriptor,
@@ -28,11 +28,15 @@ export const IDeclarationConfigProperties = strictKeysOf<IDeclarationConfig>()([
 /**
  * @hidden
  */
-export class Declaration implements IActionBuilder<dataform.Declaration> {
+export class Declaration extends ActionBuilder<dataform.Declaration> {
   // TODO(ekrekr): make this field private, to enforce proto update logic to happen in this class.
   public proto: dataform.IDeclaration = dataform.Declaration.create();
 
   public session: Session;
+
+  constructor(session?: Session) {
+    super(session);
+  }
 
   public config(config: IDeclarationConfig) {
     checkExcessProperties(

--- a/core/actions/index.ts
+++ b/core/actions/index.ts
@@ -50,14 +50,14 @@ export abstract class ActionBuilder<T> {
    * @deprecated
    * Configs are soon to be replaced with pure protobuf representations.
    */
-  abstract config(config: any): ActionBuilder<T>;
+  public abstract config(config: any): ActionBuilder<T>;
 
   /** Retrieves the filename from the config. */
-  abstract getFileName(): string;
+  public abstract getFileName(): string;
 
   /** Retrieves the resolved target from the proto. */
-  abstract getTarget(): dataform.Target;
+  public abstract getTarget(): dataform.Target;
 
   /** Creates the final protobuf representation. */
-  abstract compile(): T;
+  public abstract compile(): T;
 }

--- a/core/actions/index.ts
+++ b/core/actions/index.ts
@@ -4,6 +4,7 @@ import { Notebook } from "df/core/actions/notebook";
 import { IOperationConfig, Operation } from "df/core/actions/operation";
 import { ITableConfig, Table, TableType } from "df/core/actions/table";
 import { ITestConfig } from "df/core/actions/test";
+import { Session } from "df/core/session";
 import { dataform } from "df/protos/ts";
 
 export type Action = Table | Operation | Assertion | Declaration | Notebook;
@@ -20,19 +21,43 @@ export type SqlxConfig = (
   | (ITestConfig & { type: "test" })
 ) & { name: string };
 
-export interface IActionBuilder<T> {
+export abstract class ActionBuilder<T> {
+  public session: Session;
+
+  constructor(session?: Session) {
+    this.session = session;
+  }
+
+  // Applying the session canonically means using the schema and database present before overrides.
+  public applySessionCanonicallyToTarget(targetFromConfig: dataform.ITarget): dataform.Target {
+    return dataform.Target.create({
+      name: targetFromConfig.name,
+      schema: targetFromConfig.schema || this.session.canonicalConfig.defaultSchema || undefined,
+      database:
+        targetFromConfig.database || this.session.canonicalConfig.defaultDatabase || undefined
+    });
+  }
+
+  public applySessionToTarget(targetFromConfig: dataform.ITarget): dataform.Target {
+    return dataform.Target.create({
+      name: targetFromConfig.name,
+      schema: targetFromConfig.schema || this.session.config.defaultSchema || undefined,
+      database: targetFromConfig.database || this.session.config.defaultDatabase || undefined
+    });
+  }
+
   /**
    * @deprecated
    * Configs are soon to be replaced with pure protobuf representations.
    */
-  config?: (config: any) => IActionBuilder<T>;
+  abstract config(config: any): ActionBuilder<T>;
 
   /** Retrieves the filename from the config. */
-  getFileName: () => string;
+  abstract getFileName(): string;
 
   /** Retrieves the resolved target from the proto. */
-  getTarget: () => dataform.Target;
+  abstract getTarget(): dataform.Target;
 
   /** Creates the final protobuf representation. */
-  compile: () => T;
+  abstract compile(): T;
 }

--- a/core/actions/notebook.ts
+++ b/core/actions/notebook.ts
@@ -1,37 +1,37 @@
 import { verifyObjectMatchesProto } from "df/common/protos";
-import { IActionBuilder } from "df/core/actions";
+import { ActionBuilder } from "df/core/actions";
 import { Session } from "df/core/session";
 import { dataform } from "df/protos/ts";
 
 /**
  * @hidden
  */
-export class Notebook implements IActionBuilder<dataform.Notebook> {
+export class Notebook extends ActionBuilder<dataform.Notebook> {
   public session: Session;
 
   // TODO: make this field private, to enforce proto update logic to happen in this class.
   public proto: dataform.INotebook = dataform.Notebook.create();
 
   constructor(session: Session, config: dataform.ActionConfig) {
+    super(session);
+
     this.session = session;
     this.proto.config = config;
 
-    // TODO(ekrekr): move this to an Action Builder utility method, once configs are on all protos.
-    const canonicalTarget = this.proto.config.target;
-    this.proto.config.target = dataform.Target.create({
-      name: canonicalTarget.name,
-      schema: canonicalTarget.schema || session.canonicalConfig.defaultSchema || undefined,
-      database: canonicalTarget.database || session.canonicalConfig.defaultDatabase || undefined
-    });
-    this.proto.target = dataform.Target.create({
-      name: canonicalTarget.name,
-      schema: canonicalTarget.schema || session.config.defaultSchema || undefined,
-      database: canonicalTarget.database || session.config.defaultDatabase || undefined
-    });
+    this.proto.target = this.applySessionToTarget(this.proto.config.target);
+    this.proto.config.target = this.applySessionCanonicallyToTarget(this.proto.config.target);
   }
 
-  public notebookContents(notebookContents: string) {
+  public notebookContents(notebookContents: string): Notebook {
     this.proto.notebookContents = notebookContents;
+    return this;
+  }
+
+  /**
+   * @hidden
+   */
+  public config(config: any) {
+    return this;
   }
 
   /**

--- a/core/actions/operation.ts
+++ b/core/actions/operation.ts
@@ -1,5 +1,5 @@
 import { verifyObjectMatchesProto } from "df/common/protos";
-import { IActionBuilder } from "df/core/actions";
+import { ActionBuilder } from "df/core/actions";
 import { ColumnDescriptors } from "df/core/column_descriptors";
 import {
   Contextable,
@@ -61,7 +61,7 @@ export const IIOperationConfigProperties = strictKeysOf<IOperationConfig>()([
 /**
  * @hidden
  */
-export class Operation implements IActionBuilder<dataform.Operation> {
+export class Operation extends ActionBuilder<dataform.Operation> {
   // TODO(ekrekr): make this field private, to enforce proto update logic to happen in this class.
   public proto: dataform.IOperation = dataform.Operation.create();
 
@@ -70,6 +70,10 @@ export class Operation implements IActionBuilder<dataform.Operation> {
 
   // We delay contextification until the final compile step, so hold these here for now.
   private contextableQueries: Contextable<ICommonContext, string | string[]>;
+
+  constructor(session?: Session) {
+    super(session);
+  }
 
   public config(config: IOperationConfig) {
     checkExcessProperties(

--- a/core/actions/table.ts
+++ b/core/actions/table.ts
@@ -1,5 +1,5 @@
 import { verifyObjectMatchesProto } from "df/common/protos";
-import { IActionBuilder } from "df/core/actions";
+import { ActionBuilder } from "df/core/actions";
 import { Assertion } from "df/core/actions/assertion";
 import { ColumnDescriptors } from "df/core/column_descriptors";
 import {
@@ -240,7 +240,7 @@ export interface ITableContext extends ICommonContext {
 /**
  * @hidden
  */
-export class Table implements IActionBuilder<dataform.Table> {
+export class Table extends ActionBuilder<dataform.Table> {
   public static readonly INLINE_IGNORED_PROPS: Array<keyof dataform.ITable> = [
     "bigquery",
     "preOps",
@@ -269,6 +269,10 @@ export class Table implements IActionBuilder<dataform.Table> {
 
   private uniqueKeyAssertions: Assertion[] = [];
   private rowConditionsAssertion: Assertion;
+
+  constructor(session?: Session) {
+    super(session);
+  }
 
   public config(config: ITableConfig) {
     checkExcessProperties(

--- a/core/actions/test.ts
+++ b/core/actions/test.ts
@@ -1,6 +1,6 @@
 import { verifyObjectMatchesProto } from "df/common/protos";
 import { StringifiedMap } from "df/common/strings/stringifier";
-import { IActionBuilder } from "df/core/actions";
+import { ActionBuilder } from "df/core/actions";
 import * as table from "df/core/actions/table";
 import { ITableContext } from "df/core/actions/table";
 import { Contextable, ICommonContext, INamedConfig, Resolvable } from "df/core/common";
@@ -31,7 +31,7 @@ const ITestConfigProperties = strictKeysOf<ITestConfig>()(["type", "dataset", "n
 /**
  * @hidden
  */
-export class Test implements IActionBuilder<dataform.Test> {
+export class Test extends ActionBuilder<dataform.Test> {
   // TODO(ekrekr): make this field private, to enforce proto update logic to happen in this class.
   public proto: dataform.ITest = dataform.Test.create();
 
@@ -43,6 +43,10 @@ export class Test implements IActionBuilder<dataform.Test> {
 
   private datasetToTest: Resolvable;
   private contextableQuery: Contextable<ICommonContext, string>;
+
+  constructor(session?: Session) {
+    super(session);
+  }
 
   public config(config: ITestConfig) {
     checkExcessProperties(


### PR DESCRIPTION
Facilitate this by making the action builder an abstract class.

This makes migrating the existing SQL action types to using the protobuf config types easier.