### PR TITLE
Make proto object verification give more descriptive error messages

### DIFF
--- a/common/protos/index.ts
+++ b/common/protos/index.ts
@@ -18,6 +18,12 @@ export interface IProtoClass<IProto, Proto> {
   getTypeUrl(prefix: string): string;
 }
 
+export enum VerifyProtoErrorBehaviour {
+  DEFAULT,
+  SUGGEST_REPORTING_TO_DATAFORM_TEAM,
+  SHOW_DOCS_LINK
+}
+
 // This is a minimalist Typescript equivalent for the validation part of Profobuf's JsonFormat's
 // mergeMessage method:
 // https://github.com/protocolbuffers/protobuf/blob/670e0c2a0d0b64c994f743a73ee9b8926c47580d/java/util/src/main/java/com/google/protobuf/util/JsonFormat.java#L1455
@@ -29,7 +35,7 @@ export interface IProtoClass<IProto, Proto> {
 export function verifyObjectMatchesProto<Proto>(
   protoType: IProtoClass<any, Proto>,
   object: object,
-  options?: { suggestReportToDataformTeam?: boolean; showDocsLink?: boolean }
+  errorBehaviour: VerifyProtoErrorBehaviour = VerifyProtoErrorBehaviour.DEFAULT
 ): Proto {
   if (Array.isArray(object)) {
     throw ReferenceError(`Expected a top-level object, but found an array`);
@@ -53,7 +59,7 @@ export function verifyObjectMatchesProto<Proto>(
           // Empty objects are assigned to empty object fields by ProtobufJS.
           return;
         }
-        if (options?.suggestReportToDataformTeam) {
+        if (errorBehaviour === VerifyProtoErrorBehaviour.SUGGEST_REPORTING_TO_DATAFORM_TEAM) {
           throw ReferenceError(
             `Unexpected property "${presentKey}" for "${protoType
               .getTypeUrl("")
@@ -64,7 +70,7 @@ export function verifyObjectMatchesProto<Proto>(
         throw ReferenceError(
           `Unexpected property "${presentKey}", or property value type of ` +
             `"${typeof presentValue}" is incorrect.` +
-            (options?.showDocsLink
+            (errorBehaviour === VerifyProtoErrorBehaviour.SHOW_DOCS_LINK
               ? ` See ${CONFIGS_PROTO_DOCUMENTATION_URL}#${protoType
                   .getTypeUrl("")
                   // Clean up the proto type into its URL form.

--- a/common/protos/index.ts
+++ b/common/protos/index.ts
@@ -1,6 +1,7 @@
 import { util } from "protobufjs";
 
-import { IStringifier } from "df/common/strings/stringifier";
+const DOCUMENTATION_URL = "https://dataform-co.github.io/dataform/docs/configs-reference";
+const REPORT_ISSUE_URL = "https://github.com/dataform-co/dataform/issues";
 
 export interface IProtoClass<IProto, Proto> {
   new (): Proto;
@@ -24,7 +25,8 @@ export interface IProtoClass<IProto, Proto> {
 // meaning that the type of fields cannot be verified; an int can be confused with a string.
 export function verifyObjectMatchesProto<Proto>(
   protoType: IProtoClass<any, Proto>,
-  object: object
+  object: object,
+  isConfigsProto: boolean = true
 ): Proto {
   if (Array.isArray(object)) {
     throw ReferenceError(`Expected a top-level object, but found an array`);
@@ -48,8 +50,16 @@ export function verifyObjectMatchesProto<Proto>(
           // Empty objects are assigned to empty object fields by ProtobufJS.
           return;
         }
+        if (isConfigsProto) {
+          throw ReferenceError(
+            `Unexpected property "${presentKey}", or property value is of an incorrect type. See ` +
+              `${DOCUMENTATION_URL} for allowed properties.`
+          );
+        }
+        // If it's not a configs proto, then it's not a configuration issue by the user, it's a bug.
         throw ReferenceError(
-          `Cannot find field: ${presentKey} in message, or value type is incorrect`
+          `Unexpected property "${presentKey}", please report this to the Dataform team at ` +
+            `${REPORT_ISSUE_URL}.`
         );
       }
       if (typeof presentValue === "object") {

--- a/common/protos/index.ts
+++ b/common/protos/index.ts
@@ -1,6 +1,7 @@
 import { util } from "protobufjs";
 
-const DOCUMENTATION_URL = "https://dataform-co.github.io/dataform/docs/configs-reference";
+const CONFIGS_PROTO_DOCUMENTATION_URL =
+  "https://dataform-co.github.io/dataform/docs/configs-reference";
 const REPORT_ISSUE_URL = "https://github.com/dataform-co/dataform/issues";
 
 export interface IProtoClass<IProto, Proto> {
@@ -53,7 +54,7 @@ export function verifyObjectMatchesProto<Proto>(
         if (isConfigsProto) {
           throw ReferenceError(
             `Unexpected property "${presentKey}", or property value is of an incorrect type. See ` +
-              `${DOCUMENTATION_URL} for allowed properties.`
+              `${CONFIGS_PROTO_DOCUMENTATION_URL} for allowed properties.`
           );
         }
         // If it's not a configs proto, then it's not a configuration issue by the user, it's a bug.

--- a/common/protos/index.ts
+++ b/common/protos/index.ts
@@ -29,8 +29,7 @@ export interface IProtoClass<IProto, Proto> {
 export function verifyObjectMatchesProto<Proto>(
   protoType: IProtoClass<any, Proto>,
   object: object,
-  suggestReportToDataformTeam: boolean = false,
-  showDocsLink: boolean = true
+  options?: { suggestReportToDataformTeam?: boolean; showDocsLink?: boolean }
 ): Proto {
   if (Array.isArray(object)) {
     throw ReferenceError(`Expected a top-level object, but found an array`);
@@ -54,7 +53,7 @@ export function verifyObjectMatchesProto<Proto>(
           // Empty objects are assigned to empty object fields by ProtobufJS.
           return;
         }
-        if (suggestReportToDataformTeam) {
+        if (options?.suggestReportToDataformTeam) {
           throw ReferenceError(
             `Unexpected property "${presentKey}" for "${protoType
               .getTypeUrl("")
@@ -65,7 +64,7 @@ export function verifyObjectMatchesProto<Proto>(
         throw ReferenceError(
           `Unexpected property "${presentKey}", or property value type of ` +
             `"${typeof presentValue}" is incorrect.` +
-            (showDocsLink
+            (options?.showDocsLink
               ? ` See ${CONFIGS_PROTO_DOCUMENTATION_URL}#${protoType
                   .getTypeUrl("")
                   // Clean up the proto type into its URL form.

--- a/core/actions/assertion.ts
+++ b/core/actions/assertion.ts
@@ -227,7 +227,7 @@ export class Assertion extends ActionBuilder<dataform.Assertion> {
     this.proto.query = context.apply(this.contextableQuery);
     validateQueryString(this.session, this.proto.query, this.proto.fileName);
 
-    return verifyObjectMatchesProto(dataform.Assertion, this.proto, false);
+    return verifyObjectMatchesProto(dataform.Assertion, this.proto, true);
   }
 }
 

--- a/core/actions/assertion.ts
+++ b/core/actions/assertion.ts
@@ -239,7 +239,9 @@ export class Assertion extends ActionBuilder<dataform.Assertion> {
     this.proto.query = context.apply(this.contextableQuery);
     validateQueryString(this.session, this.proto.query, this.proto.fileName);
 
-    return verifyObjectMatchesProto(dataform.Assertion, this.proto, true);
+    return verifyObjectMatchesProto(dataform.Assertion, this.proto, {
+      suggestReportToDataformTeam: true
+    });
   }
 }
 

--- a/core/actions/assertion.ts
+++ b/core/actions/assertion.ts
@@ -1,4 +1,4 @@
-import { verifyObjectMatchesProto } from "df/common/protos";
+import { verifyObjectMatchesProto, VerifyProtoErrorBehaviour } from "df/common/protos";
 import { ActionBuilder } from "df/core/actions";
 import {
   IActionConfig,
@@ -239,9 +239,11 @@ export class Assertion extends ActionBuilder<dataform.Assertion> {
     this.proto.query = context.apply(this.contextableQuery);
     validateQueryString(this.session, this.proto.query, this.proto.fileName);
 
-    return verifyObjectMatchesProto(dataform.Assertion, this.proto, {
-      suggestReportToDataformTeam: true
-    });
+    return verifyObjectMatchesProto(
+      dataform.Assertion,
+      this.proto,
+      VerifyProtoErrorBehaviour.SUGGEST_REPORTING_TO_DATAFORM_TEAM
+    );
   }
 }
 

--- a/core/actions/assertion.ts
+++ b/core/actions/assertion.ts
@@ -227,7 +227,7 @@ export class Assertion extends ActionBuilder<dataform.Assertion> {
     this.proto.query = context.apply(this.contextableQuery);
     validateQueryString(this.session, this.proto.query, this.proto.fileName);
 
-    return verifyObjectMatchesProto(dataform.Assertion, this.proto);
+    return verifyObjectMatchesProto(dataform.Assertion, this.proto, false);
   }
 }
 

--- a/core/actions/declaration.ts
+++ b/core/actions/declaration.ts
@@ -109,6 +109,6 @@ export class Declaration extends ActionBuilder<dataform.Declaration> {
 
   public compile() {
     // ProtobufJS isn't strict with the fields available on protos, so we validate this here.
-    return verifyObjectMatchesProto(dataform.Declaration, this.proto, false);
+    return verifyObjectMatchesProto(dataform.Declaration, this.proto, true);
   }
 }

--- a/core/actions/declaration.ts
+++ b/core/actions/declaration.ts
@@ -109,6 +109,6 @@ export class Declaration extends ActionBuilder<dataform.Declaration> {
 
   public compile() {
     // ProtobufJS isn't strict with the fields available on protos, so we validate this here.
-    return verifyObjectMatchesProto(dataform.Declaration, this.proto);
+    return verifyObjectMatchesProto(dataform.Declaration, this.proto, false);
   }
 }

--- a/core/actions/declaration.ts
+++ b/core/actions/declaration.ts
@@ -108,7 +108,8 @@ export class Declaration extends ActionBuilder<dataform.Declaration> {
   }
 
   public compile() {
-    // ProtobufJS isn't strict with the fields available on protos, so we validate this here.
-    return verifyObjectMatchesProto(dataform.Declaration, this.proto, true);
+    return verifyObjectMatchesProto(dataform.Declaration, this.proto, {
+      suggestReportToDataformTeam: true
+    });
   }
 }

--- a/core/actions/declaration.ts
+++ b/core/actions/declaration.ts
@@ -1,4 +1,4 @@
-import { verifyObjectMatchesProto } from "df/common/protos";
+import { verifyObjectMatchesProto, VerifyProtoErrorBehaviour } from "df/common/protos";
 import { ActionBuilder } from "df/core/actions";
 import { ColumnDescriptors } from "df/core/column_descriptors";
 import {
@@ -108,8 +108,10 @@ export class Declaration extends ActionBuilder<dataform.Declaration> {
   }
 
   public compile() {
-    return verifyObjectMatchesProto(dataform.Declaration, this.proto, {
-      suggestReportToDataformTeam: true
-    });
+    return verifyObjectMatchesProto(
+      dataform.Declaration,
+      this.proto,
+      VerifyProtoErrorBehaviour.SUGGEST_REPORTING_TO_DATAFORM_TEAM
+    );
   }
 }

--- a/core/actions/notebook.ts
+++ b/core/actions/notebook.ts
@@ -96,7 +96,9 @@ export class Notebook extends ActionBuilder<dataform.Notebook> {
   }
 
   public compile() {
-    return verifyObjectMatchesProto(dataform.Notebook, this.proto, true);
+    return verifyObjectMatchesProto(dataform.Notebook, this.proto, {
+      suggestReportToDataformTeam: true
+    });
   }
 }
 

--- a/core/actions/notebook.ts
+++ b/core/actions/notebook.ts
@@ -91,7 +91,7 @@ export class Notebook extends ActionBuilder<dataform.Notebook> {
   }
 
   public compile() {
-    return verifyObjectMatchesProto(dataform.Notebook, this.proto, false);
+    return verifyObjectMatchesProto(dataform.Notebook, this.proto, true);
   }
 }
 

--- a/core/actions/notebook.ts
+++ b/core/actions/notebook.ts
@@ -1,4 +1,4 @@
-import { verifyObjectMatchesProto } from "df/common/protos";
+import { verifyObjectMatchesProto, VerifyProtoErrorBehaviour } from "df/common/protos";
 import { ActionBuilder } from "df/core/actions";
 import { Resolvable } from "df/core/common";
 import * as Path from "df/core/path";
@@ -96,9 +96,11 @@ export class Notebook extends ActionBuilder<dataform.Notebook> {
   }
 
   public compile() {
-    return verifyObjectMatchesProto(dataform.Notebook, this.proto, {
-      suggestReportToDataformTeam: true
-    });
+    return verifyObjectMatchesProto(
+      dataform.Notebook,
+      this.proto,
+      VerifyProtoErrorBehaviour.SUGGEST_REPORTING_TO_DATAFORM_TEAM
+    );
   }
 }
 

--- a/core/actions/notebook.ts
+++ b/core/actions/notebook.ts
@@ -20,7 +20,7 @@ export class Notebook extends ActionBuilder<dataform.Notebook> {
   // TODO: make this field private, to enforce proto update logic to happen in this class.
   public proto: dataform.INotebook = dataform.Notebook.create();
 
-  // If true, adds the inline assertions of dependencies as direct dependencies for this action. 
+  // If true, adds the inline assertions of dependencies as direct dependencies for this action.
   public dependOnDependencyAssertions: boolean = false;
 
   constructor(
@@ -70,7 +70,9 @@ export class Notebook extends ActionBuilder<dataform.Notebook> {
    */
   public dependencies(value: Resolvable | Resolvable[]) {
     const newDependencies = Array.isArray(value) ? value : [value];
-    newDependencies.forEach(resolvable => addDependenciesToActionDependencyTargets(this, resolvable));
+    newDependencies.forEach(resolvable =>
+      addDependenciesToActionDependencyTargets(this, resolvable)
+    );
     return this;
   }
 
@@ -89,7 +91,7 @@ export class Notebook extends ActionBuilder<dataform.Notebook> {
   }
 
   public compile() {
-    return verifyObjectMatchesProto(dataform.Notebook, this.proto);
+    return verifyObjectMatchesProto(dataform.Notebook, this.proto, false);
   }
 }
 

--- a/core/actions/operation.ts
+++ b/core/actions/operation.ts
@@ -276,7 +276,9 @@ export class Operation extends ActionBuilder<dataform.Operation> {
     const appliedQueries = context.apply(this.contextableQueries);
     this.proto.queries = typeof appliedQueries === "string" ? [appliedQueries] : appliedQueries;
 
-    return verifyObjectMatchesProto(dataform.Operation, this.proto, true);
+    return verifyObjectMatchesProto(dataform.Operation, this.proto, {
+      suggestReportToDataformTeam: true
+    });
   }
 }
 

--- a/core/actions/operation.ts
+++ b/core/actions/operation.ts
@@ -271,7 +271,7 @@ export class Operation extends ActionBuilder<dataform.Operation> {
     const appliedQueries = context.apply(this.contextableQueries);
     this.proto.queries = typeof appliedQueries === "string" ? [appliedQueries] : appliedQueries;
 
-    return verifyObjectMatchesProto(dataform.Operation, this.proto, false);
+    return verifyObjectMatchesProto(dataform.Operation, this.proto, true);
   }
 }
 

--- a/core/actions/operation.ts
+++ b/core/actions/operation.ts
@@ -1,4 +1,4 @@
-import { verifyObjectMatchesProto } from "df/common/protos";
+import { verifyObjectMatchesProto, VerifyProtoErrorBehaviour } from "df/common/protos";
 import { ActionBuilder } from "df/core/actions";
 import { ColumnDescriptors } from "df/core/column_descriptors";
 import {
@@ -276,9 +276,11 @@ export class Operation extends ActionBuilder<dataform.Operation> {
     const appliedQueries = context.apply(this.contextableQueries);
     this.proto.queries = typeof appliedQueries === "string" ? [appliedQueries] : appliedQueries;
 
-    return verifyObjectMatchesProto(dataform.Operation, this.proto, {
-      suggestReportToDataformTeam: true
-    });
+    return verifyObjectMatchesProto(
+      dataform.Operation,
+      this.proto,
+      VerifyProtoErrorBehaviour.SUGGEST_REPORTING_TO_DATAFORM_TEAM
+    );
   }
 }
 

--- a/core/actions/operation.ts
+++ b/core/actions/operation.ts
@@ -23,7 +23,7 @@ import {
   resolveActionsConfigFilename,
   setNameAndTarget,
   strictKeysOf,
-  toResolvable,
+  toResolvable
 } from "df/core/utils";
 import { dataform } from "df/protos/ts";
 
@@ -32,10 +32,10 @@ import { dataform } from "df/protos/ts";
  */
 export interface IOperationConfig
   extends IActionConfig,
-  IDependenciesConfig,
-  IDocumentableConfig,
-  INamedConfig,
-  ITargetableConfig {
+    IDependenciesConfig,
+    IDocumentableConfig,
+    INamedConfig,
+    ITargetableConfig {
   /**
    * Declares that this `operations` action creates a dataset which should be referenceable using the `ref` function.
    *
@@ -74,7 +74,7 @@ export class Operation extends ActionBuilder<dataform.Operation> {
   // Hold a reference to the Session instance.
   public session: Session;
 
-  // If true, adds the inline assertions of dependencies as direct dependencies for this action. 
+  // If true, adds the inline assertions of dependencies as direct dependencies for this action.
   public dependOnDependencyAssertions: boolean = false;
 
   // We delay contextification until the final compile step, so hold these here for now.
@@ -164,7 +164,9 @@ export class Operation extends ActionBuilder<dataform.Operation> {
 
   public dependencies(value: Resolvable | Resolvable[]) {
     const newDependencies = Array.isArray(value) ? value : [value];
-    newDependencies.forEach(resolvable => addDependenciesToActionDependencyTargets(this, resolvable));
+    newDependencies.forEach(resolvable =>
+      addDependenciesToActionDependencyTargets(this, resolvable)
+    );
     return this;
   }
 
@@ -269,7 +271,7 @@ export class Operation extends ActionBuilder<dataform.Operation> {
     const appliedQueries = context.apply(this.contextableQueries);
     this.proto.queries = typeof appliedQueries === "string" ? [appliedQueries] : appliedQueries;
 
-    return verifyObjectMatchesProto(dataform.Operation, this.proto);
+    return verifyObjectMatchesProto(dataform.Operation, this.proto, false);
   }
 }
 

--- a/core/actions/table.ts
+++ b/core/actions/table.ts
@@ -26,7 +26,7 @@ import {
   strictKeysOf,
   tableTypeStringToEnum,
   toResolvable,
-  validateQueryString,
+  validateQueryString
 } from "df/core/utils";
 import { dataform } from "df/protos/ts";
 
@@ -158,10 +158,10 @@ const ITableAssertionsProperties = () =>
  */
 export interface ITableConfig
   extends IActionConfig,
-  IDependenciesConfig,
-  IDocumentableConfig,
-  INamedConfig,
-  ITargetableConfig {
+    IDependenciesConfig,
+    IDocumentableConfig,
+    INamedConfig,
+    ITargetableConfig {
   /**
    * The type of the dataset. For more information on how this setting works, check out some of the [guides](guides)
    * on publishing different types of datasets with Dataform.
@@ -258,7 +258,7 @@ export class Table extends ActionBuilder<dataform.Table> {
   // Hold a reference to the Session instance.
   public session: Session;
 
-  // If true, adds the inline assertions of dependencies as direct dependencies for this action. 
+  // If true, adds the inline assertions of dependencies as direct dependencies for this action.
   public dependOnDependencyAssertions: boolean = false;
 
   // We delay contextification until the final compile step, so hold these here for now.
@@ -563,7 +563,9 @@ export class Table extends ActionBuilder<dataform.Table> {
 
   public dependencies(value: Resolvable | Resolvable[]) {
     const newDependencies = Array.isArray(value) ? value : [value];
-    newDependencies.forEach(resolvable => addDependenciesToActionDependencyTargets(this, resolvable));
+    newDependencies.forEach(resolvable =>
+      addDependenciesToActionDependencyTargets(this, resolvable)
+    );
     return this;
   }
 
@@ -733,7 +735,7 @@ export class Table extends ActionBuilder<dataform.Table> {
     validateQueryString(this.session, this.proto.query, this.proto.fileName);
     validateQueryString(this.session, this.proto.incrementalQuery, this.proto.fileName);
 
-    return verifyObjectMatchesProto(dataform.Table, this.proto);
+    return verifyObjectMatchesProto(dataform.Table, this.proto, false);
   }
 
   private contextifyOps(
@@ -753,7 +755,7 @@ export class Table extends ActionBuilder<dataform.Table> {
  * @hidden
  */
 export class TableContext implements ITableContext {
-  constructor(private table: Table, private isIncremental = false) { }
+  constructor(private table: Table, private isIncremental = false) {}
 
   public config(config: ITableConfig) {
     this.table.config(config);

--- a/core/actions/table.ts
+++ b/core/actions/table.ts
@@ -1,4 +1,4 @@
-import { verifyObjectMatchesProto } from "df/common/protos";
+import { verifyObjectMatchesProto, VerifyProtoErrorBehaviour } from "df/common/protos";
 import { ActionBuilder } from "df/core/actions";
 import { Assertion } from "df/core/actions/assertion";
 import { ColumnDescriptors } from "df/core/column_descriptors";
@@ -740,9 +740,11 @@ export class Table extends ActionBuilder<dataform.Table> {
     validateQueryString(this.session, this.proto.query, this.proto.fileName);
     validateQueryString(this.session, this.proto.incrementalQuery, this.proto.fileName);
 
-    return verifyObjectMatchesProto(dataform.Table, this.proto, {
-      suggestReportToDataformTeam: true
-    });
+    return verifyObjectMatchesProto(
+      dataform.Table,
+      this.proto,
+      VerifyProtoErrorBehaviour.SUGGEST_REPORTING_TO_DATAFORM_TEAM
+    );
   }
 
   private contextifyOps(

--- a/core/actions/table.ts
+++ b/core/actions/table.ts
@@ -735,7 +735,7 @@ export class Table extends ActionBuilder<dataform.Table> {
     validateQueryString(this.session, this.proto.query, this.proto.fileName);
     validateQueryString(this.session, this.proto.incrementalQuery, this.proto.fileName);
 
-    return verifyObjectMatchesProto(dataform.Table, this.proto, false);
+    return verifyObjectMatchesProto(dataform.Table, this.proto, true);
   }
 
   private contextifyOps(

--- a/core/actions/table.ts
+++ b/core/actions/table.ts
@@ -740,7 +740,9 @@ export class Table extends ActionBuilder<dataform.Table> {
     validateQueryString(this.session, this.proto.query, this.proto.fileName);
     validateQueryString(this.session, this.proto.incrementalQuery, this.proto.fileName);
 
-    return verifyObjectMatchesProto(dataform.Table, this.proto, true);
+    return verifyObjectMatchesProto(dataform.Table, this.proto, {
+      suggestReportToDataformTeam: true
+    });
   }
 
   private contextifyOps(

--- a/core/actions/test.ts
+++ b/core/actions/test.ts
@@ -124,7 +124,9 @@ export class Test extends ActionBuilder<dataform.Test> {
     }
     this.proto.expectedOutputQuery = testContext.apply(this.contextableQuery);
 
-    return verifyObjectMatchesProto(dataform.Test, this.proto, true);
+    return verifyObjectMatchesProto(dataform.Test, this.proto, {
+      suggestReportToDataformTeam: true
+    });
   }
 }
 

--- a/core/actions/test.ts
+++ b/core/actions/test.ts
@@ -124,7 +124,7 @@ export class Test extends ActionBuilder<dataform.Test> {
     }
     this.proto.expectedOutputQuery = testContext.apply(this.contextableQuery);
 
-    return verifyObjectMatchesProto(dataform.Test, this.proto, false);
+    return verifyObjectMatchesProto(dataform.Test, this.proto, true);
   }
 }
 

--- a/core/actions/test.ts
+++ b/core/actions/test.ts
@@ -124,7 +124,7 @@ export class Test extends ActionBuilder<dataform.Test> {
     }
     this.proto.expectedOutputQuery = testContext.apply(this.contextableQuery);
 
-    return verifyObjectMatchesProto(dataform.Test, this.proto);
+    return verifyObjectMatchesProto(dataform.Test, this.proto, false);
   }
 }
 

--- a/core/actions/test.ts
+++ b/core/actions/test.ts
@@ -1,4 +1,4 @@
-import { verifyObjectMatchesProto } from "df/common/protos";
+import { verifyObjectMatchesProto, VerifyProtoErrorBehaviour } from "df/common/protos";
 import { StringifiedMap } from "df/common/strings/stringifier";
 import { ActionBuilder } from "df/core/actions";
 import * as table from "df/core/actions/table";
@@ -124,9 +124,11 @@ export class Test extends ActionBuilder<dataform.Test> {
     }
     this.proto.expectedOutputQuery = testContext.apply(this.contextableQuery);
 
-    return verifyObjectMatchesProto(dataform.Test, this.proto, {
-      suggestReportToDataformTeam: true
-    });
+    return verifyObjectMatchesProto(
+      dataform.Test,
+      this.proto,
+      VerifyProtoErrorBehaviour.SUGGEST_REPORTING_TO_DATAFORM_TEAM
+    );
   }
 }
 

--- a/core/main.ts
+++ b/core/main.ts
@@ -192,6 +192,6 @@ function loadActionConfigsFile(
   } catch (e) {
     session.compileError(e, actionConfigsPath);
   }
-  verifyObjectMatchesProto(dataform.ActionConfigs, actionConfigsAsJson);
+  verifyObjectMatchesProto(dataform.ActionConfigs, actionConfigsAsJson, { showDocsLink: true });
   return dataform.ActionConfigs.fromObject(actionConfigsAsJson);
 }

--- a/core/main.ts
+++ b/core/main.ts
@@ -1,4 +1,9 @@
-import { decode64, encode64, verifyObjectMatchesProto } from "df/common/protos";
+import {
+  decode64,
+  encode64,
+  verifyObjectMatchesProto,
+  VerifyProtoErrorBehaviour
+} from "df/common/protos";
 import { Assertion } from "df/core/actions/assertion";
 import { Declaration } from "df/core/actions/declaration";
 import { Notebook } from "df/core/actions/notebook";
@@ -192,6 +197,10 @@ function loadActionConfigsFile(
   } catch (e) {
     session.compileError(e, actionConfigsPath);
   }
-  verifyObjectMatchesProto(dataform.ActionConfigs, actionConfigsAsJson, { showDocsLink: true });
+  verifyObjectMatchesProto(
+    dataform.ActionConfigs,
+    actionConfigsAsJson,
+    VerifyProtoErrorBehaviour.SHOW_DOCS_LINK
+  );
   return dataform.ActionConfigs.fromObject(actionConfigsAsJson);
 }

--- a/core/main_test.ts
+++ b/core/main_test.ts
@@ -443,7 +443,7 @@ quotes
       );
 
       expect(() => runMainInVm(coreExecutionRequestFromPath(projectDir))).to.throw(
-        `Workflow settings error: Unexpected property "notAProjectConfigField", or property value is of an incorrect type.`
+        `Workflow settings error: Unexpected property "notAProjectConfigField", or property value type of "string" is incorrect. See https://dataform-co.github.io/dataform/docs/configs-reference#dataform-WorkflowSettings for allowed properties.`
       );
     });
 
@@ -464,7 +464,7 @@ quotes
       );
 
       expect(() => runMainInVm(coreExecutionRequestFromPath(projectDir))).to.throw(
-        `Dataform json error: Unexpected property "notAProjectConfigField", or property value is of an incorrect type.`
+        `Dataform json error: Unexpected property "notAProjectConfigField", or property value type of "string" is incorrect.`
       );
     });
 
@@ -922,7 +922,7 @@ actions:
       );
 
       expect(() => runMainInVm(coreExecutionRequestFromPath(projectDir))).to.throw(
-        `Unexpected property "fileName", or property value is of an incorrect type.`
+        `Unexpected property "fileName", or property value type of "string" is incorrect. See https://dataform-co.github.io/dataform/docs/configs-reference#dataform-ActionConfigs for allowed properties.`
       );
     });
 
@@ -1143,7 +1143,7 @@ actions:
       );
 
       expect(() => runMainInVm(coreExecutionRequestFromPath(projectDir))).to.throw(
-        `Unexpected property "materialized", or property value is of an incorrect type.`
+        `Unexpected property "materialized", or property value type of "boolean" is incorrect. See https://dataform-co.github.io/dataform/docs/configs-reference#dataform-ActionConfigs for allowed properties.`
       );
     });
 

