### PR TITLE
Cleanup: remove action hermeticity

### DIFF
--- a/cli/api/commands/build.ts
+++ b/cli/api/commands/build.ts
@@ -84,8 +84,7 @@ export class Builder {
       tableType: utils.tableTypeEnumToString(table.enumType),
       tasks: table.disabled
         ? []
-        : this.executionSql.publishTasks(table, runConfig, tableMetadata).build(),
-      hermeticity: table.hermeticity || dataform.ActionHermeticity.HERMETIC
+        : this.executionSql.publishTasks(table, runConfig, tableMetadata).build()
     };
   }
 
@@ -95,8 +94,7 @@ export class Builder {
       type: "operation",
       tasks: operation.disabled
         ? []
-        : operation.queries.map(statement => ({ type: "statement", statement })),
-      hermeticity: operation.hermeticity || dataform.ActionHermeticity.NON_HERMETIC
+        : operation.queries.map(statement => ({ type: "statement", statement }))
     };
   }
 
@@ -106,8 +104,7 @@ export class Builder {
       type: "assertion",
       tasks: assertion.disabled
         ? []
-        : this.executionSql.assertTasks(assertion, this.prunedGraph.projectConfig).build(),
-      hermeticity: assertion.hermeticity || dataform.ActionHermeticity.HERMETIC
+        : this.executionSql.assertTasks(assertion, this.prunedGraph.projectConfig).build()
     };
   }
 

