### PR TITLE
Update unit test's result messages

### DIFF
--- a/cli/api/commands/test.ts
+++ b/cli/api/commands/test.ts
@@ -83,6 +83,15 @@ async function runTest(
       const normalizedColumn = normalizeColumnName(column);
       const expectedValue = expectedResultRow[normalizedColumn];
       const actualValue = actualResultRow[normalizedColumn];
+      // Check if exactly one of the expected or actual values is null (XOR condition)
+      if ((expectedValue === null) !== (actualValue === null)) {
+        const expectedText = expectedValue === null ? 'null' : `"${expectedValue}"`;
+        const actualText = actualValue === null ? 'null' : `"${actualValue}"`;
+        rowMessages.push(
+          `For row ${i} and column "${column}": expected ${expectedText}, but saw ${actualText}.`
+        );
+        break;
+      }
       if (typeof expectedValue !== typeof actualValue) {
         rowMessages.push(
           `For row ${i} and column "${column}": expected type "${typeof expectedValue}", but saw type "${typeof actualValue}".`

--- a/cli/api/commands/test.ts
+++ b/cli/api/commands/test.ts
@@ -83,12 +83,16 @@ async function runTest(
       const normalizedColumn = normalizeColumnName(column);
       const expectedValue = expectedResultRow[normalizedColumn];
       const actualValue = actualResultRow[normalizedColumn];
-      // Check if exactly one of the expected or actual values is null (XOR condition)
-      if ((expectedValue === null) !== (actualValue === null)) {
-        const expectedText = expectedValue === null ? 'null' : `"${expectedValue}"`;
-        const actualText = actualValue === null ? 'null' : `"${actualValue}"`;
+      // Null value check
+      if (expectedValue === null && actualValue !== null) {
         rowMessages.push(
-          `For row ${i} and column "${column}": expected ${expectedText}, but saw ${actualText}.`
+          `For row ${i} and column "${column}": expected null, but saw "${actualValue}".`
+        );
+        break;
+      }
+      if (expectedValue !== null && actualValue === null) {
+        rowMessages.push(
+          `For row ${i} and column "${column}": expected "${expectedValue}", but saw null.`
         );
         break;
       }


### PR DESCRIPTION
This PR is linked to the following issue:

close #1791 

## Current
Prepare the following table and its corresponding unit test.

Test table:
```sql
config {
    type: "table",
    schema: "hoge",
    name: "fuga"
}

select
  user_id
from
  ${ref("users")}
```

Test code:
```sql
config {
  type: "test",
  dataset: "fuga",
}

select 1 as user_id union all
select cast(null as int64) as user_id

input "users" {
  select 1 as user_id union all
  select 2 as user_id
}
```

Given that the expected block includes cast(null as int64), it would be more user-friendly to have the output display as follows:

```shell
For row 1 and column "user_id": expected null, but saw "2"
```

However, the current output is as follows, which can cause confusion for the user:

```shell
For row 1 and column "user_id": expected type "object", but saw type "number".
```

## Before Committing
- Conducted unit testing
- Checked the behavior of dataform cli
