### PR TITLE
Allow 'partitionBy' and 'clusterBy' params for bigquery materialized views

### DIFF
--- a/core/session.ts
+++ b/core/session.ts
@@ -730,10 +730,22 @@ export class Session {
             table.bigquery.clusterBy?.length ||
             table.bigquery.partitionExpirationDays ||
             table.bigquery.requirePartitionFilter) &&
-          table.enumType === dataform.TableType.VIEW
+          table.enumType === dataform.TableType.VIEW &&
+          !table.materialized
         ) {
           this.compileError(
-            `partitionBy/clusterBy/requirePartitionFilter/partitionExpirationDays are not valid for BigQuery views; they are only valid for tables`,
+            `partitionBy/clusterBy/requirePartitionFilter/partitionExpirationDays are not valid for BigQuery views`,
+            table.fileName,
+            table.target
+          );
+        } else if (
+          (table.bigquery.partitionExpirationDays ||
+            table.bigquery.requirePartitionFilter) &&
+          table.enumType === dataform.TableType.VIEW &&
+          table.materialized
+        ) {
+          this.compileError(
+            `requirePartitionFilter/partitionExpirationDays are not valid for BigQuery materialized views`,
             table.fileName,
             table.target
           );

--- a/tests/core/core.spec.ts
+++ b/tests/core/core.spec.ts
@@ -513,6 +513,30 @@ suite("@dataform/core", () => {
           partitionExpirationDays: 7
         }
       });
+      session.publish("example_require_partition_filter_view_fail", {
+        type: "view",
+        bigquery: {
+          requirePartitionFilter: true
+        }
+      });
+      session.publish("example_expiring_materialized_view_fail", {
+        type: "view",
+        materialized: true,
+        bigquery: {
+          partitionBy: "some_partition",
+          clusterBy: ["some_cluster"],
+          partitionExpirationDays: 7
+        }
+      });
+      session.publish("example_require_partition_filter_materialized_view_fail", {
+        type: "view",
+        materialized: true,
+        bigquery: {
+          partitionBy: "some_partition",
+          clusterBy: ["some_cluster"],
+          requirePartitionFilter: true
+        }
+      });
       session.publish("example_materialize_table_fail", {
         type: "table",
         materialized: true
@@ -554,15 +578,27 @@ suite("@dataform/core", () => {
       ).has.deep.members([
         {
           actionName: "schema.example_partitionBy_view_fail",
-          message: `partitionBy/clusterBy/requirePartitionFilter/partitionExpirationDays are not valid for BigQuery views; they are only valid for tables`
+          message: `partitionBy/clusterBy/requirePartitionFilter/partitionExpirationDays are not valid for BigQuery views`
         },
         {
           actionName: "schema.example_clusterBy_view_fail",
-          message: `partitionBy/clusterBy/requirePartitionFilter/partitionExpirationDays are not valid for BigQuery views; they are only valid for tables`
+          message: `partitionBy/clusterBy/requirePartitionFilter/partitionExpirationDays are not valid for BigQuery views`
         },
         {
           actionName: "schema.example_expiring_view_fail",
-          message: `partitionBy/clusterBy/requirePartitionFilter/partitionExpirationDays are not valid for BigQuery views; they are only valid for tables`
+          message: `partitionBy/clusterBy/requirePartitionFilter/partitionExpirationDays are not valid for BigQuery views`
+        },
+        {
+          actionName: "schema.example_require_partition_filter_view_fail",
+          message: `partitionBy/clusterBy/requirePartitionFilter/partitionExpirationDays are not valid for BigQuery views`
+        },
+        {
+          actionName: "schema.example_expiring_materialized_view_fail",
+          message: `requirePartitionFilter/partitionExpirationDays are not valid for BigQuery materialized views`
+        },
+        {
+          actionName: "schema.example_require_partition_filter_materialized_view_fail",
+          message: `requirePartitionFilter/partitionExpirationDays are not valid for BigQuery materialized views`
         },
         {
           actionName: "schema.example_materialize_table_fail",

--- a/version.bzl
+++ b/version.bzl
@@ -1,3 +1,3 @@
 # NOTE: If you change the format of this line, you must change the bash command
 # in /scripts/publish to extract the version string correctly.
-DF_VERSION = "2.8.4"
+DF_VERSION = "2.9.0"


### PR DESCRIPTION
The problem with support of `partitionBy` and `clusterBy` params for BigQuery materialised views seems caused just by validation rules in the core, the BigQuery adapter is able to construct valid DDL without additional modifications.

Please take a note, that I have not found a way to test it locally (construct the DDL from sqlx), will do it, if someone helps me to find guidelines how to do it (contributing.md was not enough). Otherwise, all hopes are on your CI/CD.

This fixes #1441 and partially #1334 