--- a/core/actions/assertion.ts
+++ b/core/actions/assertion.ts
@@ -48,7 +48,6 @@ export const IAssertionConfigProperties = strictKeysOf<IAssertionConfig>()([
   "dependencies",
   "description",
   "disabled",
-  "hermetic",
   "name",
   "schema",
   "tags",
@@ -104,9 +103,6 @@ export class Assertion extends ActionBuilder<dataform.Assertion> {
     if (config.dependencies) {
       this.dependencies(config.dependencies);
     }
-    if (config.hermetic !== undefined) {
-      this.hermetic(config.hermetic);
-    }
     if (config.disabled) {
       this.disabled();
     }
@@ -136,12 +132,6 @@ export class Assertion extends ActionBuilder<dataform.Assertion> {
       this.proto.dependencyTargets.push(resolvableAsTarget(resolvable));
     });
     return this;
-  }
-
-  public hermetic(hermetic: boolean) {
-    this.proto.hermeticity = hermetic
-      ? dataform.ActionHermeticity.HERMETIC
-      : dataform.ActionHermeticity.NON_HERMETIC;
   }
 
   public disabled() {

--- a/core/actions/operation.ts
+++ b/core/actions/operation.ts
@@ -51,7 +51,6 @@ export const IIOperationConfigProperties = strictKeysOf<IOperationConfig>()([
   "description",
   "disabled",
   "hasOutput",
-  "hermetic",
   "name",
   "schema",
   "tags",
@@ -103,9 +102,6 @@ export class Operation extends ActionBuilder<dataform.Operation> {
     if (config.dependencies) {
       this.dependencies(config.dependencies);
     }
-    if (config.hermetic !== undefined) {
-      this.hermetic(config.hermetic);
-    }
     if (config.disabled) {
       this.disabled();
     }
@@ -141,12 +137,6 @@ export class Operation extends ActionBuilder<dataform.Operation> {
       this.proto.dependencyTargets.push(resolvableAsTarget(resolvable));
     });
     return this;
-  }
-
-  public hermetic(hermetic: boolean) {
-    this.proto.hermeticity = hermetic
-      ? dataform.ActionHermeticity.HERMETIC
-      : dataform.ActionHermeticity.NON_HERMETIC;
   }
 
   public disabled() {

--- a/core/actions/table.ts
+++ b/core/actions/table.ts
@@ -211,7 +211,6 @@ export const ITableConfigProperties = () =>
     "tags",
     "uniqueKey",
     "dependencies",
-    "hermetic",
     "schema",
     "assertions",
     "database",
@@ -308,9 +307,6 @@ export class Table extends ActionBuilder<dataform.Table> {
     }
     if (config.dependencies) {
       this.dependencies(config.dependencies);
-    }
-    if (config.hermetic !== undefined) {
-      this.hermetic(config.hermetic);
     }
     if (config.disabled) {
       this.disabled();
@@ -419,12 +415,6 @@ export class Table extends ActionBuilder<dataform.Table> {
     });
 
     return this;
-  }
-
-  public hermetic(hermetic: boolean) {
-    this.proto.hermeticity = hermetic
-      ? dataform.ActionHermeticity.HERMETIC
-      : dataform.ActionHermeticity.NON_HERMETIC;
   }
 
   public tags(value: string | string[]) {

--- a/core/common.ts
+++ b/core/common.ts
@@ -123,16 +123,6 @@ export interface IDependenciesConfig {
    * Typically this would remain unset, because most dependencies are declared as a by-product of using the `ref` function.
    */
   dependencies?: Resolvable | Resolvable[];
-
-  /**
-   * Declares whether or not this action is hermetic. An action is hermetic if all of its dependencies are explicitly
-   * declared.
-   *
-   * If this action depends on data from a source which has not been declared as a dependency, then `hermetic`
-   * should be explicitly set to `false`. Otherwise, if this action only depends on data from explicitly-declared
-   * dependencies, then it should be set to `true`.
-   */
-  hermetic?: boolean;
 }
 
 /**

--- a/core/session.ts
+++ b/core/session.ts
@@ -30,7 +30,6 @@ const DEFAULT_CONFIG = {
 export interface IActionProto {
   fileName?: string;
   dependencyTargets?: dataform.ITarget[];
-  hermeticity?: dataform.ActionHermeticity;
   target?: dataform.ITarget;
   canonicalTarget?: dataform.ITarget;
   parentAction?: dataform.ITarget;

--- a/protos/core.proto
+++ b/protos/core.proto
@@ -137,7 +137,6 @@ message Table {
   Target canonical_target = 32;
 
   repeated Target dependency_targets = 27;
-  ActionHermeticity hermeticity = 31;
 
   bool disabled = 6;
 
@@ -167,7 +166,7 @@ message Table {
   // Generated.
   string file_name = 18;
 
-  reserved 1, 2, 7, 12, 16;
+  reserved 1, 2, 7, 12, 16, 31;
 }
 
 message Operation {
@@ -176,8 +175,6 @@ message Operation {
   Target target = 3;
   Target canonical_target = 13;
   repeated Target dependency_targets = 11;
-
-  ActionHermeticity hermeticity = 12;
 
   bool disabled = 14;
 
@@ -190,7 +187,7 @@ message Operation {
   // Generated.
   string file_name = 7;
 
-  reserved 1, 2, 4, 5;
+  reserved 1, 2, 4, 5, 12;
 }
 
 message Assertion {
@@ -200,7 +197,6 @@ message Assertion {
   Target canonical_target = 13;
 
   repeated Target dependency_targets = 11;
-  ActionHermeticity hermeticity = 12;
 
   bool disabled = 14;
 
@@ -216,13 +212,7 @@ message Assertion {
   // Generated.
   string file_name = 7;
 
-  reserved 1, 2, 4, 5, 6;
-}
-
-enum ActionHermeticity {
-  UNKNOWN = 0;
-  HERMETIC = 1;
-  NON_HERMETIC = 2;
+  reserved 1, 2, 4, 5, 6, 12;
 }
 
 message Declaration {

--- a/protos/execution.proto
+++ b/protos/execution.proto
@@ -1,11 +1,10 @@
-syntax="proto3";
+syntax = "proto3";
 
 package dataform;
 
 import "protos/core.proto";
 
 option go_package = "github.com/dataform-co/dataform/protos/dataform";
-
 
 message RunConfig {
   repeated string actions = 1;
@@ -14,7 +13,7 @@ message RunConfig {
   bool include_dependents = 11;
   bool full_refresh = 2;
   int32 timeout_millis = 7;
-  
+
   // For internal use only, will be removed at a later date.
   bool disable_set_metadata = 9;
 
@@ -36,15 +35,13 @@ message ExecutionAction {
   string type = 4;
   string table_type = 6;
 
-  
   repeated Target dependency_targets = 11;
-  ActionHermeticity hermeticity = 10;
 
   repeated ExecutionTask tasks = 2;
 
   ActionDescriptor action_descriptor = 9;
 
-  reserved 1, 3, 7;
+  reserved 1, 3, 7, 10;
 }
 
 message WarehouseState {
@@ -82,7 +79,6 @@ message RunResult {
 }
 
 message ActionResult {
-  
   Target target = 5;
 
   enum ExecutionStatus {
@@ -103,24 +99,23 @@ message ActionResult {
   reserved 1, 6, 7;
 }
 
-
 message ExecutionMetadata {
   message BigqueryMetadata {
     string job_id = 1;
     int64 total_bytes_processed = 2;
-    int64 total_bytes_billed = 3;  
+    int64 total_bytes_billed = 3;
   }
   BigqueryMetadata bigquery = 1;
 }
 
 message TaskResult {
   enum ExecutionStatus {
-      UNKNOWN = 0;
-      RUNNING = 1;
-      SUCCESSFUL = 2;
-      FAILED = 3;
-      SKIPPED = 4;
-      CANCELLED = 5;
+    UNKNOWN = 0;
+    RUNNING = 1;
+    SUCCESSFUL = 2;
+    FAILED = 3;
+    SKIPPED = 4;
+    CANCELLED = 5;
   }
   ExecutionStatus status = 1;
   string error_message = 2;
@@ -135,7 +130,6 @@ message TestResult {
 }
 
 message Field {
-
   enum Primitive {
     UNKNOWN = 0;
     INTEGER = 1;
@@ -158,7 +152,7 @@ message Field {
   }
 
   string name = 1;
-  
+
   repeated Flag flags = 6;
 
   oneof type {

--- a/tests/api/api.spec.ts
+++ b/tests/api/api.spec.ts
@@ -501,8 +501,7 @@ suite("@dataform/api", () => {
                 "create or replace materialized view `deeb.schema.materialized` as select 1 as test"
             }
           ],
-          dependencyTargets: [],
-          hermeticity: dataform.ActionHermeticity.HERMETIC
+          dependencyTargets: []
         },
         {
           type: "table",
@@ -517,8 +516,7 @@ suite("@dataform/api", () => {
               statement: "create or replace view `deeb.schema.plain` as select 1 as test"
             }
           ],
-          dependencyTargets: [],
-          hermeticity: dataform.ActionHermeticity.HERMETIC
+          dependencyTargets: []
         }
       ];
       const executionGraph = new Builder(testGraph, {}, dataform.WarehouseState.create({})).build();

--- a/tests/api/api.spec.ts
+++ b/tests/api/api.spec.ts
@@ -566,8 +566,7 @@ suite("@dataform/api", () => {
                 "create or replace table `deeb.schema.partitionby` partition by DATE(test) as select 1 as test"
             }
           ],
-          dependencyTargets: [],
-          hermeticity: dataform.ActionHermeticity.HERMETIC
+          dependencyTargets: []
         },
         {
           type: "table",
@@ -582,8 +581,7 @@ suite("@dataform/api", () => {
               statement: "create or replace table `deeb.schema.plain` as select 1 as test"
             }
           ],
-          dependencyTargets: [],
-          hermeticity: dataform.ActionHermeticity.HERMETIC
+          dependencyTargets: []
         }
       ];
       const executionGraph = new Builder(testGraph, {}, dataform.WarehouseState.create({})).build();
@@ -635,8 +633,7 @@ suite("@dataform/api", () => {
                 "create or replace table `deeb.schema.partitionby` partition by DATE(test) OPTIONS(partition_expiration_days=1,require_partition_filter=true)as select 1 as test"
             }
           ],
-          dependencyTargets: [],
-          hermeticity: dataform.ActionHermeticity.HERMETIC
+          dependencyTargets: []
         },
         {
           type: "table",
@@ -651,8 +648,7 @@ suite("@dataform/api", () => {
               statement: "create or replace table `deeb.schema.plain` as select 1 as test"
             }
           ],
-          dependencyTargets: [],
-          hermeticity: dataform.ActionHermeticity.HERMETIC
+          dependencyTargets: []
         }
       ];
       const executionGraph = new Builder(testGraph, {}, dataform.WarehouseState.create({})).build();
@@ -702,8 +698,7 @@ suite("@dataform/api", () => {
                 "create or replace table `deeb.schema.partitionby` partition by DATE(test) cluster by name, revenue as select 1 as test"
             }
           ],
-          dependencyTargets: [],
-          hermeticity: dataform.ActionHermeticity.HERMETIC
+          dependencyTargets: []
         },
         {
           type: "table",
@@ -718,8 +713,7 @@ suite("@dataform/api", () => {
               statement: "create or replace table `deeb.schema.plain` as select 1 as test"
             }
           ],
-          dependencyTargets: [],
-          hermeticity: dataform.ActionHermeticity.HERMETIC
+          dependencyTargets: []
         }
       ];
       const executionGraph = new Builder(testGraph, {}, dataform.WarehouseState.create({})).build();
@@ -772,8 +766,7 @@ suite("@dataform/api", () => {
                 'create or replace table `deeb.schema.additional_options` OPTIONS(partition_expiration_days=1,require_partition_filter=true,friendly_name="friendlyName")as select 1 as test'
             }
           ],
-          dependencyTargets: [],
-          hermeticity: dataform.ActionHermeticity.HERMETIC
+          dependencyTargets: []
         },
         {
           type: "table",
@@ -788,8 +781,7 @@ suite("@dataform/api", () => {
               statement: "create or replace table `deeb.schema.plain` as select 1 as test"
             }
           ],
-          dependencyTargets: [],
-          hermeticity: dataform.ActionHermeticity.HERMETIC
+          dependencyTargets: []
         }
       ];
       const executionGraph = new Builder(testGraph, {}, dataform.WarehouseState.create({})).build();

--- a/tests/api/projects.spec.ts
+++ b/tests/api/projects.spec.ts
@@ -35,17 +35,17 @@ suite("examples", () => {
             {
               fileName: "definitions/has_compile_errors/assertion_with_bigquery.sqlx",
               message:
-                'Unexpected property "bigquery" in assertion config. Supported properties are: ["database","dependencies","description","disabled","hermetic","name","schema","tags","type"]'
+                'Unexpected property "bigquery" in assertion config. Supported properties are: ["database","dependencies","description","disabled","name","schema","tags","type"]'
             },
             {
               fileName: "definitions/has_compile_errors/assertion_with_materialized.sqlx",
               message:
-                'Unexpected property "materialized" in assertion config. Supported properties are: ["database","dependencies","description","disabled","hermetic","name","schema","tags","type"]'
+                'Unexpected property "materialized" in assertion config. Supported properties are: ["database","dependencies","description","disabled","name","schema","tags","type"]'
             },
             {
               fileName: "definitions/has_compile_errors/assertion_with_output.sqlx",
               message:
-                'Unexpected property "hasOutput" in assertion config. Supported properties are: ["database","dependencies","description","disabled","hermetic","name","schema","tags","type"]'
+                'Unexpected property "hasOutput" in assertion config. Supported properties are: ["database","dependencies","description","disabled","name","schema","tags","type"]'
             },
             {
               fileName: "definitions/has_compile_errors/assertion_with_postops.sqlx",
@@ -63,7 +63,7 @@ suite("examples", () => {
             {
               fileName: "definitions/has_compile_errors/protected_assertion.sqlx",
               message:
-                'Unexpected property "protected" in assertion config. Supported properties are: ["database","dependencies","description","disabled","hermetic","name","schema","tags","type"]'
+                'Unexpected property "protected" in assertion config. Supported properties are: ["database","dependencies","description","disabled","name","schema","tags","type"]'
             },
             {
               fileName: "definitions/has_compile_errors/view_with_incremental.sqlx",

--- a/tests/api/projects/common_v2/definitions/example_deferred.js
+++ b/tests/api/projects/common_v2/definitions/example_deferred.js
@@ -1,3 +1,3 @@
 const macros = require("includes/subdirectory/macros");
 
-macros.deferredPublish("example_deferred", "select 1 as test").hermetic(false);
+macros.deferredPublish("example_deferred", "select 1 as test");

--- a/tests/api/projects/common_v2/definitions/example_double_backslash.sqlx
+++ b/tests/api/projects/common_v2/definitions/example_double_backslash.sqlx
@@ -1,6 +1,5 @@
 config {
-    type: "view",
-    hermetic: false
+    type: "view"
 }
 
 select * from regexp_extract('01a_data_engine', '^(\\d{2}\\w)')

--- a/tests/api/projects/common_v2/definitions/example_incremental.sqlx
+++ b/tests/api/projects/common_v2/definitions/example_incremental.sqlx
@@ -1,4 +1,4 @@
-config { type: "incremental", protected: true, hermetic: false }
+config { type: "incremental", protected: true }
 
 select current_timestamp() as ts
 

--- a/tests/api/projects/common_v2/definitions/example_is_incremental.sqlx
+++ b/tests/api/projects/common_v2/definitions/example_is_incremental.sqlx
@@ -1,4 +1,4 @@
-config { type: "incremental", protected: true, hermetic: false }
+config { type: "incremental", protected: true }
 
 select * from (
     select current_timestamp() as ts

--- a/tests/api/projects/common_v2/definitions/example_js_blocks.sqlx
+++ b/tests/api/projects/common_v2/definitions/example_js_blocks.sqlx
@@ -1,6 +1,5 @@
 config {
     type: "table",
-    hermetic: false
 }
 js { const bar = "foo"; }
 js { var foo = () => bar; }

--- a/tests/api/projects/common_v2/definitions/has_compile_errors/assertion_with_bigquery.sqlx
+++ b/tests/api/projects/common_v2/definitions/has_compile_errors/assertion_with_bigquery.sqlx
@@ -1,2 +1,2 @@
-config { type: "assertion", bigquery: { partitionBy: "something0", clusterBy: ["something1", "something2"] }, hermetic: false }
+config { type: "assertion", bigquery: { partitionBy: "something0", clusterBy: ["something1", "something2"] } }
 SELECT 1 as test

--- a/tests/api/projects/common_v2/definitions/has_compile_errors/assertion_with_materialized.sqlx
+++ b/tests/api/projects/common_v2/definitions/has_compile_errors/assertion_with_materialized.sqlx
@@ -1,2 +1,2 @@
-config { type: "assertion", materialized: true, hermetic: false }
+config { type: "assertion", materialized: true }
 SELECT 1 as test

--- a/tests/api/projects/common_v2/definitions/has_compile_errors/assertion_with_output.sqlx
+++ b/tests/api/projects/common_v2/definitions/has_compile_errors/assertion_with_output.sqlx
@@ -1,2 +1,2 @@
-config { type: "assertion", hasOutput: true, hermetic: false }
+config { type: "assertion", hasOutput: true }
 SELECT 1 as test

--- a/tests/api/projects/common_v2/definitions/has_compile_errors/assertion_with_postops.sqlx
+++ b/tests/api/projects/common_v2/definitions/has_compile_errors/assertion_with_postops.sqlx
@@ -1,3 +1,3 @@
-config { type: "assertion", hermetic: false }
+config { type: "assertion" }
 SELECT 1 as test
 post_operations { select 2 as other }

--- a/tests/api/projects/common_v2/definitions/has_compile_errors/assertion_with_preops.sqlx
+++ b/tests/api/projects/common_v2/definitions/has_compile_errors/assertion_with_preops.sqlx
@@ -1,3 +1,3 @@
-config { type: "assertion", hermetic: false }
+config { type: "assertion" }
 SELECT 1 as test
 pre_operations { select 2 as other }

--- a/tests/api/projects/common_v2/definitions/has_compile_errors/protected_assertion.sqlx
+++ b/tests/api/projects/common_v2/definitions/has_compile_errors/protected_assertion.sqlx
@@ -1,2 +1,2 @@
-config { type: "assertion", protected: true, hermetic: false }
+config { type: "assertion", protected: true }
 select 1 as test

--- a/tests/api/projects/common_v2/definitions/has_compile_errors/table_with_materialized.sqlx
+++ b/tests/api/projects/common_v2/definitions/has_compile_errors/table_with_materialized.sqlx
@@ -1,2 +1,2 @@
-config { type: "table", materialized: true, hermetic: true }
+config { type: "table", materialized: true }
 select 1 as test

--- a/tests/api/projects/common_v2/definitions/has_compile_errors/view_with_incremental.sqlx
+++ b/tests/api/projects/common_v2/definitions/has_compile_errors/view_with_incremental.sqlx
@@ -1,4 +1,4 @@
-config { type: "view", hermetic: false }
+config { type: "view" }
 
 select 1 as test
 

--- a/tests/api/projects/common_v2/definitions/has_compile_errors/view_with_multiple_statements.sqlx
+++ b/tests/api/projects/common_v2/definitions/has_compile_errors/view_with_multiple_statements.sqlx
@@ -1,4 +1,4 @@
-config { type: "view", hermetic: false }
+config { type: "view" }
 select 1 as test
 ---
 select 2 as test2

--- a/tests/api/projects/common_v2/definitions/has_compile_errors/view_with_semi_colon_at_end.sqlx
+++ b/tests/api/projects/common_v2/definitions/has_compile_errors/view_with_semi_colon_at_end.sqlx
@@ -1,2 +1,2 @@
-config { type: "view", hermetic: true }
+config { type: "view" }
 select 1 as test;

--- a/tests/api/projects/common_v2/definitions/override_database_example.sqlx
+++ b/tests/api/projects/common_v2/definitions/override_database_example.sqlx
@@ -1,7 +1,6 @@
 config {
     database: "override_database",
     type: "view",
-    hermetic: false
 }
 
 select 1 as test_database_override

--- a/tests/api/projects/common_v2/definitions/override_schema_example.sqlx
+++ b/tests/api/projects/common_v2/definitions/override_schema_example.sqlx
@@ -1,7 +1,6 @@
 config {
     schema: "override_schema",
     type: "view",
-    hermetic: false
 }
 
 select 1 as test_schema_override

--- a/tests/api/projects/common_v2/definitions/override_schema_example_unchanged.sqlx
+++ b/tests/api/projects/common_v2/definitions/override_schema_example_unchanged.sqlx
@@ -1,7 +1,6 @@
 config {
     schema: "df_integration_test",
     type: "view",
-    hermetic: false
 }
 
 select 1 as test_schema_override

--- a/tests/api/projects/common_v2/definitions/sample_data.sqlx
+++ b/tests/api/projects/common_v2/definitions/sample_data.sqlx
@@ -4,7 +4,6 @@ config {
   columns: {
       sample: "Sample integers."
   },
-  hermetic: false
 }
 
 pre_operations {

--- a/tests/cli/cli.spec.ts
+++ b/tests/cli/cli.spec.ts
@@ -131,7 +131,6 @@ select 1 as \${dataform.projectConfig.vars.testVar2}
       actions: [
         {
           fileName: "definitions/example.sqlx",
-          hermeticity: "HERMETIC",
           tableType: "table",
           target: {
             database: "dataform-integration-tests",

--- a/tests/integration/bigquery_project/definitions/example_incremental.sqlx
+++ b/tests/integration/bigquery_project/definitions/example_incremental.sqlx
@@ -13,7 +13,6 @@ config {
         },
         not_a_column_name: "shouldn't appear"
     },
-    hermetic: false
 }
 
 WITH example_data AS (

--- a/tests/integration/bigquery_project/definitions/example_incremental_merge.sqlx
+++ b/tests/integration/bigquery_project/definitions/example_incremental_merge.sqlx
@@ -16,7 +16,6 @@ config {
     partitionBy: "RANGE_BUCKET(ts, GENERATE_ARRAY(0, 6, 2))",
     updatePartitionFilter: "ts > 2"
   },
-  hermetic: false
 }
 
 SELECT ts, id_1, id_2, val

--- a/tests/integration/bigquery_project/definitions/sample_data.sqlx
+++ b/tests/integration/bigquery_project/definitions/sample_data.sqlx
@@ -1,6 +1,5 @@
 config {
   type: "view",
-  hermetic: false
 }
 
 select ${when(dataform.projectConfig.vars.fooVar === "bar", "1", "2")} as val union all

--- a/tests/integration/bigquery_project/definitions/sample_data_2.sqlx
+++ b/tests/integration/bigquery_project/definitions/sample_data_2.sqlx
@@ -11,7 +11,6 @@ config {
             "'fo\\'o' = 'fo\\'o'"
         ]
     },
-    hermetic: true
 }
 
 select 1 as val1, 1 as val2, NULL as val3 union all

--- a/tests/integration/bigquery_project/definitions/sample_data_3.sqlx
+++ b/tests/integration/bigquery_project/definitions/sample_data_3.sqlx
@@ -1,6 +1,5 @@
 config {
     type: "view",
-    hermetic: true
 }
 
 select 1 as val1, 1 as val2, NULL as val3 union all


### PR DESCRIPTION
Although this option is currently documented https://cloud.google.com/dataform/docs/reference/dataform-core-reference#itableconfig, it doesn't have an effect anywhere.

IIRC from past discussions of lessons learned, we would do this differently if done today.