### PR TITLE
Improve error messages when workflow settings have non-string values for default project or dataset

### DIFF
--- a/core/main_test.ts
+++ b/core/main_test.ts
@@ -468,6 +468,38 @@ someKey: and an extra: colon
       );
     });
 
+    test(`main fails when workflow settings have non-string default dataset`, () => {
+      const projectDir = tmpDirFixture.createNewTmpDir();
+      fs.writeFileSync(
+        path.join(projectDir, "workflow_settings.yaml"),
+        `
+defaultProject: defaultProject
+defaultDataset: 12345
+defaultLocation: US
+`
+      );
+
+      expect(() => runMainInVm(coreExecutionRequestFromPath(projectDir))).to.throw(
+        "Default schema should be string."
+      );
+    });
+
+    test(`main fails when workflow settings have non-string default project`, () => {
+      const projectDir = tmpDirFixture.createNewTmpDir();
+      fs.writeFileSync(
+        path.join(projectDir, "workflow_settings.yaml"),
+        `
+defaultProject: 12345
+defaultDataset: defaultDataset
+defaultLocation: US
+`
+      );
+
+      expect(() => runMainInVm(coreExecutionRequestFromPath(projectDir))).to.throw(
+        "Default database should be string."
+      );
+    });
+
     test(`main fails when a valid dataform.json contains unknown fields`, () => {
       const projectDir = tmpDirFixture.createNewTmpDir();
       fs.writeFileSync(

--- a/core/session.ts
+++ b/core/session.ts
@@ -345,6 +345,14 @@ export class Session {
       );
     }
 
+    if (typeof this.projectConfig.defaultDatabase !== "string") {
+      throw new Error("Default database should be string.");
+    }
+
+    if (typeof this.projectConfig.defaultSchema !== "string") {
+      throw new Error("Default schema should be string.");
+    }
+
     if (
       !!this.projectConfig.vars &&
       !Object.values(this.projectConfig.vars).every(value => typeof value === "string")


### PR DESCRIPTION
Currently if `defautProject` or `defaultDataset` have an integer type in `workflow_settings.yaml`, a compilation will throw a not very obvious error like `t.target.schema.includes is not a function`. I've added a validation of these fields to be strings (if not, an explicit error is thrown).