### PR TITLE
Some project config improvements

### DIFF
--- a/core/actions/assertion.ts
+++ b/core/actions/assertion.ts
@@ -94,8 +94,20 @@ export class Assertion extends ActionBuilder<dataform.Assertion> {
       config.name = Path.basename(config.filename);
     }
     const target = actionConfigToCompiledGraphTarget(config);
-    this.proto.target = this.applySessionToTarget(target, config.filename);
-    this.proto.canonicalTarget = this.applySessionCanonicallyToTarget(target);
+    this.proto.target = this.applySessionToTarget(
+      target,
+      session.projectConfig,
+      config.filename,
+      true,
+      true
+    );
+    this.proto.canonicalTarget = this.applySessionToTarget(
+      target,
+      session.canonicalProjectConfig,
+      undefined,
+      false,
+      true
+    );
 
     config.filename = resolveActionsConfigFilename(config.filename, configPath);
     this.proto.fileName = config.filename;

--- a/core/actions/declaration.ts
+++ b/core/actions/declaration.ts
@@ -51,8 +51,8 @@ export class Declaration extends ActionBuilder<dataform.Declaration> {
     }
 
     const target = actionConfigToCompiledGraphTarget(config);
-    this.proto.target = this.applySessionToTarget(target);
-    this.proto.canonicalTarget = this.applySessionCanonicallyToTarget(target);
+    this.proto.target = this.applySessionToTarget(target, session.projectConfig);
+    this.proto.canonicalTarget = this.applySessionToTarget(target, session.canonicalProjectConfig);
 
     // TODO(ekrekr): load config proto column descriptors.
     this.config({ description: config.description });

