### PR TITLE
Adding default-schema option to the init command

### DIFF
--- a/api/commands/init.ts
+++ b/api/commands/init.ts
@@ -49,8 +49,7 @@ export async function init(
     dataformJsonPath,
     prettyJsonStringify(
       dataform.ProjectConfig.create({
-        defaultSchema: "dataform",
-        assertionSchema: "dataform_assertions",
+        assertionSchema: projectConfig.defaultSchema + "_assertions",
         ...projectConfig
       })
     )

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -226,6 +226,15 @@ export function runCli() {
             }
           },
           {
+            ...ProjectConfigOptions.defaultSchema,
+            option: {
+              ...ProjectConfigOptions.defaultSchema.option,
+              describe:
+                "The default schema to use. If not set it will be defined as `dataform`.",
+              default: "dataform"
+            }
+          },
+          {
             name: skipInstallOptionName,
             option: {
               describe: "Whether to skip installing NPM packages.",
@@ -241,6 +250,7 @@ export function runCli() {
               warehouse: argv[ProjectConfigOptions.warehouse.name],
               defaultDatabase: argv[ProjectConfigOptions.defaultDatabase.name],
               defaultLocation: argv[ProjectConfigOptions.defaultLocation.name],
+              defaultSchema: argv[ProjectConfigOptions.defaultSchema.name],
               useRunCache: false
             },
             {


### PR DESCRIPTION
The `init` CLI option always assume that the default-schema name is "dataform", so I have to go to the dataform.json file everytime to change it to a different schema.

In this PR, the `default-schema` option is added to the `init`