### PR TITLE
Revert "fix(1805): dry run fails when table/view/assertion already does not exists"

### DIFF
--- a/cli/api/commands/run.ts
+++ b/cli/api/commands/run.ts
@@ -365,7 +365,6 @@ export class Runner {
       // (i.e. it must still be RUNNING, and not FAILED).
       actionResult.status === dataform.ActionResult.ExecutionStatus.RUNNING &&
       !(this.graph.runConfig && this.graph.runConfig.disableSetMetadata) &&
-      !(this.executionOptions?.bigquery?.dryRun) &&
       action.type === "table"
     ) {
       try {

--- a/cli/api/dbadapters/execution_sql.ts
+++ b/cli/api/dbadapters/execution_sql.ts
@@ -47,10 +47,10 @@ export class ExecutionSql {
   }
 
   public insertInto(target: dataform.ITarget, columns: string[], query: string) {
-    return `
-insert into ${this.resolveTarget(target)}
-(${columns.join(",")})
-select ${columns.join(",")}
+    return `	
+insert into ${this.resolveTarget(target)}	
+(${columns.join(",")})	
+select ${columns.join(",")}	
 from (${query}) as insertions`;
   }
 
@@ -174,6 +174,7 @@ from (${query}) as insertions`;
     const tasks = new Tasks();
     const target = assertion.target;
     tasks.add(Task.statement(this.createOrReplaceView(target, assertion.query)));
+    tasks.add(Task.assertion(`select sum(1) as row_count from ${this.resolveTarget(target)}`));
     return tasks;
   }
 


### PR DESCRIPTION
Reverts dataform-co/dataform#1806

This causes `//tests/integration:bigquery.spec`, instead we need `dryRun` should be passed to `assertTasks`, and only skip `select sum(1)` then