### PR TITLE
fix(1781): go to definition when `namePrefix` is specified in `workflow_settings.yaml`

### DIFF
--- a/vscode/server.ts
+++ b/vscode/server.ts
@@ -196,10 +196,14 @@ connection.onDefinition(
       return null;
     }
 
+    let tablePrefix = CACHED_COMPILE_GRAPH.projectConfig?.tablePrefix
+    let linkedTableNameWtPrefix = "";
+    linkedTableNameWtPrefix = (tablePrefix !== undefined) ? tablePrefix + "_" + linkedTable.name : linkedTable.name;
+
     const foundCompileAction = gatherAllActions().filter(action => (
       (linkedTable.database === null || action?.target?.database !== undefined && action.target.database === linkedTable.database)
       && (linkedTable.schema === null || action?.target?.schema !== undefined && action.target.schema === linkedTable.schema)
-      && action?.target?.name !== undefined && action.target.name === linkedTable.name
+      && action?.target?.name !== undefined && (action.target.name === linkedTable.name || action.target.name === linkedTableNameWtPrefix)
     ));
     if (foundCompileAction.length === 0) {
       connection.sendNotification("error", `Definition not found for ${clickedRef}`);


### PR DESCRIPTION
Solves https://github.com/dataform-co/dataform/issues/1781 

**Solution**
Dynamically determines the table prefix from the compiled query and modified the filter condition accordingly.

**Tests**
* Go to definition works in scenarios when table prefix is defined 
* Go to definition works in scenarios when table prefix is NOT defined 

