### PR TITLE
Rethrow useful errors when reading workflow_settings.yaml

### DIFF
--- a/core/main_test.ts
+++ b/core/main_test.ts
@@ -412,12 +412,26 @@ quotes
       );
     });
 
-    test(`main fails when workflow_settings.yaml is an invalid yaml file`, () => {
+    test(`main fails when workflow_settings.yaml cannot be represented in JSON format`, () => {
       const projectDir = tmpDirFixture.createNewTmpDir();
       fs.writeFileSync(path.join(projectDir, "workflow_settings.yaml"), "&*19132sdS:asd:");
 
       expect(() => runMainInVm(coreExecutionRequestFromPath(projectDir))).to.throw(
         "workflow_settings.yaml is invalid"
+      );
+    });
+
+    test(`main fails when workflow settings fails to be parsed`, () => {
+      const projectDir = tmpDirFixture.createNewTmpDir();
+      fs.writeFileSync(
+        path.join(projectDir, "workflow_settings.yaml"),
+        `
+someKey: and an extra: colon
+`
+      );
+
+      expect(() => runMainInVm(coreExecutionRequestFromPath(projectDir))).to.throw(
+        "workflow_settings.yaml is not a valid YAML file: YAMLException: bad indentation"
       );
     });
 

--- a/core/workflow_settings.ts
+++ b/core/workflow_settings.ts
@@ -77,10 +77,12 @@ function maybeRequire(file: string): any {
     // tslint:disable-next-line: tsr-detect-non-literal-require
     return nativeRequire(file);
   } catch (e) {
-    if (e instanceof SyntaxError) {
-      throw e;
+    if (e instanceof Error) {
+      if (e.message.includes("Cannot find module")) {
+        return;
+      }
     }
-    return undefined;
+    throw e;
   }
 }
 


### PR DESCRIPTION
Previously `maybeRequire` would swallow this error, which meant the user would never see it.