### PR TITLE
Fix empty object internal error

### DIFF
--- a/common/protos/index.ts
+++ b/common/protos/index.ts
@@ -55,6 +55,12 @@ export function verifyObjectMatchesProto<Proto>(
           // Empty arrays are assigned to empty proto array fields by ProtobufJS.
           return;
         }
+        if (!presentValue) {
+          throw ReferenceError(
+            `Unexpected empty value for "${presentKey}".` +
+              maybeGetDocsLinkPrefix(errorBehaviour, protoType)
+          );
+        }
         if (typeof presentValue === "object" && Object.keys(presentValue).length === 0) {
           // Empty objects are assigned to empty object fields by ProtobufJS.
           return;
@@ -70,13 +76,7 @@ export function verifyObjectMatchesProto<Proto>(
         throw ReferenceError(
           `Unexpected property "${presentKey}", or property value type of ` +
             `"${typeof presentValue}" is incorrect.` +
-            (errorBehaviour === VerifyProtoErrorBehaviour.SHOW_DOCS_LINK
-              ? ` See ${CONFIGS_PROTO_DOCUMENTATION_URL}#${protoType
-                  .getTypeUrl("")
-                  // Clean up the proto type into its URL form.
-                  .replace(/\./g, "-")
-                  .replace(/\//, "")} for allowed properties.`
-              : "")
+            maybeGetDocsLinkPrefix(errorBehaviour, protoType)
         );
       }
       if (typeof presentValue === "object") {
@@ -87,6 +87,19 @@ export function verifyObjectMatchesProto<Proto>(
 
   checkFields(object, protoCastObject);
   return proto;
+}
+
+function maybeGetDocsLinkPrefix<Proto>(
+  errorBehaviour: VerifyProtoErrorBehaviour,
+  protoType: IProtoClass<any, Proto>
+) {
+  return errorBehaviour === VerifyProtoErrorBehaviour.SHOW_DOCS_LINK
+    ? ` See ${CONFIGS_PROTO_DOCUMENTATION_URL}#${protoType
+        .getTypeUrl("")
+        // Clean up the proto type into its URL form.
+        .replace(/\./g, "-")
+        .replace(/\//, "")} for allowed properties.`
+    : "";
 }
 
 export function encode64<IProto, Proto>(

--- a/core/main_test.ts
+++ b/core/main_test.ts
@@ -1201,6 +1201,24 @@ actions:
       );
     });
 
+    test(`fails when empty objects are given`, () => {
+      const projectDir = tmpDirFixture.createNewTmpDir();
+      fs.writeFileSync(
+        path.join(projectDir, "workflow_settings.yaml"),
+        VALID_WORKFLOW_SETTINGS_YAML
+      );
+      fs.mkdirSync(path.join(projectDir, "definitions"));
+      fs.writeFileSync(
+        path.join(projectDir, "definitions/actions.yaml"),
+        `
+actions:`
+      );
+
+      expect(() => runMainInVm(coreExecutionRequestFromPath(projectDir))).to.throw(
+        `Unexpected empty value for "actions". See https://dataform-co.github.io/dataform/docs/configs-reference#dataform-ActionConfigs for allowed properties.`
+      );
+    });
+
     test(`filenames with non-UTF8 characters are valid`, () => {
       const projectDir = tmpDirFixture.createNewTmpDir();
       fs.writeFileSync(


### PR DESCRIPTION
Previously this would throw an internal error of `Cannot convert undefined or null to object`. Now it throws a human readable error.