### PR TITLE
Extend dryrun to do dry runs against BigQuery

### DIFF
--- a/cli/api/commands/run.ts
+++ b/cli/api/commands/run.ts
@@ -26,7 +26,7 @@ export interface IExecutedAction {
 }
 
 export interface IExecutionOptions {
-  bigquery?: { jobPrefix?: string; actionRetryLimit?: number };
+  bigquery?: { jobPrefix?: string; actionRetryLimit?: number; dryRun?: boolean };
 }
 
 export function run(
@@ -338,7 +338,8 @@ export class Runner {
             bigquery: {
               labels: action.actionDescriptor?.bigqueryLabels,
               actionRetryLimit: this.executionOptions?.bigquery?.actionRetryLimit,
-              jobPrefix: this.executionOptions?.bigquery?.jobPrefix
+              jobPrefix: this.executionOptions?.bigquery?.jobPrefix,
+              dryRun: this.executionOptions?.bigquery?.dryRun
             }
           });
           if (taskStatus === dataform.TaskResult.ExecutionStatus.FAILED) {

--- a/cli/api/dbadapters/bigquery.ts
+++ b/cli/api/dbadapters/bigquery.ts
@@ -26,6 +26,7 @@ export interface IBigQueryExecutionOptions {
   labels?: { [label: string]: string };
   location?: string;
   jobPrefix?: string;
+  dryRun?: boolean;
 }
 
 export class BigQueryDbAdapter implements IDbAdapter {
@@ -82,7 +83,8 @@ export class BigQueryDbAdapter implements IDbAdapter {
                 options?.onCancel,
                 options?.bigquery?.labels,
                 options?.bigquery?.location,
-                options?.bigquery?.jobPrefix
+                options?.bigquery?.jobPrefix,
+                options?.bigquery?.dryRun
               )
       })
       .promise();
@@ -319,7 +321,8 @@ export class BigQueryDbAdapter implements IDbAdapter {
     onCancel?: OnCancel,
     labels?: { [label: string]: string },
     location?: string,
-    jobPrefix?: string
+    jobPrefix?: string,
+    dryRun?: boolean
   ) {
     let isCancelled = false;
     onCancel?.(() => (isCancelled = true));
@@ -333,7 +336,8 @@ export class BigQueryDbAdapter implements IDbAdapter {
             query,
             params,
             labels,
-            location
+            location,
+            dryRun
           });
           const resultStream = job[0].getQueryResultsStream();
           return new Promise<IExecutionResult>((resolve, reject) => {

--- a/cli/api/dbadapters/index.ts
+++ b/cli/api/dbadapters/index.ts
@@ -20,6 +20,7 @@ export interface IDbClient {
         labels?: { [label: string]: string };
         location?: string;
         jobPrefix?: string;
+        dryRun?: boolean;
       };
     }
   ): Promise<IExecutionResult>;

--- a/cli/console.ts
+++ b/cli/console.ts
@@ -225,14 +225,15 @@ export function printExecutionGraph(executionGraph: dataform.ExecutionGraph, ver
 
 export function printExecutedAction(
   executedAction: dataform.IActionResult,
-  executionAction: dataform.IExecutionAction
+  executionAction: dataform.IExecutionAction,
+  dryRun?: boolean
 ) {
   switch (executedAction.status) {
     case dataform.ActionResult.ExecutionStatus.SUCCESSFUL: {
       switch (executionAction.type) {
         case "table": {
           writeStdOut(
-            `${successOutput("Table created: ")} ${datasetString(
+            `${successOutput(`Table ${dryRun ? "dry run success" : "created"}: `)} ${datasetString(
               executionAction.target,
               executionAction.tableType,
               executionAction.tasks.length === 0
@@ -242,19 +243,17 @@ export function printExecutedAction(
         }
         case "assertion": {
           writeStdOut(
-            `${successOutput("Assertion passed: ")} ${assertionString(
-              executionAction.target,
-              executionAction.tasks.length === 0
-            )}`
+            `${successOutput(
+              `Assertion ${dryRun ? "dry run success" : "passed"}: `
+            )} ${assertionString(executionAction.target, executionAction.tasks.length === 0)}`
           );
           return;
         }
         case "operation": {
           writeStdOut(
-            `${successOutput("Operation completed successfully: ")} ${operationString(
-              executionAction.target,
-              executionAction.tasks.length === 0
-            )}`
+            `${successOutput(
+              `Operation ${dryRun ? "dry run success" : "completed successfully"}: `
+            )} ${operationString(executionAction.target, executionAction.tasks.length === 0)}`
           );
           return;
         }

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -504,12 +504,7 @@ export function runCli() {
             dbadapter
           );
 
-          if (argv[dryRunOptionName]) {
-            if (!argv[jsonOutputOption.name]) {
-              print(
-                `Dry run (--${dryRunOptionName}) mode is turned on; not running the following actions:\n`
-              );
-            }
+          if (argv[dryRunOptionName] && argv[jsonOutputOption.name]) {
             printExecutionGraph(executionGraph, argv[jsonOutputOption.name]);
             return;
           }
@@ -525,10 +520,17 @@ export function runCli() {
             printSuccess("Unit tests completed successfully.\n");
           }
 
-          if (!argv[jsonOutputOption.name]) {
+          if (argv[dryRunOptionName]) {
+            print("Dry running (no changes to the warehouse will be applied)...");
+          } else {
             print("Running...\n");
           }
-          let bigqueryOptions: {} = { actionRetryLimit: argv[actionRetryLimitName] };
+          let bigqueryOptions: {} = {
+            actionRetryLimit: argv[actionRetryLimitName]
+          };
+          if (argv[dryRunOptionName]) {
+            bigqueryOptions = { ...bigqueryOptions, dryRun: argv[dryRunOptionName] };
+          }
           if (argv[jobPrefixOption.name]) {
             bigqueryOptions = { ...bigqueryOptions, jobPrefix: argv[jobPrefixOption.name] };
           }
@@ -556,7 +558,8 @@ export function runCli() {
               .forEach(executedAction => {
                 printExecutedAction(
                   executedAction,
-                  actionsByName.get(targetAsReadableString(executedAction.target))
+                  actionsByName.get(targetAsReadableString(executedAction.target)),
+                  argv[dryRunOptionName]
                 );
                 alreadyPrintedActions.add(targetAsReadableString(executedAction.target));
               });


### PR DESCRIPTION
Fixes https://github.com/dataform-co/dataform/issues/1242

Previously dry run in the CLI would just check that the execution graph was made correctly; this now runs each action against BigQuery using the dry run API option, giving users more info on whether their jobs will succeed when actually run.