--- a/core/main_test.ts
+++ b/core/main_test.ts
@@ -443,7 +443,7 @@ quotes
       );
 
       expect(() => runMainInVm(coreExecutionRequestFromPath(projectDir))).to.throw(
-        "Cannot find field: notAProjectConfigField in message"
+        `Workflow settings error: Unexpected property "notAProjectConfigField", or property value is of an incorrect type.`
       );
     });
 
@@ -464,7 +464,7 @@ quotes
       );
 
       expect(() => runMainInVm(coreExecutionRequestFromPath(projectDir))).to.throw(
-        "Cannot find field: notAProjectConfigField in message"
+        `Dataform json error: Unexpected property "notAProjectConfigField", or property value is of an incorrect type.`
       );
     });
 
@@ -922,7 +922,7 @@ actions:
       );
 
       expect(() => runMainInVm(coreExecutionRequestFromPath(projectDir))).to.throw(
-        "Cannot find field: fileName in message, or value type is incorrect"
+        `Unexpected property "fileName", or property value is of an incorrect type.`
       );
     });
 
@@ -1143,7 +1143,7 @@ actions:
       );
 
       expect(() => runMainInVm(coreExecutionRequestFromPath(projectDir))).to.throw(
-        "Cannot find field: materialized in message, or value type is incorrect"
+        `Unexpected property "materialized", or property value is of an incorrect type.`
       );
     });
 

