### PR TITLE
Make published packages include the version.bzl file

### DIFF
--- a/packages/@dataform/core/BUILD
+++ b/packages/@dataform/core/BUILD
@@ -101,5 +101,6 @@ pkg_npm_tar(
         ":core_proto_with_license",
         ":data_preparation_proto_with_license",
         ":package.json",
+        "//:version.bzl"
     ],
 )

--- a/version.bzl
+++ b/version.bzl
@@ -1,3 +1,1 @@
-# NOTE: If you change the format of this line, you must change the bash command
-# in /scripts/publish to extract the version string correctly.
 DF_VERSION = "3.0.2"


### PR DESCRIPTION
This makes loading the current version of a downloaded package feasible in a bazel environment