### PR TITLE
Improve proto validation errors where possible

### DIFF
--- a/common/protos/index.ts
+++ b/common/protos/index.ts
@@ -14,23 +14,29 @@ export interface IProtoClass<IProto, Proto> {
   fromObject(obj: { [k: string]: any }): Proto;
 }
 
-// ProtobufJS's native verify method does not check that only defined fields are present.
-// Note: ProtobufJS does not do conversion of typed fields, so if a type number is present but a
-// string expected, this won't throw an error.
-// TODO(ekrekr): swap to Typescript protobuf library rather than having to do this; however using TS
-// libraries currently available would incur a significant performance hit.
+// This is a minimalist Typescript equivalent for the validation part of Profobuf's JsonFormat's
+// mergeMessage method:
+// https://github.com/protocolbuffers/protobuf/blob/670e0c2a0d0b64c994f743a73ee9b8926c47580d/java/util/src/main/java/com/google/protobuf/util/JsonFormat.java#L1455
+// This is used because:
+// * ProtobufJS's native verify method does not check that only defined fields are present.
+// * Other libraries, such as ProtobufTS, incur significant performance hits.
+// However, the main downside of using ProtobufJS is that it does not record the expected types of
+// fields, meaning that the type of fields cannot be verified; an int can be confused with a string.
 export function verifyObjectMatchesProto<Proto>(
   protoType: IProtoClass<any, Proto>,
   object: object
 ): Proto {
-  // Create a version of the object that only contains the valid proto fields.
-  // ProtobufJS doesn't care about the types of the values of fields.
+  if (Array.isArray(object)) {
+    throw ReferenceError(`Expected a top-level object, but found an array`);
+  }
+
+  // Calling toObject on the object/JSON creates a version only contains the valid proto fields.
   const proto = protoType.create(object);
   const protoCastObject = protoType.toObject(proto);
 
   function checkFields(present: { [k: string]: any }, desired: { [k: string]: any }) {
-    // Present is guaranteed to be a strict subset of desired.
-    // Present fields cannot have empty values.
+    // Only the entries of present need to be iterated through as desired is guaranteed to be a
+    // strict subset of present.
     Object.entries(present).forEach(([presentKey, presentValue]) => {
       const desiredValue = desired[presentKey];
       if (typeof desiredValue !== typeof presentValue) {
@@ -39,10 +45,12 @@ export function verifyObjectMatchesProto<Proto>(
           return;
         }
         if (typeof presentValue === "object" && Object.keys(presentValue).length === 0) {
-          // Empty objects are assigned to empty objects by ProtobufJS.
+          // Empty objects are assigned to empty object fields by ProtobufJS.
           return;
         }
-        throw ReferenceError(`unexpected key '${presentKey}'`);
+        throw ReferenceError(
+          `Cannot find field: ${presentKey} in message, or value type is incorrect`
+        );
       }
       if (typeof presentValue === "object") {
         checkFields(presentValue, desiredValue);

--- a/common/protos/index.ts
+++ b/common/protos/index.ts
@@ -19,9 +19,9 @@ export interface IProtoClass<IProto, Proto> {
 // https://github.com/protocolbuffers/protobuf/blob/670e0c2a0d0b64c994f743a73ee9b8926c47580d/java/util/src/main/java/com/google/protobuf/util/JsonFormat.java#L1455
 // This is used because:
 // * ProtobufJS's native verify method does not check that only defined fields are present.
-// * Other libraries, such as ProtobufTS, incur significant performance hits.
-// However, the main downside of using ProtobufJS is that it does not record the expected types of
-// fields, meaning that the type of fields cannot be verified; an int can be confused with a string.
+// * Other protobuf libraries, such as ProtobufTS, incur significant performance hits.
+// A key downside of using ProtobufJS is that it does not record the expected types of fields,
+// meaning that the type of fields cannot be verified; an int can be confused with a string.
 export function verifyObjectMatchesProto<Proto>(
   protoType: IProtoClass<any, Proto>,
   object: object
@@ -35,8 +35,8 @@ export function verifyObjectMatchesProto<Proto>(
   const protoCastObject = protoType.toObject(proto);
 
   function checkFields(present: { [k: string]: any }, desired: { [k: string]: any }) {
-    // Only the entries of present need to be iterated through as desired is guaranteed to be a
-    // strict subset of present.
+    // Only the entries of `present` need to be iterated through as `desired` is guaranteed to be a
+    // strict subset of `present`.
     Object.entries(present).forEach(([presentKey, presentValue]) => {
       const desiredValue = desired[presentKey];
       if (typeof desiredValue !== typeof presentValue) {

--- a/core/main_test.ts
+++ b/core/main_test.ts
@@ -132,7 +132,20 @@ suite("@dataform/core", ({ afterEach }) => {
       });
 
       expect(() => runMainInVm(coreExecutionRequest)).to.throw(
-        "Workflow settings error: unexpected key 'notAProjectConfigField'"
+        "Cannot find field: notAProjectConfigField in message"
+      );
+    });
+
+    test(`main fails when a valid workflow_settings.yaml base level is an array`, () => {
+      const projectDir = tmpDirFixture.createNewTmpDir();
+      // tslint:disable-next-line: tsr-detect-non-literal-fs-filename
+      fs.writeFileSync(path.join(projectDir, "workflow_settings.yaml"), "- someArrayEntry");
+      const coreExecutionRequest = dataform.CoreExecutionRequest.create({
+        compile: { compileConfig: { projectDir } }
+      });
+
+      expect(() => runMainInVm(coreExecutionRequest)).to.throw(
+        "Expected a top-level object, but found an array"
       );
     });
 
@@ -226,7 +239,7 @@ defaultDatabase: dataform`
       });
 
       expect(() => runMainInVm(coreExecutionRequest)).to.throw(
-        "Workflow settings error: unexpected key 'notAProjectConfigField'"
+        "Cannot find field: notAProjectConfigField in message"
       );
     });
 


### PR DESCRIPTION
I think this is our limit for good errors of proto validation - to improve them we'd have to swap to a type based protobuf library, and accept the performance cost.