### PR TITLE
Fix notebook dependency targets

### DIFF
--- a/common/protos/index.ts
+++ b/common/protos/index.ts
@@ -35,7 +35,8 @@ export enum VerifyProtoErrorBehaviour {
 export function verifyObjectMatchesProto<Proto>(
   protoType: IProtoClass<any, Proto>,
   object: object,
-  errorBehaviour: VerifyProtoErrorBehaviour = VerifyProtoErrorBehaviour.DEFAULT
+  errorBehaviour: VerifyProtoErrorBehaviour = VerifyProtoErrorBehaviour.DEFAULT,
+  verbose = false
 ): Proto {
   if (Array.isArray(object)) {
     throw ReferenceError(`Expected a top-level object, but found an array`);
@@ -50,6 +51,11 @@ export function verifyObjectMatchesProto<Proto>(
     // strict subset of `present`.
     Object.entries(present).forEach(([presentKey, presentValue]) => {
       const desiredValue = desired[presentKey];
+      if (verbose) {
+        console.log("PRESENT KEY:", presentKey);
+        console.log("PRESENT VALUE:", presentValue);
+        console.log("DESIRED VALUE:", desiredValue);
+      }
       if (typeof desiredValue !== typeof presentValue) {
         if (Array.isArray(presentValue) && presentValue.length === 0) {
           // Empty arrays are assigned to empty proto array fields by ProtobufJS.

--- a/common/protos/index.ts
+++ b/common/protos/index.ts
@@ -35,8 +35,7 @@ export enum VerifyProtoErrorBehaviour {
 export function verifyObjectMatchesProto<Proto>(
   protoType: IProtoClass<any, Proto>,
   object: object,
-  errorBehaviour: VerifyProtoErrorBehaviour = VerifyProtoErrorBehaviour.DEFAULT,
-  verbose = false
+  errorBehaviour: VerifyProtoErrorBehaviour = VerifyProtoErrorBehaviour.DEFAULT
 ): Proto {
   if (Array.isArray(object)) {
     throw ReferenceError(`Expected a top-level object, but found an array`);
@@ -51,11 +50,6 @@ export function verifyObjectMatchesProto<Proto>(
     // strict subset of `present`.
     Object.entries(present).forEach(([presentKey, presentValue]) => {
       const desiredValue = desired[presentKey];
-      if (verbose) {
-        console.log("PRESENT KEY:", presentKey);
-        console.log("PRESENT VALUE:", presentValue);
-        console.log("DESIRED VALUE:", desiredValue);
-      }
       if (typeof desiredValue !== typeof presentValue) {
         if (Array.isArray(presentValue) && presentValue.length === 0) {
           // Empty arrays are assigned to empty proto array fields by ProtobufJS.

--- a/core/actions/assertion.ts
+++ b/core/actions/assertion.ts
@@ -5,6 +5,7 @@ import * as Path from "df/core/path";
 import { Session } from "df/core/session";
 import {
   actionConfigToCompiledGraphTarget,
+  configTargetToCompiledGraphTarget,
   nativeRequire,
   resolvableAsTarget,
   resolveActionsConfigFilename,
@@ -78,7 +79,7 @@ export class Assertion extends ActionBuilder<dataform.Assertion> {
     if (config.dependencyTargets) {
       this.dependencies(
         config.dependencyTargets.map(dependencyTarget =>
-          actionConfigToCompiledGraphTarget(dataform.ActionConfig.Target.create(dependencyTarget))
+          configTargetToCompiledGraphTarget(dataform.ActionConfig.Target.create(dependencyTarget))
         )
       );
     }

--- a/core/actions/data_preparation.ts
+++ b/core/actions/data_preparation.ts
@@ -6,6 +6,7 @@ import { Session } from "df/core/session";
 import {
   actionConfigToCompiledGraphTarget,
   addDependenciesToActionDependencyTargets,
+  configTargetToCompiledGraphTarget,
   nativeRequire,
   resolveActionsConfigFilename
 } from "df/core/utils";
@@ -55,7 +56,7 @@ export class DataPreparation extends ActionBuilder<dataform.DataPreparation> {
     if (config.dependencyTargets) {
       this.dependencies(
         config.dependencyTargets.map(dependencyTarget =>
-          actionConfigToCompiledGraphTarget(dataform.ActionConfig.Target.create(dependencyTarget))
+          configTargetToCompiledGraphTarget(dataform.ActionConfig.Target.create(dependencyTarget))
         )
       );
     }

--- a/core/actions/data_preparation.ts
+++ b/core/actions/data_preparation.ts
@@ -4,6 +4,7 @@ import { Resolvable } from "df/core/common";
 import * as Path from "df/core/path";
 import { Session } from "df/core/session";
 import {
+  actionConfigToCompiledGraphTarget,
   addDependenciesToActionDependencyTargets,
   nativeRequire,
   resolveActionsConfigFilename
@@ -37,14 +38,13 @@ export class DataPreparation extends ActionBuilder<dataform.DataPreparation> {
     this.proto.dataPreparation = dataPreparationDefinition;
 
     // Find targets
-    const targets = getTargets(dataPreparationDefinition)
-    this.proto.targets = targets.map((target) => this.applySessionToTarget(
-      target,
-      session.projectConfig,
-      config.filename,
-      true
-    ));
-    this.proto.canonicalTargets = targets.map((target) => this.applySessionToTarget(target, session.canonicalProjectConfig));
+    const targets = getTargets(dataPreparationDefinition);
+    this.proto.targets = targets.map(target =>
+      this.applySessionToTarget(target, session.projectConfig, config.filename, true)
+    );
+    this.proto.canonicalTargets = targets.map(target =>
+      this.applySessionToTarget(target, session.canonicalProjectConfig)
+    );
 
     // Set the unique target key as the first target defined.
     // TODO: Remove once multiple targets are supported.
@@ -52,7 +52,13 @@ export class DataPreparation extends ActionBuilder<dataform.DataPreparation> {
     this.proto.canonicalTarget = this.proto.canonicalTargets[0];
 
     this.proto.tags = config.tags;
-    this.dependencies(config.dependencyTargets);
+    if (config.dependencyTargets) {
+      this.dependencies(
+        config.dependencyTargets.map(dependencyTarget =>
+          actionConfigToCompiledGraphTarget(dataform.ActionConfig.Target.create(dependencyTarget))
+        )
+      );
+    }
     this.proto.fileName = config.filename;
     if (config.disabled) {
       this.proto.disabled = config.disabled;
@@ -72,7 +78,7 @@ export class DataPreparation extends ActionBuilder<dataform.DataPreparation> {
   public dependencies(value: Resolvable | Resolvable[]) {
     const newDependencies = Array.isArray(value) ? value : [value];
     newDependencies.forEach(resolvable =>
-        addDependenciesToActionDependencyTargets(this, resolvable)
+      addDependenciesToActionDependencyTargets(this, resolvable)
     );
     return this;
   }
@@ -101,17 +107,18 @@ export class DataPreparation extends ActionBuilder<dataform.DataPreparation> {
   }
 }
 
-function parseDataPreparationDefinitionJson(
-    dataPreparationAsJson: { [key: string]: unknown }): dataform.DataPreparationDefinition  {
+function parseDataPreparationDefinitionJson(dataPreparationAsJson: {
+  [key: string]: unknown;
+}): dataform.DataPreparationDefinition {
   try {
     return dataform.DataPreparationDefinition.create(
-        verifyObjectMatchesProto(
-            dataform.DataPreparationDefinition,
-            dataPreparationAsJson as {
-              [key: string]: any;
-            },
-            VerifyProtoErrorBehaviour.SHOW_DOCS_LINK
-        )
+      verifyObjectMatchesProto(
+        dataform.DataPreparationDefinition,
+        dataPreparationAsJson as {
+          [key: string]: any;
+        },
+        VerifyProtoErrorBehaviour.SHOW_DOCS_LINK
+      )
     );
   } catch (e) {
     if (e instanceof ReferenceError) {
@@ -121,9 +128,7 @@ function parseDataPreparationDefinitionJson(
   }
 }
 
-function getTargets(
-  definition: dataform.DataPreparationDefinition
-): dataform.Target[] {
+function getTargets(definition: dataform.DataPreparationDefinition): dataform.Target[] {
   const targets: dataform.Target[] = [];
 
   definition.nodes.forEach(node => {
@@ -131,10 +136,10 @@ function getTargets(
     if (table) {
       const compiledGraphTarget: dataform.ITarget = {
         database: table.project,
-        schema:table.dataset,
+        schema: table.dataset,
         name: table.table
       };
-      targets.push(dataform.Target.create(compiledGraphTarget))
+      targets.push(dataform.Target.create(compiledGraphTarget));
     }
   });
 

--- a/core/actions/incremental_table.ts
+++ b/core/actions/incremental_table.ts
@@ -104,7 +104,11 @@ export class IncrementalTable extends ActionBuilder<dataform.Table> {
       this.setDependOnDependencyAssertions(config.dependOnDependencyAssertions);
     }
     if (config.dependencyTargets) {
-      this.dependencies(config.dependencyTargets);
+      this.dependencies(
+        config.dependencyTargets.map(dependencyTarget =>
+          actionConfigToCompiledGraphTarget(dataform.ActionConfig.Target.create(dependencyTarget))
+        )
+      );
     }
     if (config.hermetic !== undefined) {
       this.hermetic(config.hermetic);

--- a/core/actions/incremental_table.ts
+++ b/core/actions/incremental_table.ts
@@ -9,6 +9,7 @@ import { Session } from "df/core/session";
 import {
   actionConfigToCompiledGraphTarget,
   addDependenciesToActionDependencyTargets,
+  configTargetToCompiledGraphTarget,
   nativeRequire,
   resolvableAsTarget,
   resolveActionsConfigFilename,
@@ -106,7 +107,7 @@ export class IncrementalTable extends ActionBuilder<dataform.Table> {
     if (config.dependencyTargets) {
       this.dependencies(
         config.dependencyTargets.map(dependencyTarget =>
-          actionConfigToCompiledGraphTarget(dataform.ActionConfig.Target.create(dependencyTarget))
+          configTargetToCompiledGraphTarget(dataform.ActionConfig.Target.create(dependencyTarget))
         )
       );
     }

--- a/core/actions/notebook.ts
+++ b/core/actions/notebook.ts
@@ -102,16 +102,11 @@ export class Notebook extends ActionBuilder<dataform.Notebook> {
   }
 
   public compile() {
-    console.log("NOTEBOOK OBJECT:");
-    console.log(JSON.stringify(this.proto));
-    const tmp = verifyObjectMatchesProto(
+    return verifyObjectMatchesProto(
       dataform.Notebook,
       this.proto,
-      VerifyProtoErrorBehaviour.SUGGEST_REPORTING_TO_DATAFORM_TEAM,
-      true
+      VerifyProtoErrorBehaviour.SUGGEST_REPORTING_TO_DATAFORM_TEAM
     );
-    console.log("NOTEBOOK COMPILED GRAPH VERIFY COMPLETE");
-    return tmp;
   }
 }
 

--- a/core/actions/notebook.ts
+++ b/core/actions/notebook.ts
@@ -6,6 +6,7 @@ import { Session } from "df/core/session";
 import {
   actionConfigToCompiledGraphTarget,
   addDependenciesToActionDependencyTargets,
+  configTargetToCompiledGraphTarget,
   nativeRequire,
   resolveActionsConfigFilename
 } from "df/core/utils";
@@ -49,7 +50,7 @@ export class Notebook extends ActionBuilder<dataform.Notebook> {
     if (config.dependencyTargets) {
       this.dependencies(
         config.dependencyTargets.map(dependencyTarget =>
-          actionConfigToCompiledGraphTarget(dataform.ActionConfig.Target.create(dependencyTarget))
+          configTargetToCompiledGraphTarget(dataform.ActionConfig.Target.create(dependencyTarget))
         )
       );
     }

--- a/core/actions/notebook.ts
+++ b/core/actions/notebook.ts
@@ -46,7 +46,13 @@ export class Notebook extends ActionBuilder<dataform.Notebook> {
     this.proto.canonicalTarget = this.applySessionToTarget(target, session.canonicalProjectConfig);
     this.proto.tags = config.tags;
     this.dependOnDependencyAssertions = config.dependOnDependencyAssertions;
-    this.dependencies(config.dependencyTargets);
+    if (config.dependencyTargets) {
+      this.dependencies(
+        config.dependencyTargets.map(dependencyTarget =>
+          actionConfigToCompiledGraphTarget(dataform.ActionConfig.Target.create(dependencyTarget))
+        )
+      );
+    }
     this.proto.fileName = config.filename;
     if (config.disabled) {
       this.proto.disabled = config.disabled;
@@ -96,11 +102,16 @@ export class Notebook extends ActionBuilder<dataform.Notebook> {
   }
 
   public compile() {
-    return verifyObjectMatchesProto(
+    console.log("NOTEBOOK OBJECT:");
+    console.log(JSON.stringify(this.proto));
+    const tmp = verifyObjectMatchesProto(
       dataform.Notebook,
       this.proto,
-      VerifyProtoErrorBehaviour.SUGGEST_REPORTING_TO_DATAFORM_TEAM
+      VerifyProtoErrorBehaviour.SUGGEST_REPORTING_TO_DATAFORM_TEAM,
+      true
     );
+    console.log("NOTEBOOK COMPILED GRAPH VERIFY COMPLETE");
+    return tmp;
   }
 }
 

--- a/core/actions/operation.ts
+++ b/core/actions/operation.ts
@@ -7,6 +7,7 @@ import { Session } from "df/core/session";
 import {
   actionConfigToCompiledGraphTarget,
   addDependenciesToActionDependencyTargets,
+  configTargetToCompiledGraphTarget,
   nativeRequire,
   resolvableAsTarget,
   resolveActionsConfigFilename,
@@ -77,7 +78,7 @@ export class Operation extends ActionBuilder<dataform.Operation> {
     if (config.dependencyTargets) {
       this.dependencies(
         config.dependencyTargets.map(dependencyTarget =>
-          actionConfigToCompiledGraphTarget(dataform.ActionConfig.Target.create(dependencyTarget))
+          configTargetToCompiledGraphTarget(dataform.ActionConfig.Target.create(dependencyTarget))
         )
       );
     }

--- a/core/actions/table.ts
+++ b/core/actions/table.ts
@@ -19,6 +19,7 @@ import {
   actionConfigToCompiledGraphTarget,
   addDependenciesToActionDependencyTargets,
   checkExcessProperties,
+  configTargetToCompiledGraphTarget,
   nativeRequire,
   resolvableAsTarget,
   resolveActionsConfigFilename,
@@ -345,7 +346,7 @@ export class Table extends ActionBuilder<dataform.Table> {
       this.config({
         type: "table",
         dependencies: config.dependencyTargets.map(dependencyTarget =>
-          actionConfigToCompiledGraphTarget(dataform.ActionConfig.Target.create(dependencyTarget))
+          configTargetToCompiledGraphTarget(dataform.ActionConfig.Target.create(dependencyTarget))
         ),
         tags: config.tags,
         disabled: config.disabled,
@@ -377,7 +378,7 @@ export class Table extends ActionBuilder<dataform.Table> {
       this.config({
         type: "view",
         dependencies: config.dependencyTargets.map(dependencyTarget =>
-          actionConfigToCompiledGraphTarget(dataform.ActionConfig.Target.create(dependencyTarget))
+          configTargetToCompiledGraphTarget(dataform.ActionConfig.Target.create(dependencyTarget))
         ),
         disabled: config.disabled,
         materialized: config.materialized,
@@ -431,7 +432,7 @@ export class Table extends ActionBuilder<dataform.Table> {
       this.config({
         type: "incremental",
         dependencies: config.dependencyTargets.map(dependencyTarget =>
-          actionConfigToCompiledGraphTarget(dataform.ActionConfig.Target.create(dependencyTarget))
+          configTargetToCompiledGraphTarget(dataform.ActionConfig.Target.create(dependencyTarget))
         ),
         disabled: config.disabled,
         protected: config.protected,

--- a/core/actions/view.ts
+++ b/core/actions/view.ts
@@ -96,7 +96,11 @@ export class View extends ActionBuilder<dataform.Table> {
       this.setDependOnDependencyAssertions(config.dependOnDependencyAssertions);
     }
     if (config.dependencyTargets) {
-      this.dependencies(config.dependencyTargets);
+      this.dependencies(
+        config.dependencyTargets.map(dependencyTarget =>
+          actionConfigToCompiledGraphTarget(dataform.ActionConfig.Target.create(dependencyTarget))
+        )
+      );
     }
     if (config.hermetic !== undefined) {
       this.hermetic(config.hermetic);

--- a/core/actions/view.ts
+++ b/core/actions/view.ts
@@ -9,6 +9,7 @@ import { Session } from "df/core/session";
 import {
   actionConfigToCompiledGraphTarget,
   addDependenciesToActionDependencyTargets,
+  configTargetToCompiledGraphTarget,
   nativeRequire,
   resolvableAsTarget,
   resolveActionsConfigFilename,
@@ -98,7 +99,7 @@ export class View extends ActionBuilder<dataform.Table> {
     if (config.dependencyTargets) {
       this.dependencies(
         config.dependencyTargets.map(dependencyTarget =>
-          actionConfigToCompiledGraphTarget(dataform.ActionConfig.Target.create(dependencyTarget))
+          configTargetToCompiledGraphTarget(dataform.ActionConfig.Target.create(dependencyTarget))
         )
       );
     }

--- a/core/main_test.ts
+++ b/core/main_test.ts
@@ -860,14 +860,14 @@ defaultNotebookRuntimeOptions:
 
   suite("data preparations", () => {
     const createSimpleDataPreparationProject = (
-        workflowSettingsYaml = VALID_WORKFLOW_SETTINGS_YAML
+      workflowSettingsYaml = VALID_WORKFLOW_SETTINGS_YAML
     ): string => {
       const projectDir = tmpDirFixture.createNewTmpDir();
       fs.writeFileSync(path.join(projectDir, "workflow_settings.yaml"), workflowSettingsYaml);
       fs.mkdirSync(path.join(projectDir, "definitions"));
       fs.writeFileSync(
-          path.join(projectDir, "definitions/actions.yaml"),
-          `
+        path.join(projectDir, "definitions/actions.yaml"),
+        `
 actions:
 - dataPreparation:
     filename: data_preparation.yaml`
@@ -878,8 +878,8 @@ actions:
     test(`data preparations can be loaded via an actions config file`, () => {
       const projectDir = createSimpleDataPreparationProject();
       fs.writeFileSync(
-          path.join(projectDir, "definitions/data_preparation.yaml"),
-          `
+        path.join(projectDir, "definitions/data_preparation.yaml"),
+        `
 nodes:
 - id: node1
   source:
@@ -918,54 +918,75 @@ nodes:
 
       expect(result.compile.compiledGraph.graphErrors.compilationErrors).deep.equals([]);
       expect(asPlainObject(result.compile.compiledGraph.dataPreparations)).deep.equals(
-          asPlainObject([
-            {
-              target: {
+        asPlainObject([
+          {
+            target: {
+              database: "prj",
+              schema: "ds",
+              name: "dest"
+            },
+            canonicalTarget: {
+              database: "prj",
+              schema: "ds",
+              name: "dest"
+            },
+            targets: [
+              {
                 database: "prj",
                 schema: "ds",
                 name: "dest"
-              },
-              canonicalTarget: {
+              }
+            ],
+            canonicalTargets: [
+              {
                 database: "prj",
                 schema: "ds",
                 name: "dest"
-              },
-              targets: [
+              }
+            ],
+            fileName: "definitions/data_preparation.yaml",
+            dataPreparation: {
+              nodes: [
                 {
-                  database: "prj",
-                  schema: "ds",
-                  name: "dest"
-                }
-              ],
-              canonicalTargets: [
-                {
-                  database: "prj",
-                  schema: "ds",
-                  name: "dest"
-                }
-              ],
-              fileName: "definitions/data_preparation.yaml",
-              dataPreparation: {
-                nodes: [
-                  {
-                    id: "node1",
-                    source: {
-                      table: {
-                        dataset: "ds",
-                        project: "prj",
-                        table: "src"
+                  id: "node1",
+                  source: {
+                    table: {
+                      dataset: "ds",
+                      project: "prj",
+                      table: "src"
+                    }
+                  },
+                  destination: {
+                    table: {
+                      dataset: "ds",
+                      project: "prj",
+                      table: "dest"
+                    }
+                  },
+                  generated: {
+                    destinationGenerated: {
+                      schema: {
+                        field: [
+                          {
+                            mode: "NULLABLE",
+                            name: "a",
+                            type: "STRING"
+                          }
+                        ]
                       }
                     },
-                    destination: {
-                      table: {
-                        dataset: "ds",
-                        project: "prj",
-                        table: "dest"
-                      }
+                    outputSchema: {
+                      field: [
+                        {
+                          mode: "NULLABLE",
+                          name: "a",
+                          type: "INT64"
+                        }
+                      ]
                     },
-                    generated: {
-                      destinationGenerated: {
-                        schema: {
+                    sourceGenerated: {
+                      sourceSchema: {
+                        tableSchema: {
                           field: [
                             {
                               mode: "NULLABLE",
@@ -974,35 +995,14 @@ nodes:
                             }
                           ]
                         }
-                      },
-                      outputSchema: {
-                        field: [
-                          {
-                            mode: "NULLABLE",
-                            name: "a",
-                            type: "INT64"
-                          }
-                        ]
-                      },
-                      sourceGenerated: {
-                        sourceSchema: {
-                          tableSchema: {
-                            field: [
-                              {
-                                mode: "NULLABLE",
-                                name: "a",
-                                type: "STRING"
-                              }
-                            ]
-                          }
-                        }
                       }
                     }
                   }
-                ]
-              }
+                }
+              ]
             }
-          ])
+          }
+        ])
       );
     });
   });
@@ -1448,22 +1448,32 @@ actions:
     filename: table.sql
     dependencyTargets:
     - name: declaration
+      dataset: defaultDataset
+      project: defaultProject
 - incrementalTable:
     filename: incrementalTable.sql
     dependencyTargets:
     - name: table
+      dataset: defaultDataset
+      project: defaultProject
 - view:
     filename: view.sql
     dependencyTargets:
     - name: incrementalTable
+      dataset: defaultDataset
+      project: defaultProject
 - operation:
     filename: operation.sql
     dependencyTargets:
     - name: view
+      dataset: defaultDataset
+      project: defaultProject
 - notebook:
     filename: notebook.ipynb
     dependencyTargets:
-    - name: view`
+    - name: view
+      dataset: defaultDataset
+      project: defaultProject`
       );
       ["table.sql", "incrementalTable.sql", "view.sql", "operation.sql"].forEach(filename => {
         fs.writeFileSync(path.join(projectDir, `definitions/${filename}`), "SELECT 1");
@@ -1478,30 +1488,43 @@ actions:
       expect(result.compile.compiledGraph.graphErrors.compilationErrors).deep.equals([]);
     });
 
-    test(`files can be loaded from the root directory and are normalized in the compiled graph`, () => {
+    test(`dependency targets of actions with different types are loaded`, () => {
       const projectDir = tmpDirFixture.createNewTmpDir();
       fs.writeFileSync(
         path.join(projectDir, "workflow_settings.yaml"),
         VALID_WORKFLOW_SETTINGS_YAML
       );
       fs.mkdirSync(path.join(projectDir, "definitions"));
+      // The dependency target for depending on a notebook currently hacks around the limitations of
+      // the target proto, until proper target support for notebooks is added.
       fs.writeFileSync(
         path.join(projectDir, "definitions/actions.yaml"),
         `
 actions:
 - notebook:
-    filename: ../contents.ipynb
+    name: notebook1
+    location: location
+    project: project
+    filename: notebook.ipynb
 - operation:
-    filename: ../table.sql`
+    name: operation1
+    dataset: dataset
+    project: project
+    dependencyTargets:
+    - name: notebook1
+      dataset: dataset
+      project: project
+    filename: operation.sql`
       );
-      fs.writeFileSync(path.join(projectDir, `contents.ipynb`), JSON.stringify({ cells: [] }));
-      fs.writeFileSync(path.join(projectDir, `table.sql`), "SELECT 1");
+      fs.writeFileSync(path.join(projectDir, "definitions/operation.sql"), "SELECT 1");
+      fs.writeFileSync(
+        path.join(projectDir, `definitions/notebook.ipynb`),
+        EMPTY_NOTEBOOK_CONTENTS
+      );
 
       const result = runMainInVm(coreExecutionRequestFromPath(projectDir));
 
       expect(result.compile.compiledGraph.graphErrors.compilationErrors).deep.equals([]);
-      expect(result.compile.compiledGraph.notebooks[0].fileName).deep.equals("contents.ipynb");
-      expect(result.compile.compiledGraph.operations[0].fileName).deep.equals("table.sql");
     });
   });
 

--- a/core/main_test.ts
+++ b/core/main_test.ts
@@ -1482,15 +1482,6 @@ actions:
         path.join(projectDir, `definitions/notebook.ipynb`),
         EMPTY_NOTEBOOK_CONTENTS
       );
-      fs.writeFileSync(
-        path.join(projectDir, `definitions/data_preparation.yaml`),
-        `
-nodes:
-- id: node1
-  source:
-    table:
-      project: prj`
-      );
 
       const result = runMainInVm(coreExecutionRequestFromPath(projectDir));
 

--- a/core/main_test.ts
+++ b/core/main_test.ts
@@ -1473,14 +1473,7 @@ actions:
     dependencyTargets:
     - name: view
       dataset: defaultDataset
-      project: defaultProject
-- dataPreparation:
-    filename: data_preparation.yaml
-    dependencyTargets:
-    - name: view
-      dataset: defaultDataset
-      project: defaultProject
-      `
+      project: defaultProject`
       );
       ["table.sql", "incrementalTable.sql", "view.sql", "operation.sql"].forEach(filename => {
         fs.writeFileSync(path.join(projectDir, `definitions/${filename}`), "SELECT 1");
@@ -1489,7 +1482,15 @@ actions:
         path.join(projectDir, `definitions/notebook.ipynb`),
         EMPTY_NOTEBOOK_CONTENTS
       );
-      fs.writeFileSync(path.join(projectDir, `definitions/data_preparation.yaml`), "");
+      fs.writeFileSync(
+        path.join(projectDir, `definitions/data_preparation.yaml`),
+        `
+nodes:
+- id: node1
+  source:
+    table:
+      project: prj`
+      );
 
       const result = runMainInVm(coreExecutionRequestFromPath(projectDir));
 

--- a/core/main_test.ts
+++ b/core/main_test.ts
@@ -1473,7 +1473,14 @@ actions:
     dependencyTargets:
     - name: view
       dataset: defaultDataset
-      project: defaultProject`
+      project: defaultProject
+- dataPreparation:
+    filename: data_preparation.yaml
+    dependencyTargets:
+    - name: view
+      dataset: defaultDataset
+      project: defaultProject
+      `
       );
       ["table.sql", "incrementalTable.sql", "view.sql", "operation.sql"].forEach(filename => {
         fs.writeFileSync(path.join(projectDir, `definitions/${filename}`), "SELECT 1");
@@ -1482,6 +1489,7 @@ actions:
         path.join(projectDir, `definitions/notebook.ipynb`),
         EMPTY_NOTEBOOK_CONTENTS
       );
+      fs.writeFileSync(path.join(projectDir, `definitions/data_preparation.yaml`), "");
 
       const result = runMainInVm(coreExecutionRequestFromPath(projectDir));
 
@@ -1512,7 +1520,7 @@ actions:
     project: project
     dependencyTargets:
     - name: notebook1
-      dataset: dataset
+      dataset: location
       project: project
     filename: operation.sql`
       );

--- a/core/session.ts
+++ b/core/session.ts
@@ -372,7 +372,9 @@ export class Session {
       ),
       tests: this.compileGraphChunk(Object.values(this.tests)),
       notebooks: this.compileGraphChunk(this.actions.filter(action => action instanceof Notebook)),
-      dataPreparations: this.compileGraphChunk(this.actions.filter(action => action instanceof DataPreparation)),
+      dataPreparations: this.compileGraphChunk(
+        this.actions.filter(action => action instanceof DataPreparation)
+      ),
       graphErrors: this.graphErrors,
       dataformCoreVersion,
       targets: this.actions.map(action => action.proto.target)

--- a/core/utils.ts
+++ b/core/utils.ts
@@ -328,15 +328,15 @@ export function actionConfigToCompiledGraphTarget(
     | dataform.ActionConfig.DataPreparationConfig
 ): dataform.Target {
   const compiledGraphTarget: dataform.ITarget = { name: actionConfig.name };
-  if ("project" in actionConfig && actionConfig.project != undefined) {
+  if ("project" in actionConfig && actionConfig.project !== undefined) {
     compiledGraphTarget.database = actionConfig.project;
   }
-  if ("location" in actionConfig && actionConfig.location != undefined) {
+  if ("location" in actionConfig && actionConfig.location !== undefined) {
     // This is a hack around the limitations of the compiled graph's target proto not having a
     // "location" field.
     compiledGraphTarget.schema = actionConfig.location;
   }
-  if ("dataset" in actionConfig && actionConfig.dataset != undefined) {
+  if ("dataset" in actionConfig && actionConfig.dataset !== undefined) {
     compiledGraphTarget.schema = actionConfig.dataset;
   }
   return dataform.Target.create(compiledGraphTarget);

--- a/core/utils.ts
+++ b/core/utils.ts
@@ -299,11 +299,25 @@ export function extractActionDetailsFromFileName(
   return { fileExtension, fileNameAsTargetName: basename };
 }
 
+// Converts the config proto's target proto to the compiled graph proto's representation.
+export function configTargetToCompiledGraphTarget(configTarget: dataform.ActionConfig.Target) {
+  const compiledGraphTarget: dataform.ITarget = { name: configTarget.name };
+  if (configTarget.project) {
+    compiledGraphTarget.database = configTarget.project;
+  }
+  if (configTarget.dataset) {
+    compiledGraphTarget.schema = configTarget.dataset;
+  }
+  if (configTarget.hasOwnProperty("includeDependentAssertions")) {
+    compiledGraphTarget.includeDependentAssertions = configTarget.includeDependentAssertions;
+  }
+  return dataform.Target.create(compiledGraphTarget);
+}
+
+// Converts a config proto's action config proto to the compiled graph proto's representation.
+// Action config protos roughly contain target protos fields.
 export function actionConfigToCompiledGraphTarget(
-  // Action configs contain all the fields of action config targets, even if they are not strictly
-  // target objects, so they are included in this conversion.
-  actionConfigTarget:
-    | dataform.ActionConfig.Target
+  actionConfig:
     | dataform.ActionConfig.TableConfig
     | dataform.ActionConfig.ViewConfig
     | dataform.ActionConfig.IncrementalTableConfig
@@ -313,23 +327,17 @@ export function actionConfigToCompiledGraphTarget(
     | dataform.ActionConfig.NotebookConfig
     | dataform.ActionConfig.DataPreparationConfig
 ): dataform.Target {
-  const compiledGraphTarget: dataform.ITarget = { name: actionConfigTarget.name };
-  if ("project" in actionConfigTarget && actionConfigTarget.project != undefined) {
-    compiledGraphTarget.database = actionConfigTarget.project;
+  const compiledGraphTarget: dataform.ITarget = { name: actionConfig.name };
+  if ("project" in actionConfig && actionConfig.project != undefined) {
+    compiledGraphTarget.database = actionConfig.project;
   }
-  if ("location" in actionConfigTarget && actionConfigTarget.location != undefined) {
+  if ("location" in actionConfig && actionConfig.location != undefined) {
     // This is a hack around the limitations of the compiled graph's target proto not having a
     // "location" field.
-    compiledGraphTarget.schema = actionConfigTarget.location;
+    compiledGraphTarget.schema = actionConfig.location;
   }
-  if ("dataset" in actionConfigTarget && actionConfigTarget.dataset != undefined) {
-    compiledGraphTarget.schema = actionConfigTarget.dataset;
-  }
-  if (
-    "includeDependentAssertions" in actionConfigTarget &&
-    actionConfigTarget.includeDependentAssertions != undefined
-  ) {
-    compiledGraphTarget.includeDependentAssertions = actionConfigTarget.includeDependentAssertions;
+  if ("dataset" in actionConfig && actionConfig.dataset != undefined) {
+    compiledGraphTarget.schema = actionConfig.dataset;
   }
   return dataform.Target.create(compiledGraphTarget);
 }

--- a/version.bzl
+++ b/version.bzl
@@ -1,3 +1,3 @@
 # NOTE: If you change the format of this line, you must change the bash command
 # in /scripts/publish to extract the version string correctly.
-DF_VERSION = "3.0.0"
+DF_VERSION = "3.0.1"


### PR DESCRIPTION
Some fixes are:
* Notebooks can properly be dependency targets of other targets, by hacking from "location" to "dataset" fields.
* Notebooks, views and incremental tables now correctly convert dependency targets to compiled graph targets.
* Better type safeness by extracting configs proto target conversion and action configs proto conversion to separate functions.