### PR TITLE
fix(1805): dry run fails when table/view/assertion already does not exists

### DIFF
--- a/cli/api/commands/run.ts
+++ b/cli/api/commands/run.ts
@@ -365,6 +365,7 @@ export class Runner {
       // (i.e. it must still be RUNNING, and not FAILED).
       actionResult.status === dataform.ActionResult.ExecutionStatus.RUNNING &&
       !(this.graph.runConfig && this.graph.runConfig.disableSetMetadata) &&
+      !(this.executionOptions?.bigquery?.dryRun) &&
       action.type === "table"
     ) {
       try {

--- a/cli/api/dbadapters/execution_sql.ts
+++ b/cli/api/dbadapters/execution_sql.ts
@@ -47,10 +47,10 @@ export class ExecutionSql {
   }
 
   public insertInto(target: dataform.ITarget, columns: string[], query: string) {
-    return `	
-insert into ${this.resolveTarget(target)}	
-(${columns.join(",")})	
-select ${columns.join(",")}	
+    return `
+insert into ${this.resolveTarget(target)}
+(${columns.join(",")})
+select ${columns.join(",")}
 from (${query}) as insertions`;
   }
 
@@ -174,7 +174,6 @@ from (${query}) as insertions`;
     const tasks = new Tasks();
     const target = assertion.target;
     tasks.add(Task.statement(this.createOrReplaceView(target, assertion.query)));
-    tasks.add(Task.assertion(`select sum(1) as row_count from ${this.resolveTarget(target)}`));
     return tasks;
   }
 


### PR DESCRIPTION
Solves https://github.com/dataform-co/dataform/issues/1805

1. **Tables/views:** For a view / table the metadata need not be set when doing a dry run only query validation is sufficient as metadata cannot be set if the object is not yet being materialised in BigQuery 
2. **Assertions**: No need to do `select sum(1) ...` on the view that will be created by the assertion. The query validation is sufficient to establish if the query that will be created is valid.

**Tests**

1. Dry run on assertions pass if the query is correct 
2. Dry run on assertion correctly fails if the query is not valid
3. Dry run on table/view passes if the query is valid 
4. Dry run on table/view correctly fails if the query is not valid 
5. `bazel test //core/...` passes 