--- a/core/actions/notebook.ts
+++ b/core/actions/notebook.ts
@@ -20,7 +20,7 @@ export class Notebook extends ActionBuilder<dataform.Notebook> {
   // TODO: make this field private, to enforce proto update logic to happen in this class.
   public proto: dataform.INotebook = dataform.Notebook.create();
 
-  // If true, adds the inline assertions of dependencies as direct dependencies for this action. 
+  // If true, adds the inline assertions of dependencies as direct dependencies for this action.
   public dependOnDependencyAssertions: boolean = false;
 
   constructor(
@@ -37,8 +37,13 @@ export class Notebook extends ActionBuilder<dataform.Notebook> {
     config.filename = resolveActionsConfigFilename(config.filename, configPath);
 
     this.session = session;
-    this.proto.target = this.applySessionToTarget(target, config.filename);
-    this.proto.canonicalTarget = this.applySessionCanonicallyToTarget(target);
+    this.proto.target = this.applySessionToTarget(
+      target,
+      session.projectConfig,
+      config.filename,
+      true
+    );
+    this.proto.canonicalTarget = this.applySessionToTarget(target, session.canonicalProjectConfig);
     this.proto.tags = config.tags;
     this.dependOnDependencyAssertions = config.dependOnDependencyAssertions;
     this.dependencies(config.dependencyTargets);
@@ -70,7 +75,9 @@ export class Notebook extends ActionBuilder<dataform.Notebook> {
    */
   public dependencies(value: Resolvable | Resolvable[]) {
     const newDependencies = Array.isArray(value) ? value : [value];
-    newDependencies.forEach(resolvable => addDependenciesToActionDependencyTargets(this, resolvable));
+    newDependencies.forEach(resolvable =>
+      addDependenciesToActionDependencyTargets(this, resolvable)
+    );
     return this;
   }
 

--- a/core/actions/operation.ts
+++ b/core/actions/operation.ts
@@ -23,7 +23,7 @@ import {
   resolveActionsConfigFilename,
   setNameAndTarget,
   strictKeysOf,
-  toResolvable,
+  toResolvable
 } from "df/core/utils";
 import { dataform } from "df/protos/ts";
 
@@ -32,10 +32,10 @@ import { dataform } from "df/protos/ts";
  */
 export interface IOperationConfig
   extends IActionConfig,
-  IDependenciesConfig,
-  IDocumentableConfig,
-  INamedConfig,
-  ITargetableConfig {
+    IDependenciesConfig,
+    IDocumentableConfig,
+    INamedConfig,
+    ITargetableConfig {
   /**
    * Declares that this `operations` action creates a dataset which should be referenceable using the `ref` function.
    *
@@ -74,7 +74,7 @@ export class Operation extends ActionBuilder<dataform.Operation> {
   // Hold a reference to the Session instance.
   public session: Session;
 
-  // If true, adds the inline assertions of dependencies as direct dependencies for this action. 
+  // If true, adds the inline assertions of dependencies as direct dependencies for this action.
   public dependOnDependencyAssertions: boolean = false;
 
   // We delay contextification until the final compile step, so hold these here for now.
@@ -96,8 +96,13 @@ export class Operation extends ActionBuilder<dataform.Operation> {
       config.name = Path.basename(config.filename);
     }
     const target = actionConfigToCompiledGraphTarget(config);
-    this.proto.target = this.applySessionToTarget(target, config.filename);
-    this.proto.canonicalTarget = this.applySessionCanonicallyToTarget(target);
+    this.proto.target = this.applySessionToTarget(
+      target,
+      session.projectConfig,
+      config.filename,
+      true
+    );
+    this.proto.canonicalTarget = this.applySessionToTarget(target, session.canonicalProjectConfig);
 
     config.filename = resolveActionsConfigFilename(config.filename, configPath);
     this.proto.fileName = config.filename;
@@ -164,7 +169,9 @@ export class Operation extends ActionBuilder<dataform.Operation> {
 
   public dependencies(value: Resolvable | Resolvable[]) {
     const newDependencies = Array.isArray(value) ? value : [value];
-    newDependencies.forEach(resolvable => addDependenciesToActionDependencyTargets(this, resolvable));
+    newDependencies.forEach(resolvable =>
+      addDependenciesToActionDependencyTargets(this, resolvable)
+    );
     return this;
   }
 

--- a/core/actions/table.ts
+++ b/core/actions/table.ts
@@ -26,7 +26,7 @@ import {
   strictKeysOf,
   tableTypeStringToEnum,
   toResolvable,
-  validateQueryString,
+  validateQueryString
 } from "df/core/utils";
 import { dataform } from "df/protos/ts";
 
@@ -158,10 +158,10 @@ const ITableAssertionsProperties = () =>
  */
 export interface ITableConfig
   extends IActionConfig,
-  IDependenciesConfig,
-  IDocumentableConfig,
-  INamedConfig,
-  ITargetableConfig {
+    IDependenciesConfig,
+    IDocumentableConfig,
+    INamedConfig,
+    ITargetableConfig {
   /**
    * The type of the dataset. For more information on how this setting works, check out some of the [guides](guides)
    * on publishing different types of datasets with Dataform.
@@ -258,7 +258,7 @@ export class Table extends ActionBuilder<dataform.Table> {
   // Hold a reference to the Session instance.
   public session: Session;
 
-  // If true, adds the inline assertions of dependencies as direct dependencies for this action. 
+  // If true, adds the inline assertions of dependencies as direct dependencies for this action.
   public dependOnDependencyAssertions: boolean = false;
 
   // We delay contextification until the final compile step, so hold these here for now.
@@ -295,8 +295,13 @@ export class Table extends ActionBuilder<dataform.Table> {
       tableTypeConfig.name = Path.basename(tableTypeConfig.filename);
     }
     const target = actionConfigToCompiledGraphTarget(tableTypeConfig);
-    this.proto.target = this.applySessionToTarget(target, tableTypeConfig.filename);
-    this.proto.canonicalTarget = this.applySessionCanonicallyToTarget(target);
+    this.proto.target = this.applySessionToTarget(
+      target,
+      session.projectConfig,
+      tableTypeConfig.filename,
+      true
+    );
+    this.proto.canonicalTarget = this.applySessionToTarget(target, session.canonicalProjectConfig);
 
     tableTypeConfig.filename = resolveActionsConfigFilename(tableTypeConfig.filename, configPath);
     this.proto.fileName = tableTypeConfig.filename;
@@ -563,7 +568,9 @@ export class Table extends ActionBuilder<dataform.Table> {
 
   public dependencies(value: Resolvable | Resolvable[]) {
     const newDependencies = Array.isArray(value) ? value : [value];
-    newDependencies.forEach(resolvable => addDependenciesToActionDependencyTargets(this, resolvable));
+    newDependencies.forEach(resolvable =>
+      addDependenciesToActionDependencyTargets(this, resolvable)
+    );
     return this;
   }
 
@@ -753,7 +760,7 @@ export class Table extends ActionBuilder<dataform.Table> {
  * @hidden
  */
 export class TableContext implements ITableContext {
-  constructor(private table: Table, private isIncremental = false) { }
+  constructor(private table: Table, private isIncremental = false) {}
 
   public config(config: ITableConfig) {
     this.table.config(config);

--- a/core/session.ts
+++ b/core/session.ts
@@ -43,8 +43,9 @@ export interface IActionProto {
 export class Session {
   public rootDir: string;
 
-  public config: dataform.IProjectConfig;
-  public canonicalConfig: dataform.IProjectConfig;
+  public projectConfig: dataform.ProjectConfig;
+  // The canonical project config contains the project config before schema and database overrides.
+  public canonicalProjectConfig: dataform.ProjectConfig;
 
   public actions: Action[];
   public indexedActions: ActionMap;
@@ -58,54 +59,54 @@ export class Session {
 
   constructor(
     rootDir?: string,
-    projectConfig?: dataform.IProjectConfig,
-    originalProjectConfig?: dataform.IProjectConfig
+    projectConfig?: dataform.ProjectConfig,
+    originalProjectConfig?: dataform.ProjectConfig
   ) {
     this.init(rootDir, projectConfig, originalProjectConfig);
   }
 
   public init(
     rootDir: string,
-    projectConfig?: dataform.IProjectConfig,
-    originalProjectConfig?: dataform.IProjectConfig
+    projectConfig?: dataform.ProjectConfig,
+    originalProjectConfig?: dataform.ProjectConfig
   ) {
     this.rootDir = rootDir;
-    this.config = projectConfig || DEFAULT_CONFIG;
-    this.canonicalConfig = getCanonicalProjectConfig(
-      originalProjectConfig || projectConfig || DEFAULT_CONFIG
+    this.projectConfig = dataform.ProjectConfig.create(projectConfig || DEFAULT_CONFIG);
+    this.canonicalProjectConfig = getCanonicalProjectConfig(
+      dataform.ProjectConfig.create(originalProjectConfig || projectConfig || DEFAULT_CONFIG)
     );
     this.actions = [];
     this.tests = {};
     this.graphErrors = { compilationErrors: [] };
   }
 
-  public get projectConfig(): Pick<
-    dataform.IProjectConfig,
-    | "warehouse"
-    | "defaultDatabase"
-    | "defaultSchema"
-    | "defaultLocation"
-    | "assertionSchema"
-    | "databaseSuffix"
-    | "schemaSuffix"
-    | "tablePrefix"
-    | "vars"
-  > {
-    return Object.freeze({
-      warehouse: this.config.warehouse,
-      defaultDatabase: this.config.defaultDatabase,
-      defaultSchema: this.config.defaultSchema,
-      defaultLocation: this.config.defaultLocation,
-      assertionSchema: this.config.assertionSchema,
-      databaseSuffix: this.config.databaseSuffix,
-      schemaSuffix: this.config.schemaSuffix,
-      tablePrefix: this.config.tablePrefix,
-      vars: Object.freeze({ ...this.config.vars })
-    });
-  }
+  // public get projectConfig(): Pick<
+  //   dataform.IProjectConfig,
+  //   | "warehouse"
+  //   | "defaultDatabase"
+  //   | "defaultSchema"
+  //   | "defaultLocation"
+  //   | "assertionSchema"
+  //   | "databaseSuffix"
+  //   | "schemaSuffix"
+  //   | "tablePrefix"
+  //   | "vars"
+  // > {
+  //   return Object.freeze({
+  //     warehouse: this.config.warehouse,
+  //     defaultDatabase: this.config.defaultDatabase,
+  //     defaultSchema: this.config.defaultSchema,
+  //     defaultLocation: this.config.defaultLocation,
+  //     assertionSchema: this.config.assertionSchema,
+  //     databaseSuffix: this.config.databaseSuffix,
+  //     schemaSuffix: this.config.schemaSuffix,
+  //     tablePrefix: this.config.tablePrefix,
+  //     vars: Object.freeze({ ...this.config.vars })
+  //   });
+  // }
 
   public compilationSql(): CompilationSql {
-    return new CompilationSql(this.config, dataformCoreVersion);
+    return new CompilationSql(this.projectConfig, dataformCoreVersion);
   }
 
   public sqlxAction(actionOptions: {
@@ -270,7 +271,7 @@ export class Session {
   public assert(name: string, query?: AContextable<string>): Assertion {
     const assertion = new Assertion();
     assertion.session = this;
-    utils.setNameAndTarget(this, assertion.proto, name, this.config.assertionSchema);
+    utils.setNameAndTarget(this, assertion.proto, name, this.projectConfig.assertionSchema);
     if (query) {
       assertion.query(query);
     }
@@ -328,8 +329,8 @@ export class Session {
     this.indexedActions = new ActionMap(this.actions);
 
     if (
-      (this.config.warehouse === "bigquery" || this.config.warehouse === "") &&
-      !this.config.defaultLocation
+      (this.projectConfig.warehouse === "bigquery" || this.projectConfig.warehouse === "") &&
+      !this.projectConfig.defaultLocation
     ) {
       this.compileError(
         "A defaultLocation is required for BigQuery. This can be configured in workflow_settings.yaml.",
@@ -338,15 +339,15 @@ export class Session {
     }
 
     if (
-      !!this.config.vars &&
-      !Object.values(this.config.vars).every(value => typeof value === "string")
+      !!this.projectConfig.vars &&
+      !Object.values(this.projectConfig.vars).every(value => typeof value === "string")
     ) {
       throw new Error("Custom variables defined in workflow settings can only be strings.");
     }
 
     // TODO(ekrekr): replace verify here with something that actually works.
     const compiledGraph = dataform.CompiledGraph.create({
-      projectConfig: this.config,
+      projectConfig: this.projectConfig,
       tables: this.compileGraphChunk(this.actions.filter(action => action instanceof Table)),
       operations: this.compileGraphChunk(
         this.actions.filter(action => action instanceof Operation)
@@ -419,15 +420,15 @@ export class Session {
   }
 
   private getDatabaseSuffixWithUnderscore() {
-    return !!this.config.databaseSuffix ? `_${this.config.databaseSuffix}` : "";
+    return !!this.projectConfig.databaseSuffix ? `_${this.projectConfig.databaseSuffix}` : "";
   }
 
   private getSchemaSuffixWithUnderscore() {
-    return !!this.config.schemaSuffix ? `_${this.config.schemaSuffix}` : "";
+    return !!this.projectConfig.schemaSuffix ? `_${this.projectConfig.schemaSuffix}` : "";
   }
 
   private getTablePrefixWithUnderscore() {
-    return !!this.config.tablePrefix ? `${this.config.tablePrefix}_` : "";
+    return !!this.projectConfig.tablePrefix ? `${this.projectConfig.tablePrefix}_` : "";
   }
 
   private compileGraphChunk<T>(actions: Array<Action | Test>): T[] {
@@ -467,9 +468,13 @@ export class Session {
           fullyQualifiedDependencies[targetAsReadableString(protoDep.target)] = protoDep.target;
 
           if (dependency.includeDependentAssertions) {
-            this.actionAssertionMap.find(dependency).forEach(assertion =>
-              fullyQualifiedDependencies[targetAsReadableString(assertion.proto.target)] = assertion.proto.target
-            );
+            this.actionAssertionMap
+              .find(dependency)
+              .forEach(
+                assertion =>
+                  (fullyQualifiedDependencies[targetAsReadableString(assertion.proto.target)] =
+                    assertion.proto.target)
+              );
           }
         } else {
           // Too many targets matched the dependency.
@@ -485,7 +490,7 @@ export class Session {
   }
 
   private alterActionName(actions: IActionProto[], declarationTargets: dataform.ITarget[]) {
-    const { tablePrefix, schemaSuffix, databaseSuffix } = this.config;
+    const { tablePrefix, schemaSuffix, databaseSuffix } = this.projectConfig;
 
     if (!tablePrefix && !schemaSuffix && !databaseSuffix) {
       return;
@@ -722,13 +727,13 @@ function definesDataset(type: string) {
   return type === "view" || type === "table" || type === "incremental";
 }
 
-function getCanonicalProjectConfig(originalProjectConfig: dataform.IProjectConfig) {
-  return {
+function getCanonicalProjectConfig(originalProjectConfig: dataform.ProjectConfig) {
+  return dataform.ProjectConfig.create({
     warehouse: originalProjectConfig.warehouse,
     defaultSchema: originalProjectConfig.defaultSchema,
     defaultDatabase: originalProjectConfig.defaultDatabase,
     assertionSchema: originalProjectConfig.assertionSchema
-  };
+  });
 }
 
 function joinQuoted(values: readonly string[]) {
@@ -751,14 +756,11 @@ class ActionMap {
   private byName: Map<string, Action[]> = new Map();
   private bySchemaAndName: Map<string, Map<string, Action[]>> = new Map();
   private byDatabaseAndName: Map<string, Map<string, Action[]>> = new Map();
-  private byDatabaseSchemaAndName: Map<
-    string,
-    Map<string, Map<string, Action[]>>
-  > = new Map();
+  private byDatabaseSchemaAndName: Map<string, Map<string, Map<string, Action[]>>> = new Map();
 
   public constructor(actions: Action[]) {
     for (const action of actions) {
-      this.set(action.proto.target, action)
+      this.set(action.proto.target, action);
     }
   }
 
@@ -774,7 +776,7 @@ class ActionMap {
         this.byDatabaseAndName.set(actionTarget.database, new Map());
       }
       const forDatabaseNoSchema = this.byDatabaseAndName.get(actionTarget.database);
-      this.setByNameLevel(forDatabaseNoSchema, actionTarget.name, assertionTarget)
+      this.setByNameLevel(forDatabaseNoSchema, actionTarget.name, assertionTarget);
 
       if (!!actionTarget.schema) {
         if (!this.byDatabaseSchemaAndName.has(actionTarget.database)) {
@@ -811,7 +813,11 @@ class ActionMap {
     targetMap.get(name).push(assertionTarget);
   }
 
-  private setBySchemaLevel(targetMap: Map<string, Map<string, Action[]>>, actionTarget: ITarget, assertionTarget: Action) {
+  private setBySchemaLevel(
+    targetMap: Map<string, Map<string, Action[]>>,
+    actionTarget: ITarget,
+    assertionTarget: Action
+  ) {
     if (!targetMap.has(actionTarget.schema)) {
       targetMap.set(actionTarget.schema, new Map());
     }

--- a/core/utils.ts
+++ b/core/utils.ts
@@ -11,7 +11,7 @@ import { dataform } from "df/protos/ts";
 declare var __webpack_require__: any;
 declare var __non_webpack_require__: any;
 
-type actionsWithDependencies = Table | Operation | Notebook
+type actionsWithDependencies = Table | Operation | Notebook;
 
 // This side-steps webpack's require in favour of the real require.
 export const nativeRequire =
@@ -137,8 +137,8 @@ export function ambiguousActionNameMsg(act: Resolvable, allActs: Action[] | stri
     typeof allActs[0] === "string"
       ? allActs
       : (allActs as Array<Table | Operation | Assertion>).map(
-        r => `${r.proto.target.schema}.${r.proto.target.name}`
-      );
+          r => `${r.proto.target.schema}.${r.proto.target.name}`
+        );
   return `Ambiguous Action name: ${stringifyResolvable(
     act
   )}. Did you mean one of: ${allActNames.join(", ")}.`;
@@ -170,8 +170,13 @@ export function setNameAndTarget(
   overrideSchema?: string,
   overrideDatabase?: string
 ) {
-  action.target = target(session.config, name, overrideSchema, overrideDatabase);
-  action.canonicalTarget = target(session.canonicalConfig, name, overrideSchema, overrideDatabase);
+  action.target = target(session.projectConfig, name, overrideSchema, overrideDatabase);
+  action.canonicalTarget = target(
+    session.canonicalProjectConfig,
+    name,
+    overrideSchema,
+    overrideDatabase
+  );
   if (action.target.name.includes(".")) {
     session.compileError(
       new Error("Action target names cannot include '.'"),
@@ -219,7 +224,8 @@ export function checkExcessProperties<T>(
   if (extraProperties.length > 0) {
     reportError(
       new Error(
-        `Unexpected property "${extraProperties[0]}"${!!name ? ` in ${name}` : ""
+        `Unexpected property "${extraProperties[0]}"${
+          !!name ? ` in ${name}` : ""
         }. Supported properties are: ${JSON.stringify(supportedProperties)}`
       )
     );
@@ -305,7 +311,10 @@ export function resolveActionsConfigFilename(configFilename: string, configPath:
   return Path.normalize(Path.join(Path.dirName(configPath), configFilename));
 }
 
-export function addDependenciesToActionDependencyTargets(action: actionsWithDependencies, resolvable: Resolvable) {
+export function addDependenciesToActionDependencyTargets(
+  action: actionsWithDependencies,
+  resolvable: Resolvable
+) {
   const dependencyTarget = resolvableAsTarget(resolvable);
   if (!dependencyTarget.hasOwnProperty("includeDependentAssertions")) {
     // dependency `includeDependentAssertions` takes precedence over the config's `dependOnDependencyAssertions`
@@ -313,18 +322,24 @@ export function addDependenciesToActionDependencyTargets(action: actionsWithDepe
   }
 
   // check if same dependency already exist in this action but with opposite value for includeDependentAssertions
-  const dependencyTargetString = action.session.compilationSql().resolveTarget(dependencyTarget)
+  const dependencyTargetString = action.session.compilationSql().resolveTarget(dependencyTarget);
 
   if (action.includeAssertionsForDependency.has(dependencyTargetString)) {
-    if (action.includeAssertionsForDependency.get(dependencyTargetString) !== dependencyTarget.includeDependentAssertions) {
+    if (
+      action.includeAssertionsForDependency.get(dependencyTargetString) !==
+      dependencyTarget.includeDependentAssertions
+    ) {
       action.session.compileError(
         `Conflicting "includeDependentAssertions" properties are not allowed. Dependency ${dependencyTarget.name} has different values set for this property.`,
         action.proto.fileName,
         action.proto.target
-      )
+      );
       return action;
     }
   }
   action.proto.dependencyTargets.push(dependencyTarget);
-  action.includeAssertionsForDependency.set(dependencyTargetString, dependencyTarget.includeDependentAssertions)
+  action.includeAssertionsForDependency.set(
+    dependencyTargetString,
+    dependencyTarget.includeDependentAssertions
+  );
 }

--- a/tests/core/core.spec.ts
+++ b/tests/core/core.spec.ts
@@ -9,31 +9,31 @@ import { suite, test } from "df/testing";
 // TODO(ekrekr): migrate the tests in this file to core/main_test.ts.
 
 class TestConfigs {
-  public static bigquery: dataform.IProjectConfig = {
+  public static bigquery = dataform.ProjectConfig.create({
     warehouse: "bigquery",
     defaultSchema: "schema",
     defaultLocation: "US"
-  };
+  });
 
-  public static bigqueryWithDefaultDatabase: dataform.IProjectConfig = {
+  public static bigqueryWithDefaultDatabase = dataform.ProjectConfig.create({
     ...TestConfigs.bigquery,
     defaultDatabase: "default-database"
-  };
+  });
 
-  public static bigqueryWithSchemaSuffix: dataform.IProjectConfig = {
+  public static bigqueryWithSchemaSuffix = dataform.ProjectConfig.create({
     ...TestConfigs.bigquery,
     schemaSuffix: "suffix"
-  };
+  });
 
-  public static bigqueryWithDefaultDatabaseAndSuffix: dataform.IProjectConfig = {
+  public static bigqueryWithDefaultDatabaseAndSuffix = dataform.ProjectConfig.create({
     ...TestConfigs.bigqueryWithDefaultDatabase,
     databaseSuffix: "suffix"
-  };
+  });
 
-  public static bigqueryWithTablePrefix: dataform.IProjectConfig = {
+  public static bigqueryWithTablePrefix = dataform.ProjectConfig.create({
     ...TestConfigs.bigquery,
     tablePrefix: "prefix"
-  };
+  });
 }
 
 suite("@dataform/core", () => {
@@ -42,7 +42,10 @@ suite("@dataform/core", () => {
       test(`config with prefix "${testConfig.tablePrefix}"`, () => {
         const tableWithPrefix = (table: string) =>
           testConfig.tablePrefix ? `${testConfig.tablePrefix}_${table}` : table;
-        const session = new Session(path.dirname(__filename), testConfig);
+        const session = new Session(
+          path.dirname(__filename),
+          dataform.ProjectConfig.create(testConfig)
+        );
         session
           .publish("example", {
             type: "table",
@@ -135,7 +138,10 @@ suite("@dataform/core", () => {
       test(`config with suffix "${testConfig.schemaSuffix}"`, () => {
         const schemaWithSuffix = (schema: string) =>
           testConfig.schemaSuffix ? `${schema}_${testConfig.schemaSuffix}` : schema;
-        const session = new Session(path.dirname(__filename), testConfig);
+        const session = new Session(
+          path.dirname(__filename),
+          dataform.ProjectConfig.create(testConfig)
+        );
         session
           .publish("example", {
             type: "table",
@@ -247,18 +253,18 @@ suite("@dataform/core", () => {
     });
 
     test("canonical targets", () => {
-      const originalConfig = {
+      const originalConfig = dataform.ProjectConfig.create({
         warehouse: "bigquery",
         defaultSchema: "schema",
         defaultDatabase: "database",
         schemaSuffix: "dev",
         tablePrefix: "dev"
-      };
-      const overrideConfig = {
+      });
+      const overrideConfig = dataform.ProjectConfig.create({
         ...originalConfig,
         defaultSchema: "otherschema",
         defaultDatabase: "otherdatabase"
-      };
+      });
       const session = new Session(path.dirname(__filename), overrideConfig, originalConfig);
       session.publish("dataset");
       session.assert("assertion");
@@ -298,13 +304,16 @@ suite("@dataform/core", () => {
     });
 
     test("non-unique canonical targets fails", () => {
-      const originalConfig = {
+      const originalConfig = dataform.ProjectConfig.create({
         warehouse: "bigquery",
         defaultSchema: "schema",
         defaultDatabase: "database",
         defaultLocation: "US"
-      };
-      const overrideConfig = { ...originalConfig, defaultSchema: "otherschema" };
+      });
+      const overrideConfig = dataform.ProjectConfig.create({
+        ...originalConfig,
+        defaultSchema: "otherschema"
+      });
       const session = new Session(path.dirname(__filename), overrideConfig, originalConfig);
       session
         .publish("view", {
@@ -943,10 +952,13 @@ suite("@dataform/core", () => {
     });
 
     test("defaultLocation must be set in BigQuery", () => {
-      const session = new Session(path.dirname(__filename), {
-        warehouse: "bigquery",
-        defaultSchema: "schema"
-      });
+      const session = new Session(
+        path.dirname(__filename),
+        dataform.ProjectConfig.create({
+          warehouse: "bigquery",
+          defaultSchema: "schema"
+        })
+      );
       const graph = session.compile();
       expect(graph.graphErrors.compilationErrors.map(error => error.message)).deep.equals([
         "A defaultLocation is required for BigQuery. This can be configured in workflow_settings.yaml."


### PR DESCRIPTION
* Rename config in session to projectConfig, to remove name overload confusion with action configs.
* Pass around created protobuf classes rather than interfaces, to make parameters type safe.
* Fixes an issue where assertion schema wasn't being applied - tests for this will be applied in https://github.com/dataform-co/dataform/pull/1731.
* Use the same method for applying targets with project configs as canonical project configs, to prevent them from having different behaviour.
* Fix lint from https://github.com/dataform-co/dataform/pull/1730.