### PR TITLE
fix: vscode extension crash on windows due to *.cmd spawn

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,9 +72,12 @@
     "url": "^0.11.0",
     "vm2": "3.9.19",
     "vsce": "^1.79.5",
+    "vscode-jsonrpc": "^5.0.1",
     "vscode-languageclient": "^6.1.3",
     "vscode-languageserver": "^6.1.1",
+    "vscode-languageserver-protocol": "^3.15.3",
     "vscode-languageserver-textdocument": "^1.0.1",
+    "vscode-languageserver-types": "3.15.1",
     "webpack": "^4.20.0",
     "webpack-cli": "^3.3.10",
     "yargs": "^16.2.0"

--- a/vscode/extension.ts
+++ b/vscode/extension.ts
@@ -47,13 +47,13 @@ export async function activate(context: vscode.ExtensionContext) {
 
   // wait for client to be ready before setting up notification handlers
   await client.onReady();
-  client.onNotification("error", errorMessage => {
+  client.onNotification("error", (errorMessage: string) => {
     vscode.window.showErrorMessage(errorMessage);
   });
-  client.onNotification("info", message => {
+  client.onNotification("info", (message: string) => {
     vscode.window.showInformationMessage(message);
   });
-  client.onNotification("success", message => {
+  client.onNotification("success", (message: string) => {
     vscode.window.showInformationMessage(message);
   });
 

--- a/vscode/server.ts
+++ b/vscode/server.ts
@@ -64,11 +64,11 @@ async function applySettings() {
 
 async function compileAndValidate() {
   let compilationFailed = false;
-  const spawnedProcess = spawn(process.platform !== "win32" ? "dataform" : "dataform.cmd", [
+  const spawnedProcess = spawn("dataform", [
     "compile",
     "--json",
-    ...settings.compilerOptions
-  ]);
+    ...settings.compilerOptions,
+  ], {shell: true});
 
   const compileResult = await getProcessResult(spawnedProcess);
   if (compileResult.exitCode !== 0) {


### PR DESCRIPTION
Fix #1813

I fixed some other lines since those lines caused build error.
I belive nothing has been changed from the last release, so I'm not sure why this happened.
I also needed to add some lines on package.json in the root folder.
If you want to revert those changes, please let me know.