--- a/core/session.ts
+++ b/core/session.ts
@@ -398,7 +398,7 @@ export class Session {
       )
     );
 
-    verifyObjectMatchesProto(dataform.CompiledGraph, compiledGraph);
+    verifyObjectMatchesProto(dataform.CompiledGraph, compiledGraph, false);
     return compiledGraph;
   }
 
@@ -467,9 +467,13 @@ export class Session {
           fullyQualifiedDependencies[targetAsReadableString(protoDep.target)] = protoDep.target;
 
           if (dependency.includeDependentAssertions) {
-            this.actionAssertionMap.find(dependency).forEach(assertion =>
-              fullyQualifiedDependencies[targetAsReadableString(assertion.proto.target)] = assertion.proto.target
-            );
+            this.actionAssertionMap
+              .find(dependency)
+              .forEach(
+                assertion =>
+                  (fullyQualifiedDependencies[targetAsReadableString(assertion.proto.target)] =
+                    assertion.proto.target)
+              );
           }
         } else {
           // Too many targets matched the dependency.
@@ -751,14 +755,11 @@ class ActionMap {
   private byName: Map<string, Action[]> = new Map();
   private bySchemaAndName: Map<string, Map<string, Action[]>> = new Map();
   private byDatabaseAndName: Map<string, Map<string, Action[]>> = new Map();
-  private byDatabaseSchemaAndName: Map<
-    string,
-    Map<string, Map<string, Action[]>>
-  > = new Map();
+  private byDatabaseSchemaAndName: Map<string, Map<string, Map<string, Action[]>>> = new Map();
 
   public constructor(actions: Action[]) {
     for (const action of actions) {
-      this.set(action.proto.target, action)
+      this.set(action.proto.target, action);
     }
   }
 
@@ -774,7 +775,7 @@ class ActionMap {
         this.byDatabaseAndName.set(actionTarget.database, new Map());
       }
       const forDatabaseNoSchema = this.byDatabaseAndName.get(actionTarget.database);
-      this.setByNameLevel(forDatabaseNoSchema, actionTarget.name, assertionTarget)
+      this.setByNameLevel(forDatabaseNoSchema, actionTarget.name, assertionTarget);
 
       if (!!actionTarget.schema) {
         if (!this.byDatabaseSchemaAndName.has(actionTarget.database)) {
@@ -811,7 +812,11 @@ class ActionMap {
     targetMap.get(name).push(assertionTarget);
   }
 
-  private setBySchemaLevel(targetMap: Map<string, Map<string, Action[]>>, actionTarget: ITarget, assertionTarget: Action) {
+  private setBySchemaLevel(
+    targetMap: Map<string, Map<string, Action[]>>,
+    actionTarget: ITarget,
+    assertionTarget: Action
+  ) {
     if (!targetMap.has(actionTarget.schema)) {
       targetMap.set(actionTarget.schema, new Map());
     }

--- a/core/session.ts
+++ b/core/session.ts
@@ -1,6 +1,6 @@
 import { default as TarjanGraphConstructor, Graph as TarjanGraph } from "tarjan-graph";
 
-import { encode64, verifyObjectMatchesProto } from "df/common/protos";
+import { encode64, verifyObjectMatchesProto, VerifyProtoErrorBehaviour } from "df/common/protos";
 import { StringifiedMap, StringifiedSet } from "df/common/strings/stringifier";
 import { Action, SqlxConfig } from "df/core/actions";
 import { AContextable, Assertion, AssertionContext } from "df/core/actions/assertion";
@@ -374,9 +374,11 @@ export class Session {
       )
     );
 
-    verifyObjectMatchesProto(dataform.CompiledGraph, compiledGraph, {
-      suggestReportToDataformTeam: true
-    });
+    verifyObjectMatchesProto(
+      dataform.CompiledGraph,
+      compiledGraph,
+      VerifyProtoErrorBehaviour.SUGGEST_REPORTING_TO_DATAFORM_TEAM
+    );
     return compiledGraph;
   }
 

--- a/core/session.ts
+++ b/core/session.ts
@@ -374,7 +374,9 @@ export class Session {
       )
     );
 
-    verifyObjectMatchesProto(dataform.CompiledGraph, compiledGraph, true);
+    verifyObjectMatchesProto(dataform.CompiledGraph, compiledGraph, {
+      suggestReportToDataformTeam: true
+    });
     return compiledGraph;
   }
 

--- a/core/session.ts
+++ b/core/session.ts
@@ -398,7 +398,7 @@ export class Session {
       )
     );
 
-    verifyObjectMatchesProto(dataform.CompiledGraph, compiledGraph, false);
+    verifyObjectMatchesProto(dataform.CompiledGraph, compiledGraph, true);
     return compiledGraph;
   }
 

