### PR TITLE
Fix vscode extension crashes on windows

### DIFF
--- a/vscode/server.ts
+++ b/vscode/server.ts
@@ -114,7 +114,7 @@ async function getProcessResult(childProcess: ChildProcess) {
   childProcess.stderr.on("data", chunk => (stderr += String(chunk)));
   childProcess.stdout.pipe(process.stdout);
   childProcess.stdout.on("data", chunk => (stdout += String(chunk)));
-  childProcess.on("error", _err => ( error = _err));
+  childProcess.on("error", err => (error = err));
   const exitCode: number = await new Promise(resolve => {
     childProcess.on("close", resolve);
   });

--- a/vscode/server.ts
+++ b/vscode/server.ts
@@ -59,18 +59,43 @@ async function applySettings() {
 }
 
 async function compileAndValidate() {
-  const spawnedProcess = spawn("dataform", ["compile", "--json", ...settings.compilerOptions]);
-  spawnedProcess.on("error", err => {
+  const spawnedProcess = spawn(
+    (process.platform !== "win32") ? "dataform" : "dataform.cmd",
+    ["compile", "--json", ...settings.compilerOptions]
+  );
+
+  const compileResult = await getProcessResult(spawnedProcess);
+  if (compileResult.exitCode !== 0) {
     // tslint:disable-next-line: no-console
-    console.error("Error running 'dataform compile':", err);
+    console.error("Error running 'dataform compile':", compileResult);
+    if (compileResult.error?.code === "ENOENT") {
+      connection.sendNotification(
+        "error",
+        "Errors encountered when running 'dataform' CLI. Please ensure that the CLI is installed and up-to-date: 'npm i -g @dataform/cli'."
+      );
+      return;
+    } else {
+      connection.sendNotification(
+        "error",
+        "Errors encountered when running 'dataform' CLI. Please check the output for more information."
+      );
+      return;
+    }
+  }
+
+  let parsedResult: dataform.ICompiledGraph = null;
+  try {
+    parsedResult = JSON.parse(compileResult.stdout);
+  } catch (e) {
+    // tslint:disable-next-line: no-console
+    console.error("Error parsing 'dataform compile' output", e);
     connection.sendNotification(
       "error",
-      "Errors encountered when running 'dataform' CLI. Please ensure that the CLI is installed and up-to-date: 'npm i -g @dataform/cli'."
+      "Error parsing 'dataform compile' output. Please check the output for more information."
     );
-  });
-  const compileResult = await getProcessResult(spawnedProcess);
+    return;
+  }
 
-  const parsedResult: dataform.ICompiledGraph = JSON.parse(compileResult.stdout);
   if (parsedResult?.graphErrors?.compilationErrors) {
     parsedResult.graphErrors.compilationErrors.forEach(compilationError => {
       connection.sendNotification("error", compilationError.message);
@@ -83,13 +108,17 @@ async function compileAndValidate() {
 
 async function getProcessResult(childProcess: ChildProcess) {
   let stdout = "";
+  let stderr = "";
+  let error: any = null;
   childProcess.stderr.pipe(process.stderr);
+  childProcess.stderr.on("data", chunk => (stderr += String(chunk)));
   childProcess.stdout.pipe(process.stdout);
   childProcess.stdout.on("data", chunk => (stdout += String(chunk)));
+  childProcess.on("error", _err => ( error = _err));
   const exitCode: number = await new Promise(resolve => {
     childProcess.on("close", resolve);
   });
-  return { exitCode, stdout };
+  return { exitCode, stdout, stderr, error };
 }
 
 function gatherAllActions(


### PR DESCRIPTION
1. Fix command name on windows to "dataform.cmd".
2. Add error handling to prevent whole extension crash.

I'm not sure how to run linter (I tried to run `scripts/lint`, but it ended up with an error `could not require "tslint-config-prettier".`), so I'd appreciate any advice you can offer.
Also, since this is my first PR to this project, please let me know if you notice any issues.