### PR TITLE
Normalize paths during compilation

### DIFF
--- a/core/actions/assertion.ts
+++ b/core/actions/assertion.ts
@@ -15,6 +15,7 @@ import {
   checkExcessProperties,
   nativeRequire,
   resolvableAsTarget,
+  resolveActionsConfigFilename,
   setNameAndTarget,
   strictKeysOf,
   toResolvable,
@@ -95,8 +96,7 @@ export class Assertion extends ActionBuilder<dataform.Assertion> {
     this.proto.target = this.applySessionToTarget(target);
     this.proto.canonicalTarget = this.applySessionCanonicallyToTarget(target);
 
-    // Resolve the filename as its absolute path.
-    config.filename = Path.join(Path.dirName(configPath), config.filename);
+    config.filename = resolveActionsConfigFilename(config.filename, configPath);
     this.proto.fileName = config.filename;
 
     // TODO(ekrekr): load config proto column descriptors.

--- a/core/actions/notebook.ts
+++ b/core/actions/notebook.ts
@@ -43,7 +43,6 @@ export class Notebook extends ActionBuilder<dataform.Notebook> {
       this.proto.disabled = config.disabled;
     }
 
-    console.log("🚀 ~ Notebook ~ config.filename:", config.filename);
     const notebookContents = nativeRequire(config.filename).asJson;
     this.proto.notebookContents = JSON.stringify(
       stripNotebookOutputs(notebookContents, config.filename)

--- a/core/actions/notebook.ts
+++ b/core/actions/notebook.ts
@@ -2,7 +2,11 @@ import { verifyObjectMatchesProto } from "df/common/protos";
 import { ActionBuilder } from "df/core/actions";
 import * as Path from "df/core/path";
 import { Session } from "df/core/session";
-import { actionConfigToCompiledGraphTarget, nativeRequire } from "df/core/utils";
+import {
+  actionConfigToCompiledGraphTarget,
+  nativeRequire,
+  resolveActionsConfigFilename
+} from "df/core/utils";
 import { dataform } from "df/protos/ts";
 
 /**
@@ -25,9 +29,7 @@ export class Notebook extends ActionBuilder<dataform.Notebook> {
       config.name = Path.fileName(config.filename);
     }
     const target = actionConfigToCompiledGraphTarget(config);
-
-    // Resolve the filename as its absolute path.
-    config.filename = Path.join(Path.dirName(configPath), config.filename);
+    config.filename = resolveActionsConfigFilename(config.filename, configPath);
 
     this.session = session;
     this.proto.target = this.applySessionToTarget(target);
@@ -41,6 +43,7 @@ export class Notebook extends ActionBuilder<dataform.Notebook> {
       this.proto.disabled = config.disabled;
     }
 
+    console.log("🚀 ~ Notebook ~ config.filename:", config.filename);
     const notebookContents = nativeRequire(config.filename).asJson;
     this.proto.notebookContents = JSON.stringify(
       stripNotebookOutputs(notebookContents, config.filename)

--- a/core/actions/operation.ts
+++ b/core/actions/operation.ts
@@ -19,6 +19,7 @@ import {
   checkExcessProperties,
   nativeRequire,
   resolvableAsTarget,
+  resolveActionsConfigFilename,
   setNameAndTarget,
   strictKeysOf,
   toResolvable
@@ -93,8 +94,7 @@ export class Operation extends ActionBuilder<dataform.Operation> {
     this.proto.target = this.applySessionToTarget(target);
     this.proto.canonicalTarget = this.applySessionCanonicallyToTarget(target);
 
-    // Resolve the filename as its absolute path.
-    config.filename = Path.join(Path.dirName(configPath), config.filename);
+    config.filename = resolveActionsConfigFilename(config.filename, configPath);
     this.proto.fileName = config.filename;
 
     // TODO(ekrekr): load config proto column descriptors.

--- a/core/actions/table.ts
+++ b/core/actions/table.ts
@@ -20,6 +20,7 @@ import {
   checkExcessProperties,
   nativeRequire,
   resolvableAsTarget,
+  resolveActionsConfigFilename,
   setNameAndTarget,
   strictKeysOf,
   tableTypeStringToEnum,
@@ -292,8 +293,7 @@ export class Table extends ActionBuilder<dataform.Table> {
     this.proto.target = this.applySessionToTarget(target);
     this.proto.canonicalTarget = this.applySessionCanonicallyToTarget(target);
 
-    // Resolve the filename as its absolute path.
-    tableTypeConfig.filename = Path.join(Path.dirName(configPath), tableTypeConfig.filename);
+    tableTypeConfig.filename = resolveActionsConfigFilename(tableTypeConfig.filename, configPath);
     this.proto.fileName = tableTypeConfig.filename;
 
     // TODO(ekrekr): load config proto column descriptors.

--- a/core/main_test.ts
+++ b/core/main_test.ts
@@ -1203,7 +1203,7 @@ actions:
       expect(result.compile.compiledGraph.graphErrors.compilationErrors).deep.equals([]);
     });
 
-    test(`files can be loaded from the root directory`, () => {
+    test(`files can be loaded from the root directory and are normalized in the compiled graph`, () => {
       const projectDir = tmpDirFixture.createNewTmpDir();
       fs.writeFileSync(
         path.join(projectDir, "workflow_settings.yaml"),
@@ -1215,9 +1215,9 @@ actions:
         `
 actions:
 - notebook:
-    filename: /contents.ipynb
+    filename: ../contents.ipynb
 - operation:
-    filename: /table.sql`
+    filename: ../table.sql`
       );
       fs.writeFileSync(path.join(projectDir, `contents.ipynb`), JSON.stringify({ cells: [] }));
       fs.writeFileSync(path.join(projectDir, `table.sql`), "SELECT 1");

--- a/core/path.ts
+++ b/core/path.ts
@@ -49,3 +49,31 @@ export function escapedFileName(path: string) {
 export function fileExtension(fullPath: string) {
   return fullPath.split(".").slice(-1)[0];
 }
+
+export function normalize(path: string) {
+  const parts = [];
+  let dotDotCount = 0;
+  for (const part of path.split("/").filter(part => !!part && part !== ".")) {
+    if (part === "..") {
+      if (parts.length === 0) {
+        dotDotCount++;
+      } else {
+        parts.pop();
+      }
+    } else {
+      parts.push(part);
+    }
+  }
+  if (path.startsWith("/")) {
+    if (parts.length === 0) {
+      return "/";
+    }
+    parts.unshift("");
+  } else {
+    parts.unshift(...new Array(dotDotCount).fill(".."));
+    if (parts.length === 0) {
+      return ".";
+    }
+  }
+  return parts.join("/");
+}

--- a/core/path.ts
+++ b/core/path.ts
@@ -53,7 +53,7 @@ export function fileExtension(fullPath: string) {
 export function normalize(path: string) {
   const parts = [];
   let dotDotCount = 0;
-  for (const part of path.split("/").filter(part => !!part && part !== ".")) {
+  for (const part of path.split("/").filter(p => !!p && p !== ".")) {
     if (part === "..") {
       if (parts.length === 0) {
         dotDotCount++;

--- a/core/utils.ts
+++ b/core/utils.ts
@@ -268,3 +268,12 @@ export function actionConfigToCompiledGraphTarget(
   }
   return dataform.Target.create(compiledGraphTarget);
 }
+
+export function resolveActionsConfigFilename(configFilename: string, configPath: string) {
+  // This path computation supports "absolute" paths in the context of a dataform project.
+  if (configFilename[0] === "/") {
+    return configFilename.slice(1);
+  }
+  // Otherwise load paths relative to the location of the actions.yaml file.
+  return Path.join(Path.dirName(configPath), configFilename);
+}

--- a/core/utils.ts
+++ b/core/utils.ts
@@ -270,10 +270,5 @@ export function actionConfigToCompiledGraphTarget(
 }
 
 export function resolveActionsConfigFilename(configFilename: string, configPath: string) {
-  // This path computation supports "absolute" paths in the context of a dataform project.
-  if (configFilename[0] === "/") {
-    return configFilename.slice(1);
-  }
-  // Otherwise load paths relative to the location of the actions.yaml file.
-  return Path.join(Path.dirName(configPath), configFilename);
+  return Path.normalize(Path.join(Path.dirName(configPath), configFilename));
 }

--- a/version.bzl
+++ b/version.bzl
@@ -1,3 +1,3 @@
 # NOTE: If you change the format of this line, you must change the bash command
 # in /scripts/publish to extract the version string correctly.
-DF_VERSION = "3.0.0-beta.2"
+DF_VERSION = "3.0.0-beta.3"


### PR DESCRIPTION
Because Node isn't used in Core, Node's path computation can't be used to do this directly. To avoid redefining path resolution in yet another place, this seems like the best option.