### PR TITLE
feat: vscode extension, more intutive compile errors

### DIFF
--- a/vscode/server.ts
+++ b/vscode/server.ts
@@ -60,7 +60,7 @@ async function applySettings() {
 }
 
 async function compileAndValidate() {
-  let hasCompilationError = false;
+  let compilationFailed = false;
   const spawnedProcess = spawn(
     (process.platform !== "win32") ? "dataform" : "dataform.cmd",
     ["compile", "--json", ...settings.compilerOptions]
@@ -77,7 +77,7 @@ async function compileAndValidate() {
       );
       return;
     } else {
-      hasCompilationError = true;
+      compilationFailed = true;
     }
   }
 
@@ -98,7 +98,7 @@ async function compileAndValidate() {
     parsedResult.graphErrors.compilationErrors.forEach(compilationError => {
       connection.sendNotification("error", compilationError.fileName + ": " + compilationError.message);
     });
-    if (hasCompilationError) {
+    if (compilationFailed) {
        connection.sendNotification(
          "error",
          "Errors encountered when running 'dataform' CLI. Please check the output for more information."

--- a/vscode/server.ts
+++ b/vscode/server.ts
@@ -59,6 +59,7 @@ async function applySettings() {
 }
 
 async function compileAndValidate() {
+  let hasCompilationError = false;
   const spawnedProcess = spawn(
     (process.platform !== "win32") ? "dataform" : "dataform.cmd",
     ["compile", "--json", ...settings.compilerOptions]
@@ -75,11 +76,7 @@ async function compileAndValidate() {
       );
       return;
     } else {
-      connection.sendNotification(
-        "error",
-        "Errors encountered when running 'dataform' CLI. Please check the output for more information."
-      );
-      return;
+      hasCompilationError = true;
     }
   }
 
@@ -98,8 +95,15 @@ async function compileAndValidate() {
 
   if (parsedResult?.graphErrors?.compilationErrors) {
     parsedResult.graphErrors.compilationErrors.forEach(compilationError => {
-      connection.sendNotification("error", compilationError.message);
+      connection.sendNotification("error", compilationError.fileName + ": " + compilationError.message);
     });
+    if (hasCompilationError) {
+       connection.sendNotification(
+         "error",
+         "Errors encountered when running 'dataform' CLI. Please check the output for more information."
+       );
+       return;
+    }
   } else {
     connection.sendNotification("success", "Project compiled successfully");
   }


### PR DESCRIPTION
Currently the default behaviour for when a compilation error occurs is to show a generic information message. The PR uses the graphErrors object and outputs the errors to the user similar to GCP Dataform UI 

**Current behaviour**

![CleanShot 2024-07-02 at 20 21 58@2x](https://github.com/dataform-co/dataform/assets/34306898/5f2feaaa-62d2-4fcd-b55f-454dd31f75ad)



**New behaviour**


![CleanShot 2024-07-02 at 20 14 57@2x](https://github.com/dataform-co/dataform/assets/34306898/5cd61f79-9c40-467d-b5bc-1957f2e2fd88)
