### PR TITLE
Include type declarations with @dataform/core

### DIFF
--- a/packages/@dataform/core/BUILD
+++ b/packages/@dataform/core/BUILD
@@ -61,10 +61,26 @@ copy_file(
     out = "core.proto",
 )
 
+pkg_bundle_dts(
+    name = "bundle.d",
+    entry_point = "index.ts",
+    externals = [
+      "protobufjs",
+      "tarjan-graph",
+      "semver",
+      "moo",
+      "long",
+    ],
+    deps = [
+        ":core",
+    ],
+)
+
 pkg_npm_tar(
     name = "package",
     deps = [
         ":bundle",
+        ":bundle.d",
         ":package.json",
         ":core.proto",
     ],


### PR DESCRIPTION
A suggested, trivial resolution for https://github.com/dataform-co/dataform/issues/1646.

I understand the typings were removed in https://github.com/dataform-co/dataform/pull/1552 to minimize the installed footprint of the `@dataform/core` package.

While re-adding the declarations file increases the bundle size, the size reductions introduced by #1552 would remain very similar. Before the introduction of minification, the total `node_module` size was 9.4MB. After the minifaction PR, it was ~432KB, and with the `d.ts` file re-added it would increase back to ~675KB. Instead of the original ~20x reduction, we just get a ~16x reduction. This increase can not impact compile performance, as the types file is not used during run time, so that performance gain remains.

This is just a suggestion. As I mentioned in the issue, my goal is to get type declarations for the `@dataform/core` package.

I'm very happy to assist with any solution that achieves this, including publishing type declarations in a separate package, possibly to the Definitely Typed repository.

I'd like to nominate @lewish as reviewer, since he introduced #1552 .