### PR TITLE
Add workflow_settings.yaml validation/completion VSCode extension

### DIFF
--- a/vscode/BUILD
+++ b/vscode/BUILD
@@ -32,6 +32,7 @@ sh_binary(
         ":language-configuration.json",
         ":package.json",
         ":sqlx.grammar.json",
+        ":workflow_settings_yaml.schema.json",
         ":vscode-sources",
     ],
 )
@@ -46,6 +47,7 @@ sh_binary(
         ":README.md",
         ":LICENSE",
         ":sqlx.grammar.json",
+        ":workflow_settings_yaml.schema.json",
         ":vscode-sources",
     ],
 )

--- a/vscode/extension.ts
+++ b/vscode/extension.ts
@@ -53,4 +53,35 @@ export async function activate(context: vscode.ExtensionContext) {
   client.onNotification("success", message => {
     vscode.window.showInformationMessage(message);
   });
+
+  // Recommend YAML extension if not installed
+  // We also can add the extension to "extensionDependencies" in package.json,
+  // but this way we can avoid forcing users to install the extension.
+  // You can control this recommendation behavior through the setting.
+  if (workspace.getConfiguration("dataform").get("recommendYamlExtension")) {
+    const yamlExtension = vscode.extensions.getExtension("redhat.vscode-yaml");
+    if (!yamlExtension) {
+      await vscode.window.showInformationMessage(
+        "The Dataform extension recommends installing the YAML extension for workflow_settings.yaml support.",
+        "Install",
+        "Don't show again"
+      ).then(selection => {
+        if (selection === "Install") {
+          // Open the YAML extension page
+          vscode.env.openExternal(
+            vscode.Uri.parse(
+              "vscode:extension/redhat.vscode-yaml"
+            )
+          );
+        } else if (selection === "Don't show again") {
+          // Disable the recommendation
+          workspace.getConfiguration("dataform").update(
+            "recommendYamlExtension",
+            false,
+            vscode.ConfigurationTarget.Global
+          );
+        }
+      });
+    }
+  }
 }

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -40,6 +40,11 @@
             },
             "default": [],
             "markdownDescription": "An array of additional arguments the extension should pass to the Dataform cli while executing `dataform compile --json`."
+          },
+          "dataform.recommendYamlExtension": {
+            "type": "boolean",
+            "default": true,
+            "markdownDescription": "Whether to recommend the YAML extension for validating `workflow_settings.yaml`."
           }
         }
       }
@@ -65,6 +70,12 @@
         "language": "sqlx",
         "scopeName": "source.sqlx",
         "path": "sqlx.grammar.json"
+      }
+    ],
+    "yamlValidation": [
+      {
+        "fileMatch": "workflow_settings.yaml",
+        "url": "./workflow_settings_yaml.schema.json"
       }
     ]
   }

--- a/vscode/workflow_settings_yaml.schema.json
+++ b/vscode/workflow_settings_yaml.schema.json
@@ -2,6 +2,7 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",
     "$comment": "Created from 'protos/configs.proto'. Even options are specified as 'required' in proto, they might be specified from the CLI options, so leave them optional except for the dataformCoreVersion which is required in compile.",
+    "additionalProperties": false,
     "properties": {
         "dataformCoreVersion": {
             "type": "string",

--- a/vscode/workflow_settings_yaml.schema.json
+++ b/vscode/workflow_settings_yaml.schema.json
@@ -1,0 +1,57 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "$comment": "Created from 'protos/configs.proto'. Even options are specified as 'required' in proto, they might be specified from the CLI options, so leave them optional except for the dataformCoreVersion which is required in compile.",
+    "properties": {
+        "dataformCoreVersion": {
+            "type": "string",
+            "description": "The desired dataform core version to compile against."
+        },
+        "defaultProject": {
+            "type": "string",
+            "description": "The default Google Cloud project (database)."
+        },
+        "defaultDataset": {
+            "type": "string",
+            "description": "The default dataset (schema)."
+        },
+        "defaultLocation": {
+            "type": "string",
+            "description": "The default BigQuery location to use."
+        },
+        "defaultAssertionDataset": {
+            "type": "string",
+            "description": "The default dataset (schema) for assertions."
+        },
+        "vars": {
+            "type": "object",
+            "description": "User-defined variables that are made available to project code during compilation. An object containing a list of key-value pairs.",
+            "additionalProperties": {
+                "type": "string"
+            }
+        },
+        "projectSuffix": {
+            "type": "string",
+            "description": "The suffix to append to all Google Cloud project references."
+        },
+        "datasetSuffix": {
+            "type": "string",
+            "description": "The suffix to append to all dataset references."
+        },
+        "namePrefix": {
+            "type": "string",
+            "description": "The prefix to append to all action names."
+        },
+        "defaultNotebookRuntimeOptions": {
+            "type": "object",
+            "description": "Default runtime options for Notebook actions.",
+            "outputBucket": {
+                "type": "string",
+                "description": "Storage bucket to output notebooks to after their execution."
+            }
+        }
+    },
+    "required": [
+        "dataformCoreVersion"
+    ]
+}


### PR DESCRIPTION
Add workflow_settings.yaml validation/completion VSCode extension.
This feature depends on 3rd party extension "redhat.vscode-yaml", so please reject this PR if you mind this point.
(I implemented the feature as optional, so the extension should work fine even without the redhat extension.)