### PR TITLE
Update Dataform CLI npm installs to best-effort

### DIFF
--- a/cli/api/commands/init.ts
+++ b/cli/api/commands/init.ts
@@ -4,7 +4,6 @@ import * as path from "path";
 
 import { CREDENTIALS_FILENAME } from "df/cli/api/commands/credentials";
 import { install } from "df/cli/api/commands/install";
-import { prettyJsonStringify } from "df/cli/api/utils";
 import { version } from "df/core/version";
 import { dataform } from "df/protos/ts";
 

--- a/cli/api/commands/install.ts
+++ b/cli/api/commands/install.ts
@@ -22,17 +22,6 @@ export async function install(projectPath: string, skipInstall?: boolean) {
   let dataformCoreVersion = readDataformCoreVersionIfPresent(workflowSettingsPath);
 
   if (dataformCoreVersion) {
-    if (fs.existsSync(packageJsonPath)) {
-      throw new Error(
-        "dataformCoreVersion cannot be defined in workflow_settings.yaml when a package.json is present"
-      );
-    }
-    if (fs.existsSync(packageLockJsonPath)) {
-      throw new Error(
-        "dataformCoreVersion cannot be defined in workflow_settings.yaml when a package-lock.json is present"
-      );
-    }
-
     // If there are other packages already in the package.json, specifying a specific package to
     // install will trigger the other packages to be installed too.
     installCommand += ` @dataform/core@${dataformCoreVersion}`;

--- a/cli/api/commands/install.ts
+++ b/cli/api/commands/install.ts
@@ -1,11 +1,62 @@
+import * as fs from "fs";
+import { load as loadYaml, YAMLException } from "js-yaml";
 import * as path from "path";
 import { promisify } from "util";
 
 import * as childProcess from "child_process";
+import { dataform } from "df/protos/ts";
 
-export async function install(projectDir: string, skipInstall?: boolean) {
+export async function install(projectPath: string, skipInstall?: boolean) {
   if (skipInstall) {
     return;
   }
-  await promisify(childProcess.exec)("npm i --ignore-scripts", { cwd: path.resolve(projectDir) });
+  const resolvedProjectPath = path.resolve(projectPath);
+  const workflowSettingsPath = path.join(resolvedProjectPath, "workflow_settings.yaml");
+  const packageJsonPath = path.join(resolvedProjectPath, "package.json");
+  const packageLockJsonPath = path.join(resolvedProjectPath, "package-lock.json");
+
+  let installCommand = "npm i --ignore-scripts";
+
+  if (fs.existsSync(workflowSettingsPath)) {
+    // Core's readWorkflowSettings method cannot be used for this because Core assumes that
+    // `require` can read YAML files directly.
+    const workflowSettings = readWorkflowSettings(workflowSettingsPath);
+    if (workflowSettings.dataformCoreVersion) {
+      if (fs.existsSync(packageJsonPath)) {
+        throw new Error(
+          "dataformCoreVersion cannot be defined in workflow_settings.yaml when a package.json is present"
+        );
+      }
+      if (fs.existsSync(packageLockJsonPath)) {
+        throw new Error(
+          "dataformCoreVersion cannot be defined in workflow_settings.yaml when a package-lock.json is present"
+        );
+      }
+      // If there are other packages already in the package.json, specifying a specific package to
+      // install will trigger the other packages to be installed too.
+      installCommand += ` @dataform/core@${workflowSettings.dataformCoreVersion}`;
+    } else {
+      if (!fs.existsSync(packageJsonPath)) {
+        throw new Error(
+          "dataformCoreVersion must be specified either in workflow_settings.yaml or via a package.json"
+        );
+      }
+    }
+  }
+
+  await promisify(childProcess.exec)(installCommand, { cwd: resolvedProjectPath });
+}
+
+function readWorkflowSettings(workflowSettingsPath: string): dataform.ProjectConfig {
+  const workflowSettingsContent = fs.readFileSync(workflowSettingsPath, "utf-8");
+  let workflowSettingsAsJson = {};
+  try {
+    workflowSettingsAsJson = loadYaml(workflowSettingsContent);
+  } catch (e) {
+    if (e instanceof YAMLException) {
+      throw Error(`${path} is not a valid YAML file: ${e}`);
+    }
+    throw e;
+  }
+  return dataform.ProjectConfig.create(workflowSettingsAsJson);
 }

--- a/cli/api/commands/install.ts
+++ b/cli/api/commands/install.ts
@@ -19,7 +19,7 @@ export async function install(projectPath: string, skipInstall?: boolean) {
 
   // Core's readWorkflowSettings method cannot be used for this because Core assumes that
   // `require` can read YAML files directly.
-  let dataformCoreVersion = readDataformCoreVersionIfPresent(workflowSettingsPath);
+  const dataformCoreVersion = readDataformCoreVersionIfPresent(workflowSettingsPath);
 
   if (dataformCoreVersion) {
     // If there are other packages already in the package.json, specifying a specific package to

--- a/version.bzl
+++ b/version.bzl
@@ -1,3 +1,3 @@
 # NOTE: If you change the format of this line, you must change the bash command
 # in /scripts/publish to extract the version string correctly.
-DF_VERSION = "3.0.0-alpha.2"
+DF_VERSION = "3.0.0-alpha.3"


### PR DESCRIPTION
General UX:

|                      | **dataformCoreVersion present**                          | **no dataformCoreVersion present**                  |
|----------------------|------------------------------------------------------|-------------------------------------------------|
| **package.json present** | ✅ Install from dataformCoreVersion in workflow_settings.yaml | ✅ Install from @dataform/core version in package.json                |
| **no package.json**      | ✅ Install from dataformCoreVersion in workflow_settings.yaml                     | ❌ Throw error about no version definition present |