### PR TITLE
Split table tests

### DIFF
--- a/core/main_test.ts
+++ b/core/main_test.ts
@@ -1692,7 +1692,6 @@ SELECT 1`
             }
           },
           tags: ["tag1", "tag2"],
-          uniqueKey: ["key1", "key2"],
           dependencyTargets: [
             {
               database: "defaultProject",

--- a/protos/configs.proto
+++ b/protos/configs.proto
@@ -79,6 +79,37 @@ message ActionConfig {
 
     // A list of BigQuery policy tags that will be applied to the column.
     repeated string bigquery_policy_tags = 3;
+
+    // A list of tags for this column which will be applied.
+    repeated string tags = 4;
+  }
+
+  // Options for shorthand specifying assertions, useable for some table-based
+  // action types.
+  message TableAssertionsConfig {
+    // Column(s) which constitute the dataset's unique key index.
+    //  If set, the resulting assertion will fail if there is more than one row
+    //  in the dataset with the same values for all of these column(s).
+    repeated string unique_key = 1;
+
+    // Combinations of column(s), each of which should constitute a unique key
+    // index for the dataset. If set, the resulting assertion(s) will fail if
+    // there is more than one row in the dataset with the same values for all of
+    // the column(s) in the unique key(s).
+    message UniqueKey {
+      repeated string unique_key = 1;
+    }
+    repeated UniqueKey unique_keys = 2;
+
+    // Column(s) which may never be `NULL`.
+    // If set, the resulting assertion will fail if any row contains `NULL`
+    // values for these column(s).
+    repeated string non_null = 3;
+
+    // General condition(s) which should hold true for all rows in the dataset.
+    // If set, the resulting assertion will fail if any row violates any of
+    // these condition(s).
+    repeated string row_conditions = 4;
   }
 
   message TableConfig {
@@ -157,6 +188,17 @@ message ActionConfig {
     // When set to true, assertions dependent upon any dependency will
     // be add as dedpendency to this action
     bool depend_on_dependency_assertions = 18;
+
+    // Assertions to be run on the dataset.
+    // If configured, relevant assertions will automatically be created and run
+    // as a dependency of this dataset.
+    TableAssertionsConfig assertions = 19;
+
+    // If true, this indicates that the action only depends on data from
+    // explicitly-declared dependencies. Otherwise if false, it indicates that
+    // the  action depends on data from a source which has not been declared as
+    // a dependency.
+    bool hermetic = 20;
   }
 
   message ViewConfig {
@@ -221,6 +263,17 @@ message ActionConfig {
     // When set to true, assertions dependent upon any dependency will
     // be add as dedpendency to this action
     bool depend_on_dependency_assertions = 15;
+
+    // If true, this indicates that the action only depends on data from
+    // explicitly-declared dependencies. Otherwise if false, it indicates that
+    // the  action depends on data from a source which has not been declared as
+    // a dependency.
+    bool hermetic = 16;
+
+    // Assertions to be run on the dataset.
+    // If configured, relevant assertions will automatically be created and run
+    // as a dependency of this dataset.
+    TableAssertionsConfig assertions = 17;
   }
 
   message IncrementalTableConfig {
@@ -313,6 +366,17 @@ message ActionConfig {
     // When set to true, assertions dependent upon any dependency will
     // be add as dedpendency to this action
     bool depend_on_dependency_assertions = 21;
+
+    // Assertions to be run on the dataset.
+    // If configured, relevant assertions will automatically be created and run
+    // as a dependency of this dataset.
+    TableAssertionsConfig assertions = 22;
+
+    // If true, this indicates that the action only depends on data from
+    // explicitly-declared dependencies. Otherwise if false, it indicates that
+    // the  action depends on data from a source which has not been declared as
+    // a dependency.
+    bool hermetic = 23;
   }
 
   message AssertionConfig {

--- a/protos/configs.proto
+++ b/protos/configs.proto
@@ -79,37 +79,6 @@ message ActionConfig {
 
     // A list of BigQuery policy tags that will be applied to the column.
     repeated string bigquery_policy_tags = 3;
-
-    // A list of tags for this column which will be applied.
-    repeated string tags = 4;
-  }
-
-  // Options for shorthand specifying assertions, useable for some table-based
-  // action types.
-  message TableAssertionsConfig {
-    // Column(s) which constitute the dataset's unique key index.
-    //  If set, the resulting assertion will fail if there is more than one row
-    //  in the dataset with the same values for all of these column(s).
-    repeated string unique_key = 1;
-
-    // Combinations of column(s), each of which should constitute a unique key
-    // index for the dataset. If set, the resulting assertion(s) will fail if
-    // there is more than one row in the dataset with the same values for all of
-    // the column(s) in the unique key(s).
-    message UniqueKey {
-      repeated string unique_key = 1;
-    }
-    repeated UniqueKey unique_keys = 2;
-
-    // Column(s) which may never be `NULL`.
-    // If set, the resulting assertion will fail if any row contains `NULL`
-    // values for these column(s).
-    repeated string non_null = 3;
-
-    // General condition(s) which should hold true for all rows in the dataset.
-    // If set, the resulting assertion will fail if any row violates any of
-    // these condition(s).
-    repeated string row_conditions = 4;
   }
 
   message TableConfig {
@@ -188,17 +157,6 @@ message ActionConfig {
     // When set to true, assertions dependent upon any dependency will
     // be add as dedpendency to this action
     bool depend_on_dependency_assertions = 18;
-
-    // Assertions to be run on the dataset.
-    // If configured, relevant assertions will automatically be created and run
-    // as a dependency of this dataset.
-    TableAssertionsConfig assertions = 19;
-
-    // If true, this indicates that the action only depends on data from
-    // explicitly-declared dependencies. Otherwise if false, it indicates that
-    // the  action depends on data from a source which has not been declared as
-    // a dependency.
-    bool hermetic = 20;
   }
 
   message ViewConfig {
@@ -263,17 +221,6 @@ message ActionConfig {
     // When set to true, assertions dependent upon any dependency will
     // be add as dedpendency to this action
     bool depend_on_dependency_assertions = 15;
-
-    // If true, this indicates that the action only depends on data from
-    // explicitly-declared dependencies. Otherwise if false, it indicates that
-    // the  action depends on data from a source which has not been declared as
-    // a dependency.
-    bool hermetic = 16;
-
-    // Assertions to be run on the dataset.
-    // If configured, relevant assertions will automatically be created and run
-    // as a dependency of this dataset.
-    TableAssertionsConfig assertions = 17;
   }
 
   message IncrementalTableConfig {
@@ -366,17 +313,6 @@ message ActionConfig {
     // When set to true, assertions dependent upon any dependency will
     // be add as dedpendency to this action
     bool depend_on_dependency_assertions = 21;
-
-    // Assertions to be run on the dataset.
-    // If configured, relevant assertions will automatically be created and run
-    // as a dependency of this dataset.
-    TableAssertionsConfig assertions = 22;
-
-    // If true, this indicates that the action only depends on data from
-    // explicitly-declared dependencies. Otherwise if false, it indicates that
-    // the  action depends on data from a source which has not been declared as
-    // a dependency.
-    bool hermetic = 23;
   }
 
   message AssertionConfig {


### PR DESCRIPTION
This will help catch issues when splitting tables to different actions, in order to support protobuf action constructors everywhere.

See https://github.com/dataform-co/dataform/pull/1760 for example of what this means.