### PR TITLE
fix(1776): dry run of assertions failing

### DIFF
--- a/cli/api/commands/run.ts
+++ b/cli/api/commands/run.ts
@@ -424,7 +424,7 @@ export class Runner {
       if (task.type === "assertion") {
         // We expect that an assertion query returns 1 row, with 1 field that is the row count.
         // We don't really care what that field/column is called.
-        const rowCount = rows[0][Object.keys(rows[0])[0]];
+        const rowCount = rows[0]?.[Object.keys(rows[0])[0]];
         if (rowCount > 0) {
           throw new Error(`Assertion failed: query returned ${rowCount} row(s).`);
         }


### PR DESCRIPTION
Fixes https://github.com/dataform-co/dataform/issues/1776

The dry of assertion currently fail due to the code expecting the dry run to return at least one row on [this line](https://github.com/dataform-co/dataform/blob/b3638a8134f51afdb7afed13d3786b0e2e0e98c9/cli/api/commands/run.ts#L427). 

**Tests**
1. Assertions passing by making the change in the MR. verified by running `./scripts/run run --dry-run <dataform_project_directory>`
2. Assertion when actually ran i.e. using `./scripts/run run ...` catches assertion errors 
3. `bazel test //core/...` passes 

**PS:**
This might not be the best solution, but happy to receive guidance