### PR TITLE
Fix credentials path resolution when projectDir is specified

### DIFF
--- a/cli/api/commands/compile.ts
+++ b/cli/api/commands/compile.ts
@@ -65,7 +65,7 @@ export async function compile(
   compiledGraph = dataform.CompiledGraph.create(decodedResult.compile.compiledGraph);
 
   if (workflowSettingsDataformCoreVersion) {
-    fs.rmdirSync(temporaryProjectPath, { recursive: true });
+    fs.rmSync(temporaryProjectPath, { recursive: true });
   }
 
   return compiledGraph;

--- a/cli/api/commands/credentials.ts
+++ b/cli/api/commands/credentials.ts
@@ -7,6 +7,7 @@ import { dataform } from "df/protos/ts";
 export const CREDENTIALS_FILENAME = ".df-credentials.json";
 
 export function read(credentialsPath: string): dataform.IBigQuery {
+  console.log("🚀 ~ read ~ credentialsPath:", credentialsPath);
   if (!fs.existsSync(credentialsPath)) {
     throw new Error(`Missing credentials JSON file; not found at path '${credentialsPath}'.`);
   }

--- a/cli/api/commands/credentials.ts
+++ b/cli/api/commands/credentials.ts
@@ -7,7 +7,6 @@ import { dataform } from "df/protos/ts";
 export const CREDENTIALS_FILENAME = ".df-credentials.json";
 
 export function read(credentialsPath: string): dataform.IBigQuery {
-  console.log("🚀 ~ read ~ credentialsPath:", credentialsPath);
   if (!fs.existsSync(credentialsPath)) {
     throw new Error(`Missing credentials JSON file; not found at path '${credentialsPath}'.`);
   }

--- a/cli/api/commands/run.ts
+++ b/cli/api/commands/run.ts
@@ -131,7 +131,7 @@ export class Runner {
 
   public cancel() {
     this.cancelled = true;
-    this.eEmitter.emit(CANCEL_EVENT);
+    this.eEmitter.emit(CANCEL_EVENT, undefined, undefined);
   }
 
   public async result(): Promise<dataform.IRunResult> {

--- a/cli/api/utils/cancellable_promise.ts
+++ b/cli/api/utils/cancellable_promise.ts
@@ -32,7 +32,7 @@ export class CancellablePromise<T> implements PromiseLike<T> {
   ): Promise<S> {
     // TODO: Seems like local and remote bazel builds behave
     // differently and I can't get this to type correctly for both.
-    return (this.promise.then(onfulfilled, onrejected) as any);
+    return this.promise.then(onfulfilled, onrejected) as any;
   }
 
   public catch(onRejected?: (reason: any) => PromiseLike<never>): Promise<T> {
@@ -41,6 +41,6 @@ export class CancellablePromise<T> implements PromiseLike<T> {
 
   public cancel(): void {
     this.cancelled = true;
-    this.emitter.emit(CancellablePromise.CANCEL_EVENT);
+    this.emitter.emit(CancellablePromise.CANCEL_EVENT, undefined, undefined);
   }
 }

--- a/cli/console.ts
+++ b/cli/console.ts
@@ -232,7 +232,7 @@ export function printExecutedAction(
       switch (executionAction.type) {
         case "table": {
           writeStdOut(
-            `${successOutput("Dataset created: ")} ${datasetString(
+            `${successOutput("Table created: ")} ${datasetString(
               executionAction.target,
               executionAction.tableType,
               executionAction.tasks.length === 0

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -57,7 +57,8 @@ const projectDirMustExistOption = {
     );
     if (!fs.existsSync(dataformJsonPath) && !fs.existsSync(workflowSettingsYamlPath)) {
       throw new Error(
-        `${argv[projectDirOption.name]
+        `${
+          argv[projectDirOption.name]
         } does not appear to be a dataform directory (missing workflow_settings.yaml file).`
       );
     }
@@ -172,8 +173,9 @@ const runTestsOptionName = "run-tests";
 
 const actionRetryLimitName = "action-retry-limit";
 
-const getCredentialsPath = (projectDir: string, credentialsPath: string) =>
-  actuallyResolve(credentialsPath || path.join(projectDir, CREDENTIALS_FILENAME));
+function getCredentialsPath(projectDir: string, credentialsPath: string) {
+  return actuallyResolve(projectDir, CREDENTIALS_FILENAME);
+}
 
 export function runCli() {
   const builtYargs = createYargsCli({
@@ -205,7 +207,7 @@ export function runCli() {
               if (!argv[ProjectConfigOptions.defaultDatabase.name]) {
                 throw new Error(
                   `The ${ProjectConfigOptions.defaultDatabase.name} positional argument is ` +
-                  `required. Use "dataform help init" for more info.`
+                    `required. Use "dataform help init" for more info.`
                 );
               }
             }
@@ -221,7 +223,7 @@ export function runCli() {
               if (!argv[ProjectConfigOptions.defaultLocation.name]) {
                 throw new Error(
                   `The ${ProjectConfigOptions.defaultLocation.name} positional argument is ` +
-                  `required. Use "dataform help init" for more info.`
+                    `required. Use "dataform help init" for more info.`
                 );
               }
             }
@@ -283,7 +285,7 @@ export function runCli() {
               case credentials.TestResultStatus.OTHER_ERROR: {
                 throw new Error(
                   `Credentials test query failed: ${testResult.error.stack ||
-                  testResult.error.message}`
+                    testResult.error.message}`
                 );
               }
             }
@@ -402,11 +404,7 @@ export function runCli() {
         format: `test [${projectDirMustExistOption.name}]`,
         description: "Run the dataform project's unit tests.",
         positionalOptions: [projectDirMustExistOption],
-        options: [
-          credentialsOption,
-          timeoutOption,
-          ...ProjectConfigOptions.allYargsOptions,
-        ],
+        options: [credentialsOption, timeoutOption, ...ProjectConfigOptions.allYargsOptions],
         processFn: async argv => {
           print("Compiling...\n");
           const compiledGraph = await compile({
@@ -471,7 +469,7 @@ export function runCli() {
           credentialsOption,
           jsonOutputOption,
           timeoutOption,
-          ...ProjectConfigOptions.allYargsOptions,
+          ...ProjectConfigOptions.allYargsOptions
         ],
         processFn: async argv => {
           if (!argv[jsonOutputOption.name]) {
@@ -701,7 +699,7 @@ class ProjectConfigOptions {
       ) {
         throw new Error(
           `--${ProjectConfigOptions.schemaSuffix.name} should contain only ` +
-          `alphanumeric characters and/or underscores.`
+            `alphanumeric characters and/or underscores.`
         );
       }
     }

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -174,7 +174,7 @@ const runTestsOptionName = "run-tests";
 const actionRetryLimitName = "action-retry-limit";
 
 function getCredentialsPath(projectDir: string, credentialsPath: string) {
-  return actuallyResolve(projectDir, CREDENTIALS_FILENAME);
+  return actuallyResolve(projectDir, credentialsPath);
 }
 
 export function runCli() {

--- a/cli/index_test.ts
+++ b/cli/index_test.ts
@@ -263,7 +263,7 @@ select 1 as \${dataform.projectConfig.vars.testVar2}
         "run",
         projectDir,
         "--credentials",
-        "test_credentials/bigquery.json",
+        path.resolve(process.env.RUNFILES, "df/test_credentials/bigquery.json"),
         "--dry-run",
         "--json",
         "--vars=testVar1=testValue1,testVar2=testValue2",

--- a/cli/util.ts
+++ b/cli/util.ts
@@ -4,7 +4,9 @@ import * as path from "path";
 import { dataform } from "df/protos/ts";
 import untildify from "untildify";
 
-export const actuallyResolve = (filePath: string) => path.resolve(untildify(filePath));
+export function actuallyResolve(...filePaths: string[]) {
+  return path.resolve(...filePaths.map(filePath => untildify(filePath)));
+}
 
 export function assertPathExists(checkPath: string) {
   if (!fs.existsSync(checkPath)) {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@types/json-stable-stringify": "^1.0.32",
     "@types/long": "^4.0.0",
     "@types/moo": "^0.5.0",
-    "@types/node": "^12.12.6",
+    "@types/node": "^16.16.0",
     "@types/readline-sync": "^1.4.3",
     "@types/request": "^2.48.3",
     "@types/rimraf": "^2.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -401,10 +401,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.38.tgz#f8bb07c371ccb1903f3752872c89f44006132947"
   integrity "sha1-+LsHw3HMsZA/N1KHLIn0QAYTKUc= sha512-5jY9RhV7c0Z4Jy09G+NIDTsCZ5G0L5n+Z+p+Y7t5VJHM30bgwzSjVtlcBxqAj+6L/swIlvtOSzr8rBk/aNyV2g=="
 
-"@types/node@^12.12.6":
-  version "12.12.42"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.12.42.tgz#d0d1149336bd07540dd1ea576692829d575dec34"
-  integrity "sha1-0NEUkza9B1QN0epXZpKCnVdd7DQ= sha512-R/9QdYFLL9dE9l5cWWzWIZByVGFd7lk7JVOJ7KD+E1SJ4gni7XJRLz9QTjyYQiHIqEAgku9VgxdLjMlhhUaAFg=="
+"@types/node@^16.16.0":
+  version "16.18.91"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.18.91.tgz#3e7b3b3d28f740e3e2d4ceb7ad9d16e6b9277c91"
+  integrity sha512-h8Q4klc8xzc9kJKr7UYNtJde5TU2qEePVyH3WyzJaUC+3ptyc5kPQbWOIUcn8ZsG5+KSkq+P0py0kC0VqxgAXw==
 
 "@types/readline-sync@^1.4.3":
   version "1.4.3"


### PR DESCRIPTION
Credentials was never defaulting to the `.df-credentials` option inside the folder specified in the projectDir option, because resolve wasn't being called on projectDir.

Because resolve is called rather than just path.join, if credentialsPath is absolute, this still resolves to the absolute path, rather than attempting to join the projectDir with the absolute path.