### PR TITLE
Change variable name in cloudbuild.yaml

### DIFF
--- a/cloudbuild-publish.yaml
+++ b/cloudbuild-publish.yaml
@@ -15,10 +15,10 @@ steps:
     - '-c'
     - |
       set -e
-      __VERSION=$(cat version.bzl | grep DF_VERSION | awk '{ print $3 }' | sed "s/\"//g")
-      echo "Creating release notes for $__VERSION"
+      version=$(cat version.bzl | grep DF_VERSION | awk '{ print $3 }' | sed "s/\"//g")
+      echo "Creating release notes for $version"
       gh auth login --with-token < ~/token.txt
-      gh release create $__VERSION --generate-notes
+      gh release create $version --generate-notes
 availableSecrets:
   secretManager:
   - versionName: projects/178487900909/secrets/npm-publish-token/versions/2


### PR DESCRIPTION
Fix variable name to avoid conflict with GCB built-in variable names. 
This conflict was stoping release notes from publishing.