### PR TITLE
Fix `uniqueKey` assertions for views, incremental tables

### DIFF
--- a/core/actions/incremental_table.ts
+++ b/core/actions/incremental_table.ts
@@ -308,7 +308,7 @@ export class IncrementalTable extends ActionBuilder<dataform.Table> {
     if (!!assertions.uniqueKey?.length) {
       uniqueKeys = [
         dataform.ActionConfig.TableAssertionsConfig.UniqueKey.create({
-          uniqueKey: ["TableAssertionsConfig"]
+          uniqueKey: assertions.uniqueKey
         })
       ];
     }

--- a/core/actions/view.ts
+++ b/core/actions/view.ts
@@ -271,7 +271,7 @@ export class View extends ActionBuilder<dataform.Table> {
     if (!!assertions.uniqueKey?.length) {
       uniqueKeys = [
         dataform.ActionConfig.TableAssertionsConfig.UniqueKey.create({
-          uniqueKey: ["TableAssertionsConfig"]
+          uniqueKey: assertions.uniqueKey
         })
       ];
     }

--- a/core/main_test.ts
+++ b/core/main_test.ts
@@ -1690,11 +1690,15 @@ actions:
     };
 
     const exampleBuiltInAssertions = {
-      inputSqlxConfigBlock: `
+      inputSqlxConfigBlock1: `
   assertions: {
     uniqueKeys: [["uniqueKey1", "uniqueKey2"]],
     nonNull: "nonNull",
     rowConditions: ["rowConditions1", "rowConditions2"],
+  },`,
+      inputSqlxConfigBlock2: `
+  assertions: {
+    uniqueKey: ["uniqueKey1"],
   },`,
       outputAssertions: [
         {
@@ -1753,6 +1757,35 @@ actions:
           },
           query:
             "\nSELECT\n  'rowConditions1' AS failing_row_condition,\n  *\nFROM `project.dataset.name`\nWHERE NOT (rowConditions1)\nUNION ALL\nSELECT\n  'rowConditions2' AS failing_row_condition,\n  *\nFROM `project.dataset.name`\nWHERE NOT (rowConditions2)\nUNION ALL\nSELECT\n  'nonNull IS NOT NULL' AS failing_row_condition,\n  *\nFROM `project.dataset.name`\nWHERE NOT (nonNull IS NOT NULL)\n",
+          tags: ["tag1", "tag2"]
+        },
+        {
+          target: {
+            database: "defaultProject",
+            schema: "defaultDataset",
+            name: "dataset_name2_assertions_uniqueKey_0"
+          },
+          canonicalTarget: {
+            database: "defaultProject",
+            schema: "defaultDataset",
+            name: "dataset_name2_assertions_uniqueKey_0"
+          },
+          dependencyTargets: [
+            {
+              database: "project",
+              schema: "dataset",
+              name: "name2"
+            }
+          ],
+          disabled: true,
+          fileName: "definitions/filename2.sqlx",
+          parentAction: {
+            database: "project",
+            schema: "dataset",
+            name: "name2"
+          },
+          query:
+            "\nSELECT\n  *\nFROM (\n  SELECT\n    uniqueKey1,\n    COUNT(1) AS index_row_count\n  FROM `project.dataset.name2`\n  GROUP BY uniqueKey1\n  ) AS data\nWHERE index_row_count > 1\n",
           tags: ["tag1", "tag2"]
         }
       ] as dataform.IAssertion[]
@@ -1866,18 +1899,10 @@ ${exampleActionDescriptor.inputSqlxConfigBlock}
 
     test("for tables", () => {
       const projectDir = tmpDirFixture.createNewTmpDir();
-      fs.writeFileSync(
-        path.join(projectDir, "workflow_settings.yaml"),
-        VALID_WORKFLOW_SETTINGS_YAML
-      );
-      fs.mkdirSync(path.join(projectDir, "definitions"));
-      fs.writeFileSync(path.join(projectDir, "definitions/operation.sqlx"), "SELECT 1");
-      fs.writeFileSync(
-        path.join(projectDir, "definitions/filename.sqlx"),
-        `
+      const tableDefinition = (name: string, assertions: string) => `
 config {
   type: "table",
-  name: "name",
+  name: "${name}",
   schema: "dataset",
   database: "project",
   dependencies: ["operation"],
@@ -1896,71 +1921,57 @@ ${exampleActionDescriptor.inputSqlxConfigBlock}
       option2Key: "option2",
     }
   },
-  ${exampleBuiltInAssertions.inputSqlxConfigBlock}
+  ${assertions}
   dependOnDependencyAssertions: true,
   hermetic: true,
 }
-SELECT 1`
-      );
-
-      const result = runMainInVm(coreExecutionRequestFromPath(projectDir));
-
-      expect(result.compile.compiledGraph.graphErrors.compilationErrors).deep.equals([]);
-      expect(asPlainObject(result.compile.compiledGraph.tables)).deep.equals([
-        {
-          target: {
-            database: "project",
-            schema: "dataset",
-            name: "name"
+SELECT 1`;
+      const expectedCompiledTable = (name: string, fileName: string) => ({
+        target: {
+          database: "project",
+          schema: "dataset",
+          name
+        },
+        canonicalTarget: {
+          database: "project",
+          schema: "dataset",
+          name
+        },
+        type: "table",
+        disabled: true,
+        hermeticity: "HERMETIC",
+        bigquery: {
+          additionalOptions: {
+            option1Key: "option1",
+            option2Key: "option2"
           },
-          canonicalTarget: {
-            database: "project",
-            schema: "dataset",
-            name: "name"
+          clusterBy: ["clusterBy"],
+          labels: {
+            key: "val"
           },
-          type: "table",
-          disabled: true,
-          hermeticity: "HERMETIC",
-          bigquery: {
-            additionalOptions: {
-              option1Key: "option1",
-              option2Key: "option2"
-            },
-            clusterBy: ["clusterBy"],
-            labels: {
-              key: "val"
-            },
-            partitionBy: "partitionBy",
-            partitionExpirationDays: 1,
-            requirePartitionFilter: true
-          },
-          tags: ["tag1", "tag2"],
-          dependencyTargets: [
-            {
-              database: "defaultProject",
-              schema: "defaultDataset",
-              name: "operation"
-            }
-          ],
-          enumType: "TABLE",
-          fileName: "definitions/filename.sqlx",
-          query: "\n\nSELECT 1",
-          actionDescriptor: {
-            ...exampleActionDescriptor.outputActionDescriptor,
-            // sqlxConfig.bigquery.labels are placed as bigqueryLabels.
-            bigqueryLabels: {
-              key: "val"
-            }
+          partitionBy: "partitionBy",
+          partitionExpirationDays: 1,
+          requirePartitionFilter: true
+        },
+        tags: ["tag1", "tag2"],
+        dependencyTargets: [
+          {
+            database: "defaultProject",
+            schema: "defaultDataset",
+            name: "operation"
+          }
+        ],
+        enumType: "TABLE",
+        fileName,
+        query: "\n\nSELECT 1",
+        actionDescriptor: {
+          ...exampleActionDescriptor.outputActionDescriptor,
+          // sqlxConfig.bigquery.labels are placed as bigqueryLabels.
+          bigqueryLabels: {
+            key: "val"
           }
         }
-      ]);
-      expect(asPlainObject(result.compile.compiledGraph.assertions)).deep.equals(
-        exampleBuiltInAssertions.outputAssertions
-      );
-    });
-
-    test("for views", () => {
-      const projectDir = tmpDirFixture.createNewTmpDir();
+      });
       fs.writeFileSync(
         path.join(projectDir, "workflow_settings.yaml"),
         VALID_WORKFLOW_SETTINGS_YAML
@@ -1969,10 +1980,31 @@ SELECT 1`
       fs.writeFileSync(path.join(projectDir, "definitions/operation.sqlx"), "SELECT 1");
       fs.writeFileSync(
         path.join(projectDir, "definitions/filename.sqlx"),
-        `
+        tableDefinition("name", exampleBuiltInAssertions.inputSqlxConfigBlock1)
+      );
+      fs.writeFileSync(
+        path.join(projectDir, "definitions/filename2.sqlx"),
+        tableDefinition("name2", exampleBuiltInAssertions.inputSqlxConfigBlock2)
+      );
+
+      const result = runMainInVm(coreExecutionRequestFromPath(projectDir));
+
+      expect(result.compile.compiledGraph.graphErrors.compilationErrors).deep.equals([]);
+      expect(asPlainObject(result.compile.compiledGraph.tables)).deep.equals([
+        expectedCompiledTable("name", "definitions/filename.sqlx"),
+        expectedCompiledTable("name2", "definitions/filename2.sqlx")
+      ]);
+      expect(asPlainObject(result.compile.compiledGraph.assertions)).deep.equals(
+        exampleBuiltInAssertions.outputAssertions
+      );
+    });
+
+    test("for views", () => {
+      const projectDir = tmpDirFixture.createNewTmpDir();
+      const viewDefinition = (name: string, assertions: string) => `
 config {
   type: "view",
-  name: "name",
+  name: "${name}",
   schema: "dataset",
   database: "project",
   dependencies: ["operation"],
@@ -1990,66 +2022,52 @@ ${exampleActionDescriptor.inputSqlxConfigBlock}
   },
   dependOnDependencyAssertions: true,
   hermetic: true,
-${exampleBuiltInAssertions.inputSqlxConfigBlock}
+${assertions}
 }
-SELECT 1`
-      );
-
-      const result = runMainInVm(coreExecutionRequestFromPath(projectDir));
-
-      expect(result.compile.compiledGraph.graphErrors.compilationErrors).deep.equals([]);
-      expect(asPlainObject(result.compile.compiledGraph.tables)).deep.equals([
-        {
-          target: {
-            database: "project",
-            schema: "dataset",
-            name: "name"
+SELECT 1`;
+      const expectedCompiledView = (name: string, fileName: string) => ({
+        target: {
+          database: "project",
+          schema: "dataset",
+          name
+        },
+        canonicalTarget: {
+          database: "project",
+          schema: "dataset",
+          name
+        },
+        type: "view",
+        disabled: true,
+        hermeticity: "HERMETIC",
+        bigquery: {
+          additionalOptions: {
+            option1Key: "option1",
+            option2Key: "option2"
           },
-          canonicalTarget: {
-            database: "project",
-            schema: "dataset",
-            name: "name"
-          },
-          type: "view",
-          disabled: true,
-          hermeticity: "HERMETIC",
-          bigquery: {
-            additionalOptions: {
-              option1Key: "option1",
-              option2Key: "option2"
-            },
-            labels: {
-              key: "val"
-            }
-          },
-          tags: ["tag1", "tag2"],
-          dependencyTargets: [
-            {
-              database: "defaultProject",
-              schema: "defaultDataset",
-              name: "operation"
-            }
-          ],
-          enumType: "VIEW",
-          fileName: "definitions/filename.sqlx",
-          query: "\n\nSELECT 1",
-          actionDescriptor: {
-            ...exampleActionDescriptor.outputActionDescriptor,
-            // sqlxConfig.bigquery.labels are placed as bigqueryLabels.
-            bigqueryLabels: {
-              key: "val"
-            }
-          },
-          materialized: true
-        }
-      ]);
-      expect(asPlainObject(result.compile.compiledGraph.assertions)).deep.equals(
-        exampleBuiltInAssertions.outputAssertions
-      );
-    });
-
-    test("for incremental tables", () => {
-      const projectDir = tmpDirFixture.createNewTmpDir();
+          labels: {
+            key: "val"
+          }
+        },
+        tags: ["tag1", "tag2"],
+        dependencyTargets: [
+          {
+            database: "defaultProject",
+            schema: "defaultDataset",
+            name: "operation"
+          }
+        ],
+        enumType: "VIEW",
+        fileName,
+        query: "\n\nSELECT 1",
+        actionDescriptor: {
+          ...exampleActionDescriptor.outputActionDescriptor,
+          // sqlxConfig.bigquery.labels are placed as bigqueryLabels.
+          bigqueryLabels: {
+            key: "val"
+          }
+        },
+        materialized: true
+      });
       fs.writeFileSync(
         path.join(projectDir, "workflow_settings.yaml"),
         VALID_WORKFLOW_SETTINGS_YAML
@@ -2058,10 +2076,31 @@ SELECT 1`
       fs.writeFileSync(path.join(projectDir, "definitions/operation.sqlx"), "SELECT 1");
       fs.writeFileSync(
         path.join(projectDir, "definitions/filename.sqlx"),
-        `
+        viewDefinition("name", exampleBuiltInAssertions.inputSqlxConfigBlock1)
+      );
+      fs.writeFileSync(
+        path.join(projectDir, "definitions/filename2.sqlx"),
+        viewDefinition("name2", exampleBuiltInAssertions.inputSqlxConfigBlock2)
+      );
+
+      const result = runMainInVm(coreExecutionRequestFromPath(projectDir));
+
+      expect(result.compile.compiledGraph.graphErrors.compilationErrors).deep.equals([]);
+      expect(asPlainObject(result.compile.compiledGraph.tables)).deep.equals([
+        expectedCompiledView("name", "definitions/filename.sqlx"),
+        expectedCompiledView("name2", "definitions/filename2.sqlx")
+      ]);
+      expect(asPlainObject(result.compile.compiledGraph.assertions)).deep.equals(
+        exampleBuiltInAssertions.outputAssertions
+      );
+    });
+
+    test("for incremental tables", () => {
+      const projectDir = tmpDirFixture.createNewTmpDir();
+      const tableDefinition = (name: string, assertions: string) => `
 config {
   type: "incremental",
-  name: "name",
+  name: "${name}",
   schema: "dataset",
   database: "project",
   dependencies: ["operation"],
@@ -2084,66 +2123,81 @@ config {
     }
   },
   dependOnDependencyAssertions: true,
-  ${exampleBuiltInAssertions.inputSqlxConfigBlock}
+  ${assertions}
   hermetic: true,
 }
 SELECT 1`
+      const expectedCompiledTable = (name: string, fileName: string) => ({
+        target: {
+          database: "project",
+          schema: "dataset",
+          name
+        },
+        canonicalTarget: {
+          database: "project",
+          schema: "dataset",
+          name
+        },
+        type: "incremental",
+        disabled: true,
+        protected: false,
+        hermeticity: "HERMETIC",
+        bigquery: {
+          additionalOptions: {
+            option1Key: "option1",
+            option2Key: "option2"
+          },
+          clusterBy: ["clusterBy"],
+          labels: {
+            key: "val"
+          },
+          partitionBy: "partitionBy",
+          partitionExpirationDays: 1,
+          requirePartitionFilter: true,
+          updatePartitionFilter: "updatePartitionFilter"
+        },
+        tags: ["tag1", "tag2"],
+        uniqueKey: ["key1", "key2"],
+        dependencyTargets: [
+          {
+            database: "defaultProject",
+            schema: "defaultDataset",
+            name: "operation"
+          }
+        ],
+        enumType: "INCREMENTAL",
+        fileName,
+        query: "\n\nSELECT 1",
+        incrementalQuery: "\n\nSELECT 1",
+        actionDescriptor: {
+          ...exampleActionDescriptor.outputActionDescriptor,
+          // sqlxConfig.bigquery.labels are placed as bigqueryLabels.
+          bigqueryLabels: {
+            key: "val"
+          }
+        }
+      })
+      fs.writeFileSync(
+        path.join(projectDir, "workflow_settings.yaml"),
+        VALID_WORKFLOW_SETTINGS_YAML
+      );
+      fs.mkdirSync(path.join(projectDir, "definitions"));
+      fs.writeFileSync(path.join(projectDir, "definitions/operation.sqlx"), "SELECT 1");
+      fs.writeFileSync(
+        path.join(projectDir, "definitions/filename.sqlx"),
+        tableDefinition("name", exampleBuiltInAssertions.inputSqlxConfigBlock1)
+      );
+      fs.writeFileSync(
+        path.join(projectDir, "definitions/filename2.sqlx"),
+        tableDefinition("name2", exampleBuiltInAssertions.inputSqlxConfigBlock2)
       );
 
       const result = runMainInVm(coreExecutionRequestFromPath(projectDir));
 
       expect(result.compile.compiledGraph.graphErrors.compilationErrors).deep.equals([]);
       expect(asPlainObject(result.compile.compiledGraph.tables)).deep.equals([
-        {
-          target: {
-            database: "project",
-            schema: "dataset",
-            name: "name"
-          },
-          canonicalTarget: {
-            database: "project",
-            schema: "dataset",
-            name: "name"
-          },
-          type: "incremental",
-          disabled: true,
-          protected: false,
-          hermeticity: "HERMETIC",
-          bigquery: {
-            additionalOptions: {
-              option1Key: "option1",
-              option2Key: "option2"
-            },
-            clusterBy: ["clusterBy"],
-            labels: {
-              key: "val"
-            },
-            partitionBy: "partitionBy",
-            partitionExpirationDays: 1,
-            requirePartitionFilter: true,
-            updatePartitionFilter: "updatePartitionFilter"
-          },
-          tags: ["tag1", "tag2"],
-          uniqueKey: ["key1", "key2"],
-          dependencyTargets: [
-            {
-              database: "defaultProject",
-              schema: "defaultDataset",
-              name: "operation"
-            }
-          ],
-          enumType: "INCREMENTAL",
-          fileName: "definitions/filename.sqlx",
-          query: "\n\nSELECT 1",
-          incrementalQuery: "\n\nSELECT 1",
-          actionDescriptor: {
-            ...exampleActionDescriptor.outputActionDescriptor,
-            // sqlxConfig.bigquery.labels are placed as bigqueryLabels.
-            bigqueryLabels: {
-              key: "val"
-            }
-          }
-        }
+        expectedCompiledTable("name", "definitions/filename.sqlx"),
+        expectedCompiledTable("name2", "definitions/filename2.sqlx")
       ]);
       expect(asPlainObject(result.compile.compiledGraph.assertions)).deep.equals(
         exampleBuiltInAssertions.outputAssertions


### PR DESCRIPTION
# The Bug

This PR fixes a bug where `uniqueKey` assertions on views and incremental tables caused `dataform run` to exit with a query error. `uniqueKey` assertions on tables, as well as all `uniqueKeys` assertions still worked. Affected versions: `3.0.1`, `3.0.2`. I don't know whether executions on GCP were also affected.

 ## Steps to reproduce
1) Create an empty dataform project using version `3.0.1` or `3.0.2` of `@dataform/core`.
2) Add the following definition:
```
config {
  type: "view",
  name: "my table",
  assertions: {
    uniqueKey: ["id"]
  }
}

SELECT 1 as id
```
3) Execute `dataform run`. Observe the following error message:
```
Table created:  dataform.my table [view]
Assertion failed:  dataform_assertions.dataform_my table_assertions_uniqueKey_0
  >
  >       create or replace view `mbarna-mongo-to-bq-dataflow.dataform_assertions.dataform_my table_assertions_uniqueKey_0` as
  > SELECT
  >   *
  > FROM (
  >   SELECT
  >     TableAssertionsConfig,
  >     COUNT(1) AS index_row_count
  >   FROM `mbarna-mongo-to-bq-dataflow.dataform.my table`
  >   GROUP BY TableAssertionsConfig
  >   ) AS data
  > WHERE index_row_count > 1
  >
  bigquery error: Unrecognized name: TableAssertionsConfig at [7:5]
```

# The Fix

I don't fully understand what happened. The query complains about an undefined column `TableAssertionsConfig`, and the newly refactored implementations for `view` and `incremental_table` contain this hardcoded string for `uniqueKey` assertions. I'm not sure what the hardcoded string is meant to be referring to. Just replacing the hardcoded string with the user-supplied column names fixes the issue.

# The Tests
The suite in `core/main_test.ts` tested assertions for `views`, `tables` and `incremental_table`s, for the following assertions: `uniqueKeys`, `nonNull`, `rowConditions`. `uniqueKey` assertions were untested, I assume because they're incompatible with a `uniqueKeys` assertion. I extended the test suite to also include tests for `uniqueKey` assertions, for all three tested table kinds. I worked around the incompatibility by introducing a second sample file. Apart from the different `assertions` block, the second file's contents are identical to the contents of the first file.

This has confirmed the bug, as well as the fix.

I nominate @Ekrekr as reviewer.