--- a/core/workflow_settings.ts
+++ b/core/workflow_settings.ts
@@ -29,7 +29,7 @@ export function readWorkflowSettings(): dataform.ProjectConfig {
     // Dataform JSON used the compiled graph's config proto, rather than workflow settings.
     try {
       return dataform.ProjectConfig.create(
-        verifyObjectMatchesProto(dataform.ProjectConfig, dataformJson, false, false)
+        verifyObjectMatchesProto(dataform.ProjectConfig, dataformJson)
       );
     } catch (e) {
       if (e instanceof ReferenceError) {
@@ -50,7 +50,8 @@ function verifyWorkflowSettingsAsJson(workflowSettingsAsJson: object): dataform.
         dataform.WorkflowSettings,
         workflowSettingsAsJson as {
           [key: string]: any;
-        }
+        },
+        { showDocsLink: true }
       )
     );
   } catch (e) {

--- a/core/workflow_settings.ts
+++ b/core/workflow_settings.ts
@@ -29,7 +29,7 @@ export function readWorkflowSettings(): dataform.ProjectConfig {
     // Dataform JSON used the compiled graph's config proto, rather than workflow settings.
     try {
       return dataform.ProjectConfig.create(
-        verifyObjectMatchesProto(dataform.ProjectConfig, dataformJson)
+        verifyObjectMatchesProto(dataform.ProjectConfig, dataformJson, false, false)
       );
     } catch (e) {
       if (e instanceof ReferenceError) {

--- a/core/workflow_settings.ts
+++ b/core/workflow_settings.ts
@@ -1,4 +1,4 @@
-import { verifyObjectMatchesProto } from "df/common/protos";
+import { verifyObjectMatchesProto, VerifyProtoErrorBehaviour } from "df/common/protos";
 import { version } from "df/core/version";
 import { dataform } from "df/protos/ts";
 
@@ -51,7 +51,7 @@ function verifyWorkflowSettingsAsJson(workflowSettingsAsJson: object): dataform.
         workflowSettingsAsJson as {
           [key: string]: any;
         },
-        { showDocsLink: true }
+        VerifyProtoErrorBehaviour.SHOW_DOCS_LINK
       )
     );
   } catch (e) {

--- a/docs/configs-reference.md
+++ b/docs/configs-reference.md
@@ -317,7 +317,7 @@ Target represents a unique action identifier.
 | project | [string](#string) |  | The Google Cloud project (database) of the action. |
 | dataset | [string](#string) |  | The dataset (schema) of the action. For notebooks, this is the location. |
 | name | [string](#string) |  | The name of the action. |
-| include_dependent_assertions | [bool](#bool) |  | flag for when we want to add assertions of this dependency in dependency_targets as well |
+| include_dependent_assertions | [bool](#bool) |  | flag for when we want to add assertions of this dependency in dependency_targets as well. |
 
 
 
@@ -395,7 +395,6 @@ If the option name contains special characters, encapsulate the name in quotes, 
 
 ### ActionConfigs
 Action configs defines the contents of `actions.yaml` configuration files.
-TODO(ekrekr): consolidate these configuration options in the JS API.
 
 
 | Field | Type | Label | Description |

--- a/docs/configs-reference.md
+++ b/docs/configs-reference.md
@@ -149,6 +149,7 @@ Some options, for example, partitionExpirationDays, have dedicated type/validity
 String values must be encapsulated in double-quotes, for example: additionalOptions: {numeric_option: &#34;5&#34;, string_option: &#39;&#34;string-value&#34;&#39;}
 
 If the option name contains special characters, encapsulate the name in quotes, for example: additionalOptions: { &#34;option-name&#34;: &#34;value&#34; }. |
+| depend_on_dependency_assertions | [bool](#bool) |  | When set to true, assertions dependent upon any dependency will be add as dedpendency to this action |
 
 
 
@@ -203,6 +204,7 @@ If the option name contains special characters, encapsulate the name in quotes, 
 | tags | [string](#string) | repeated | A list of user-defined tags with which the action should be labeled. |
 | disabled | [bool](#bool) |  | If set to true, this action will not be executed. However, the action can still be depended upon. Useful for temporarily turning off broken actions. |
 | description | [string](#string) |  | Description of the notebook. |
+| depend_on_dependency_assertions | [bool](#bool) |  | When set to true, assertions dependent upon any dependency will be add as dedpendency to this action |
 
 
 
@@ -227,6 +229,7 @@ If the option name contains special characters, encapsulate the name in quotes, 
 | has_output | [bool](#bool) |  | Declares that this action creates a dataset which should be referenceable as a dependency target, for example by using the `ref` function. |
 | description | [string](#string) |  | Description of the operation. |
 | columns | [ActionConfig.ColumnDescriptor](#dataform-ActionConfig-ColumnDescriptor) | repeated | Descriptions of columns within the operation. Can only be set if hasOutput is true. |
+| depend_on_dependency_assertions | [bool](#bool) |  | When set to true, assertions dependent upon any dependency will be add as dedpendency to this action |
 
 
 
@@ -264,6 +267,7 @@ Some options, for example, partitionExpirationDays, have dedicated type/validity
 String values must be encapsulated in double-quotes, for example: additionalOptions: {numeric_option: &#34;5&#34;, string_option: &#39;&#34;string-value&#34;&#39;}
 
 If the option name contains special characters, encapsulate the name in quotes, for example: additionalOptions: { &#34;option-name&#34;: &#34;value&#34; }. |
+| depend_on_dependency_assertions | [bool](#bool) |  | When set to true, assertions dependent upon any dependency will be add as dedpendency to this action |
 
 
 
@@ -313,6 +317,7 @@ Target represents a unique action identifier.
 | project | [string](#string) |  | The Google Cloud project (database) of the action. |
 | dataset | [string](#string) |  | The dataset (schema) of the action. For notebooks, this is the location. |
 | name | [string](#string) |  | The name of the action. |
+| include_dependent_assertions | [bool](#bool) |  | flag for when we want to add assertions of this dependency in dependency_targets as well |
 
 
 
@@ -347,6 +352,7 @@ Some options, for example, partitionExpirationDays, have dedicated type/validity
 String values must be encapsulated in double-quotes, for example: additionalOptions: {numeric_option: &#34;5&#34;, string_option: &#39;&#34;string-value&#34;&#39;}
 
 If the option name contains special characters, encapsulate the name in quotes, for example: additionalOptions: { &#34;option-name&#34;: &#34;value&#34; }. |
+| depend_on_dependency_assertions | [bool](#bool) |  | When set to true, assertions dependent upon any dependency will be add as dedpendency to this action |
 
 
 

--- a/protos/configs.proto
+++ b/protos/configs.proto
@@ -64,7 +64,8 @@ message ActionConfig {
     // The name of the action.
     string name = 4;
 
-    // flag for when we want to add assertions of this dependency in dependency_targets as well
+    // flag for when we want to add assertions of this dependency in
+    // dependency_targets as well
     bool include_dependent_assertions = 5;
   }
 

--- a/protos/configs.proto
+++ b/protos/configs.proto
@@ -45,8 +45,9 @@ message WorkflowSettings {
   NotebookRuntimeOptionsConfig default_notebook_runtime_options = 10;
 }
 
+// TODO(ekrekr): consolidate ActionsConfigs proto types in the JS API.
+
 // Action configs defines the contents of `actions.yaml` configuration files.
-// TODO(ekrekr): consolidate these configuration options in the JS API.
 message ActionConfigs {
   repeated ActionConfig actions = 1;
 }

--- a/protos/configs.proto
+++ b/protos/configs.proto
@@ -65,7 +65,7 @@ message ActionConfig {
     string name = 4;
 
     // flag for when we want to add assertions of this dependency in
-    // dependency_targets as well
+    // dependency_targets as well.
     bool include_dependent_assertions = 5;
   }
 

--- a/scripts/publish
+++ b/scripts/publish
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+./scripts/regenerate_docs
+
 if [ "$(git status --porcelain)" ]; then 
     echo "There are uncommitted changes; aborting." 1>&2
     exit 1


### PR DESCRIPTION
Given that we can't do proper type validation due to ProtobufJS, this is the next best thing that I can think of.