### PR TITLE
Fix CLI tags, allow comma delisted tags, add test

### DIFF
--- a/cli/index.ts
+++ b/cli/index.ts
@@ -86,7 +86,16 @@ const tagsOption: INamedOption<yargs.Options> = {
   name: "tags",
   option: {
     describe: "A list of tags to filter the actions to run.",
-    type: "array"
+    type: "array",
+    coerce: (rawTags: string[] | null) => {
+      const tags: string[] = [];
+      rawTags.forEach(rawTag =>
+        rawTag?.split(",").forEach(tag => {
+          tags.push(tag);
+        })
+      );
+      return tags;
+    }
   }
 };
 
@@ -469,6 +478,7 @@ export function runCli() {
           credentialsOption,
           jsonOutputOption,
           timeoutOption,
+          tagsOption,
           ...ProjectConfigOptions.allYargsOptions
         ],
         processFn: async argv => {

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -87,15 +87,7 @@ const tagsOption: INamedOption<yargs.Options> = {
   option: {
     describe: "A list of tags to filter the actions to run.",
     type: "array",
-    coerce: (rawTags: string[] | null) => {
-      const tags: string[] = [];
-      rawTags.forEach(rawTag =>
-        rawTag?.split(",").forEach(tag => {
-          tags.push(tag);
-        })
-      );
-      return tags;
-    }
+    coerce: (rawTags: string[] | null) => rawTags.map(tags => tags.split(",")).flat()
   }
 };
 

--- a/cli/index_test.ts
+++ b/cli/index_test.ts
@@ -194,7 +194,7 @@ defaultAssertionDataset: dataform_assertions
     fs.writeFileSync(
       filePath,
       `
-config { type: "table" }
+config { type: "table", tags: ["someTag"] }
 select 1 as \${dataform.projectConfig.vars.testVar2}
 `
     );
@@ -230,7 +230,8 @@ select 1 as \${dataform.projectConfig.vars.testVar2}
           },
           query: "\n\nselect 1 as testValue2\n",
           disabled: false,
-          fileName: "definitions/example.sqlx"
+          fileName: "definitions/example.sqlx",
+          tags: ["someTag"]
         }
       ],
       projectConfig: {
@@ -267,7 +268,8 @@ select 1 as \${dataform.projectConfig.vars.testVar2}
         "--dry-run",
         "--json",
         "--vars=testVar1=testValue1,testVar2=testValue2",
-        "--default-location=europe"
+        "--default-location=europe",
+        "--tags=someTag,someOtherTag"
       ])
     );
 
@@ -306,7 +308,8 @@ select 1 as \${dataform.projectConfig.vars.testVar2}
         }
       },
       runConfig: {
-        fullRefresh: false
+        fullRefresh: false,
+        tags: ["someTag", "someOtherTag"]
       },
       warehouseState: {}
     });

--- a/docs/configs-reference.md
+++ b/docs/configs-reference.md
@@ -39,7 +39,7 @@
 <a name="dataform-ActionConfig"></a>
 
 ### ActionConfig
-Action config defines the configuration properties of actions.
+Action config defines the contents of `actions.yaml` configuration files.
 
 
 | Field | Type | Label | Description |

--- a/protos/configs.proto
+++ b/protos/configs.proto
@@ -51,7 +51,7 @@ message ActionConfigs {
   repeated ActionConfig actions = 1;
 }
 
-// Action config defines the configuration properties of actions.
+// Action config defines the contents of `actions.yaml` configuration files.
 message ActionConfig {
   // Target represents a unique action identifier.
   message Target {


### PR DESCRIPTION
Fixes https://github.com/dataform-co/dataform/issues/1200

At some point the `tagsOption` got removed from the `run` command 👀