### PR TITLE
refactor: run format to all ts files

### DIFF
--- a/cli/index.ts
+++ b/cli/index.ts
@@ -586,18 +586,18 @@ export function runCli() {
         format: `format [${projectDirMustExistOption.name}]`,
         description: "Format the dataform project's files.",
         positionalOptions: [projectDirMustExistOption],
-        options: [
-            actionsOption
-        ],
+        options: [actionsOption],
         processFn: async argv => {
-          let actions = ["{definitions,includes}/**/*.{js,sqlx}"]
+          let actions = ["{definitions,includes}/**/*.{js,sqlx}"];
           if (actionsOption.name in argv && argv[actionsOption.name].length > 0) {
-            actions = argv[actionsOption.name]
+            actions = argv[actionsOption.name];
           }
-          const filenames = actions.map((action: string) =>
-            glob.sync(action, {cwd: argv[projectDirMustExistOption.name]})
-          ).flat();
-          const results: Array<{ filename: string; err?: Error; }> = await Promise.all(
+          const filenames = actions
+            .map((action: string) =>
+              glob.sync(action, { cwd: argv[projectDirMustExistOption.name] })
+            )
+            .flat();
+          const results: Array<{ filename: string; err?: Error }> = await Promise.all(
             filenames.map(async (filename: string) => {
               try {
                 await formatFile(path.resolve(argv[projectDirMustExistOption.name], filename), {

--- a/common/errors/errors.ts
+++ b/common/errors/errors.ts
@@ -15,7 +15,7 @@ export function coerceAsError<T extends Error | any>(errorLike: T): T extends Er
   if ((errorLike as any) instanceof Error) {
     return errorLike as any;
   }
-  const error = (errorLike as any) as Error
+  const error = (errorLike as any) as Error;
   // Otherwise, attempt to reconstruct an error class from the object.
   const message = error.message ? String(error.message) : String(errorLike);
   const coercedError = new Error(message);

--- a/core/actions/index.ts
+++ b/core/actions/index.ts
@@ -50,16 +50,16 @@ export abstract class ActionBuilder<T> {
     return target;
   }
 
-  public finalizeTarget(
-    targetFromConfig: dataform.Target
-  ): dataform.Target {
+  public finalizeTarget(targetFromConfig: dataform.Target): dataform.Target {
     return dataform.Target.create({
       name: this.session.finalizeName(targetFromConfig.name),
-      schema: targetFromConfig.schema ?
-          this.session.finalizeSchema(targetFromConfig.schema) : undefined,
-      database: targetFromConfig.database ?
-          this.session.finalizeDatabase(targetFromConfig.database) : undefined
-    })
+      schema: targetFromConfig.schema
+        ? this.session.finalizeSchema(targetFromConfig.schema)
+        : undefined,
+      database: targetFromConfig.database
+        ? this.session.finalizeDatabase(targetFromConfig.database)
+        : undefined
+    });
   }
 
   /** Retrieves the filename from the config. */

--- a/core/main.ts
+++ b/core/main.ts
@@ -182,11 +182,11 @@ function loadActionConfigs(session: Session, filePaths: string[]) {
           );
         } else if (actionConfig.dataPreparation) {
           session.actions.push(
-              new DataPreparation(
-                  session,
-                  dataform.ActionConfig.DataPreparationConfig.create(actionConfig.dataPreparation),
-                  actionConfigsPath
-              )
+            new DataPreparation(
+              session,
+              dataform.ActionConfig.DataPreparationConfig.create(actionConfig.dataPreparation),
+              actionConfigsPath
+            )
           );
         } else {
           throw Error("Empty action configs are not permitted.");

--- a/core/main_test.ts
+++ b/core/main_test.ts
@@ -5,13 +5,17 @@ import { dump as dumpYaml, load as loadYaml } from "js-yaml";
 import * as path from "path";
 import { CompilerFunction, NodeVM } from "vm2";
 
-import { decode64, encode64, verifyObjectMatchesProto, VerifyProtoErrorBehaviour } from "df/common/protos";
+import {
+  decode64,
+  encode64,
+  verifyObjectMatchesProto,
+  VerifyProtoErrorBehaviour
+} from "df/common/protos";
 import { compile } from "df/core/compilers";
 import { version } from "df/core/version";
 import { dataform } from "df/protos/ts";
 import { asPlainObject, suite, test } from "df/testing";
 import { TmpDirFixture } from "df/testing/fixtures";
-
 
 const SOURCE_EXTENSIONS = ["js", "sql", "sqlx", "yaml", "ipynb"];
 
@@ -910,47 +914,47 @@ nodes:
         - name: a
           type: STRING
           mode: NULLABLE
-`
+`;
 
       fs.writeFileSync(
-          path.join(projectDir, "definitions/data_preparation.yaml"),
-          dataPreparationYaml
+        path.join(projectDir, "definitions/data_preparation.yaml"),
+        dataPreparationYaml
       );
 
       const result = runMainInVm(coreExecutionRequestFromPath(projectDir));
 
       expect(result.compile.compiledGraph.graphErrors.compilationErrors).deep.equals([]);
       expect(asPlainObject(result.compile.compiledGraph.dataPreparations)).deep.equals(
-          asPlainObject([
-            {
-              target: {
+        asPlainObject([
+          {
+            target: {
+              database: "prj",
+              schema: "ds",
+              name: "dest"
+            },
+            canonicalTarget: {
+              database: "prj",
+              schema: "ds",
+              name: "dest"
+            },
+            targets: [
+              {
                 database: "prj",
                 schema: "ds",
                 name: "dest"
-              },
-              canonicalTarget: {
+              }
+            ],
+            canonicalTargets: [
+              {
                 database: "prj",
                 schema: "ds",
                 name: "dest"
-              },
-              targets: [
-                {
-                  database: "prj",
-                  schema: "ds",
-                  name: "dest"
-                }
-              ],
-              canonicalTargets: [
-                {
-                  database: "prj",
-                  schema: "ds",
-                  name: "dest"
-                }
-              ],
-              fileName: "definitions/data_preparation.yaml",
-              dataPreparationYaml: dumpYaml(loadYaml(dataPreparationYaml))
-            }
-          ])
+              }
+            ],
+            fileName: "definitions/data_preparation.yaml",
+            dataPreparationYaml: dumpYaml(loadYaml(dataPreparationYaml))
+          }
+        ])
       );
     });
 
@@ -1010,11 +1014,11 @@ nodes:
         - name: a
           type: STRING
           mode: NULLABLE
-`
+`;
 
       fs.writeFileSync(
-          path.join(projectDir, "definitions/data_preparation.yaml"),
-          dataPreparationYaml
+        path.join(projectDir, "definitions/data_preparation.yaml"),
+        dataPreparationYaml
       );
 
       const resolvedYaml = `
@@ -1070,42 +1074,42 @@ nodes:
         - name: a
           type: STRING
           mode: NULLABLE
-`
+`;
 
       const result = runMainInVm(coreExecutionRequestFromPath(projectDir));
 
       expect(result.compile.compiledGraph.graphErrors.compilationErrors).deep.equals([]);
       expect(asPlainObject(result.compile.compiledGraph.dataPreparations)).deep.equals(
-          asPlainObject([
-            {
-              target: {
+        asPlainObject([
+          {
+            target: {
+              database: "defaultProject_projectSuffix",
+              schema: "defaultDataset_datasetSuffix",
+              name: "tablePrefix_dest"
+            },
+            canonicalTarget: {
+              database: "defaultProject",
+              schema: "defaultDataset",
+              name: "dest"
+            },
+            targets: [
+              {
                 database: "defaultProject_projectSuffix",
                 schema: "defaultDataset_datasetSuffix",
                 name: "tablePrefix_dest"
-              },
-              canonicalTarget: {
+              }
+            ],
+            canonicalTargets: [
+              {
                 database: "defaultProject",
                 schema: "defaultDataset",
                 name: "dest"
-              },
-              targets: [
-                {
-                  database: "defaultProject_projectSuffix",
-                  schema: "defaultDataset_datasetSuffix",
-                  name: "tablePrefix_dest"
-                }
-              ],
-              canonicalTargets: [
-                {
-                  database: "defaultProject",
-                  schema: "defaultDataset",
-                  name: "dest"
-                }
-              ],
-              fileName: "definitions/data_preparation.yaml",
-              dataPreparationYaml: dumpYaml(loadYaml(resolvedYaml))
-            }
-          ])
+              }
+            ],
+            fileName: "definitions/data_preparation.yaml",
+            dataPreparationYaml: dumpYaml(loadYaml(resolvedYaml))
+          }
+        ])
       );
     });
   });
@@ -2103,7 +2107,7 @@ config {
   ${assertions}
   hermetic: true,
 }
-SELECT 1`
+SELECT 1`;
       const expectedCompiledTable = (name: string, fileName: string) => ({
         target: {
           database: "project",
@@ -2153,7 +2157,7 @@ SELECT 1`
             key: "val"
           }
         }
-      })
+      });
       fs.writeFileSync(
         path.join(projectDir, "workflow_settings.yaml"),
         VALID_WORKFLOW_SETTINGS_YAML

--- a/sqlx/lexer.ts
+++ b/sqlx/lexer.ts
@@ -83,14 +83,16 @@ const SQL_TRIPLE_SINGLE_QUOTE_STRING_LEXER_TOKEN_NAMES = {
   ESCAPED_BACKSLASH: LEXER_STATE_NAMES.SQL_TRIPLE_SINGLE_QUOTE_STRING + "_escapedBackslash",
   START_JS_PLACEHOLDER: LEXER_STATE_NAMES.SQL_TRIPLE_SINGLE_QUOTE_STRING + "_startJsPlaceholder",
   CLOSE_QUOTE: LEXER_STATE_NAMES.SQL_TRIPLE_SINGLE_QUOTE_STRING + "_closeTripleQuoteSingle",
-  CAPTURE_EVERYTHING_ELSE: LEXER_STATE_NAMES.SQL_TRIPLE_SINGLE_QUOTE_STRING + "_captureEverythingElse"
+  CAPTURE_EVERYTHING_ELSE:
+    LEXER_STATE_NAMES.SQL_TRIPLE_SINGLE_QUOTE_STRING + "_captureEverythingElse"
 };
 
 const SQL_TRIPLE_DOUBLE_QUOTE_STRING_LEXER_TOKEN_NAMES = {
   ESCAPED_BACKSLASH: LEXER_STATE_NAMES.SQL_TRIPLE_DOUBLE_QUOTE_STRING + "_escapedBackslash",
   START_JS_PLACEHOLDER: LEXER_STATE_NAMES.SQL_TRIPLE_DOUBLE_QUOTE_STRING + "_startJsPlaceholder",
   CLOSE_QUOTE: LEXER_STATE_NAMES.SQL_TRIPLE_DOUBLE_QUOTE_STRING + "_closeTripleQuoteDouble",
-  CAPTURE_EVERYTHING_ELSE: LEXER_STATE_NAMES.SQL_TRIPLE_DOUBLE_QUOTE_STRING + "_captureEverythingElse"
+  CAPTURE_EVERYTHING_ELSE:
+    LEXER_STATE_NAMES.SQL_TRIPLE_DOUBLE_QUOTE_STRING + "_captureEverythingElse"
 };
 
 const lexer = moo.states(buildSqlxLexer());
@@ -118,8 +120,14 @@ const START_TOKEN_NODE_MAPPINGS = new Map<string, SyntaxTreeNodeType>([
   [SQL_LEXER_TOKEN_NAMES.START_PRE_OPERATIONS, SyntaxTreeNodeType.SQL],
   [SQL_LEXER_TOKEN_NAMES.START_QUOTE_SINGLE, SyntaxTreeNodeType.SQL_LITERAL_STRING],
   [SQL_LEXER_TOKEN_NAMES.START_QUOTE_DOUBLE, SyntaxTreeNodeType.SQL_LITERAL_STRING],
-  [SQL_LEXER_TOKEN_NAMES.START_TRIPLE_QUOTE_SINGLE, SyntaxTreeNodeType.SQL_LITERAL_MULTILINE_STRING],
-  [SQL_LEXER_TOKEN_NAMES.START_TRIPLE_QUOTE_DOUBLE, SyntaxTreeNodeType.SQL_LITERAL_MULTILINE_STRING],
+  [
+    SQL_LEXER_TOKEN_NAMES.START_TRIPLE_QUOTE_SINGLE,
+    SyntaxTreeNodeType.SQL_LITERAL_MULTILINE_STRING
+  ],
+  [
+    SQL_LEXER_TOKEN_NAMES.START_TRIPLE_QUOTE_DOUBLE,
+    SyntaxTreeNodeType.SQL_LITERAL_MULTILINE_STRING
+  ],
 
   [JS_BLOCK_LEXER_TOKEN_NAMES.START_JS_BLOCK, SyntaxTreeNodeType.JAVASCRIPT],
 
@@ -131,8 +139,14 @@ const START_TOKEN_NODE_MAPPINGS = new Map<string, SyntaxTreeNodeType>([
   ],
   [INNER_SQL_BLOCK_LEXER_TOKEN_NAMES.START_QUOTE_SINGLE, SyntaxTreeNodeType.SQL_LITERAL_STRING],
   [INNER_SQL_BLOCK_LEXER_TOKEN_NAMES.START_QUOTE_DOUBLE, SyntaxTreeNodeType.SQL_LITERAL_STRING],
-  [INNER_SQL_BLOCK_LEXER_TOKEN_NAMES.START_TRIPLE_QUOTE_SINGLE, SyntaxTreeNodeType.SQL_LITERAL_MULTILINE_STRING],
-  [INNER_SQL_BLOCK_LEXER_TOKEN_NAMES.START_TRIPLE_QUOTE_DOUBLE, SyntaxTreeNodeType.SQL_LITERAL_MULTILINE_STRING],
+  [
+    INNER_SQL_BLOCK_LEXER_TOKEN_NAMES.START_TRIPLE_QUOTE_SINGLE,
+    SyntaxTreeNodeType.SQL_LITERAL_MULTILINE_STRING
+  ],
+  [
+    INNER_SQL_BLOCK_LEXER_TOKEN_NAMES.START_TRIPLE_QUOTE_DOUBLE,
+    SyntaxTreeNodeType.SQL_LITERAL_MULTILINE_STRING
+  ],
 
   [
     SQL_SINGLE_QUOTE_STRING_LEXER_TOKEN_NAMES.START_JS_PLACEHOLDER,
@@ -185,7 +199,7 @@ export class SyntaxTreeNode {
     lexer.reset(code);
     for (const token of lexer) {
       if (!token.type) {
-        throw new Error('Undefined token type encountered.');
+        throw new Error("Undefined token type encountered.");
       }
       if (START_TOKEN_NODE_MAPPINGS.has(token.type)) {
         const childType = START_TOKEN_NODE_MAPPINGS.get(token.type)!;
@@ -315,11 +329,11 @@ function buildSqlxLexer(): { [x: string]: moo.Rules } {
   // on the order of property creation in rule object.
   sqlLexer[SQL_LEXER_TOKEN_NAMES.START_TRIPLE_QUOTE_SINGLE] = {
     match: "'''",
-    push: LEXER_STATE_NAMES.SQL_TRIPLE_SINGLE_QUOTE_STRING,
+    push: LEXER_STATE_NAMES.SQL_TRIPLE_SINGLE_QUOTE_STRING
   };
   sqlLexer[SQL_LEXER_TOKEN_NAMES.START_TRIPLE_QUOTE_DOUBLE] = {
     match: '"""',
-    push: LEXER_STATE_NAMES.SQL_TRIPLE_DOUBLE_QUOTE_STRING,
+    push: LEXER_STATE_NAMES.SQL_TRIPLE_DOUBLE_QUOTE_STRING
   };
 
   sqlLexer[SQL_LEXER_TOKEN_NAMES.START_QUOTE_SINGLE] = {
@@ -438,8 +452,11 @@ function buildSqlxLexer(): { [x: string]: moo.Rules } {
   };
 
   const innerTripleSingleQuoteLexer: moo.Rules = {};
-  innerTripleSingleQuoteLexer[SQL_TRIPLE_SINGLE_QUOTE_STRING_LEXER_TOKEN_NAMES.ESCAPED_BACKSLASH] = "\\\\";
-  innerTripleSingleQuoteLexer[SQL_TRIPLE_SINGLE_QUOTE_STRING_LEXER_TOKEN_NAMES.START_JS_PLACEHOLDER] = {
+  innerTripleSingleQuoteLexer[SQL_TRIPLE_SINGLE_QUOTE_STRING_LEXER_TOKEN_NAMES.ESCAPED_BACKSLASH] =
+    "\\\\";
+  innerTripleSingleQuoteLexer[
+    SQL_TRIPLE_SINGLE_QUOTE_STRING_LEXER_TOKEN_NAMES.START_JS_PLACEHOLDER
+  ] = {
     match: "${",
     push: LEXER_STATE_NAMES.JS_BLOCK
   };
@@ -447,14 +464,19 @@ function buildSqlxLexer(): { [x: string]: moo.Rules } {
     match: "'''",
     pop: 1
   };
-  innerTripleSingleQuoteLexer[SQL_TRIPLE_SINGLE_QUOTE_STRING_LEXER_TOKEN_NAMES.CAPTURE_EVERYTHING_ELSE] = {
+  innerTripleSingleQuoteLexer[
+    SQL_TRIPLE_SINGLE_QUOTE_STRING_LEXER_TOKEN_NAMES.CAPTURE_EVERYTHING_ELSE
+  ] = {
     match: /[\s\S]+?/,
     lineBreaks: true
   };
 
   const innerTripleDoubleQuoteLexer: moo.Rules = {};
-  innerTripleDoubleQuoteLexer[SQL_TRIPLE_DOUBLE_QUOTE_STRING_LEXER_TOKEN_NAMES.ESCAPED_BACKSLASH] = "\\\\";
-  innerTripleDoubleQuoteLexer[SQL_TRIPLE_DOUBLE_QUOTE_STRING_LEXER_TOKEN_NAMES.START_JS_PLACEHOLDER] = {
+  innerTripleDoubleQuoteLexer[SQL_TRIPLE_DOUBLE_QUOTE_STRING_LEXER_TOKEN_NAMES.ESCAPED_BACKSLASH] =
+    "\\\\";
+  innerTripleDoubleQuoteLexer[
+    SQL_TRIPLE_DOUBLE_QUOTE_STRING_LEXER_TOKEN_NAMES.START_JS_PLACEHOLDER
+  ] = {
     match: "${",
     push: LEXER_STATE_NAMES.JS_BLOCK
   };
@@ -462,7 +484,9 @@ function buildSqlxLexer(): { [x: string]: moo.Rules } {
     match: '"""',
     pop: 1
   };
-  innerTripleDoubleQuoteLexer[SQL_TRIPLE_DOUBLE_QUOTE_STRING_LEXER_TOKEN_NAMES.CAPTURE_EVERYTHING_ELSE] = {
+  innerTripleDoubleQuoteLexer[
+    SQL_TRIPLE_DOUBLE_QUOTE_STRING_LEXER_TOKEN_NAMES.CAPTURE_EVERYTHING_ELSE
+  ] = {
     match: /[\s\S]+?/,
     lineBreaks: true
   };

--- a/testing/index.ts
+++ b/testing/index.ts
@@ -7,7 +7,6 @@ export * from "df/testing/suite";
 export * from "df/testing/test";
 export * from "df/testing/runner";
 
-
 export const platformPath = () => {
   if (os.platform() === "darwin") {
     if (os.arch() === "arm64") {
@@ -16,13 +15,13 @@ export const platformPath = () => {
       return "nodejs_darwin_amd64";
     }
   } else {
-    if (os.arch() === 'arm64') {
+    if (os.arch() === "arm64") {
       return "nodejs_linux_arm64";
     } else {
       return "nodejs_linux_amd64";
     }
   }
-}
+};
 
 // Note: it would be more correct for these to be injected by blaze at run time.
 export const nodePath = `external/${platformPath()}/bin/node`;

--- a/tests/integration/bigquery.spec.ts
+++ b/tests/integration/bigquery.spec.ts
@@ -246,7 +246,7 @@ suite("@dataform/integration/bigquery", { parallel: true }, ({ before, after }) 
           'For row 2 and column "col1": expected "sup?", but saw "WRONG".'
         ]
       },
-      { name: "test a view", successful: true },
+      { name: "test a view", successful: true }
     ]);
   });
 

--- a/vscode/extension.ts
+++ b/vscode/extension.ts
@@ -64,27 +64,23 @@ export async function activate(context: vscode.ExtensionContext) {
   if (workspace.getConfiguration("dataform").get("recommendYamlExtension")) {
     const yamlExtension = vscode.extensions.getExtension("redhat.vscode-yaml");
     if (!yamlExtension) {
-      await vscode.window.showInformationMessage(
-        "The Dataform extension recommends installing the YAML extension for workflow_settings.yaml support.",
-        "Install",
-        "Don't show again"
-      ).then(selection => {
-        if (selection === "Install") {
-          // Open the YAML extension page
-          vscode.env.openExternal(
-            vscode.Uri.parse(
-              "vscode:extension/redhat.vscode-yaml"
-            )
-          );
-        } else if (selection === "Don't show again") {
-          // Disable the recommendation
-          workspace.getConfiguration("dataform").update(
-            "recommendYamlExtension",
-            false,
-            vscode.ConfigurationTarget.Global
-          );
-        }
-      });
+      await vscode.window
+        .showInformationMessage(
+          "The Dataform extension recommends installing the YAML extension for workflow_settings.yaml support.",
+          "Install",
+          "Don't show again"
+        )
+        .then(selection => {
+          if (selection === "Install") {
+            // Open the YAML extension page
+            vscode.env.openExternal(vscode.Uri.parse("vscode:extension/redhat.vscode-yaml"));
+          } else if (selection === "Don't show again") {
+            // Disable the recommendation
+            workspace
+              .getConfiguration("dataform")
+              .update("recommendYamlExtension", false, vscode.ConfigurationTarget.Global);
+          }
+        });
     }
   }
 }

--- a/vscode/server.ts
+++ b/vscode/server.ts
@@ -64,11 +64,9 @@ async function applySettings() {
 
 async function compileAndValidate() {
   let compilationFailed = false;
-  const spawnedProcess = spawn("dataform", [
-    "compile",
-    "--json",
-    ...settings.compilerOptions,
-  ], {shell: true});
+  const spawnedProcess = spawn("dataform", ["compile", "--json", ...settings.compilerOptions], {
+    shell: true
+  });
 
   const compileResult = await getProcessResult(spawnedProcess);
   if (compileResult.exitCode !== 0) {


### PR DESCRIPTION
Hi @dataform/core 👋

Thank you for this great project! My company has been using @dataform/core as part of our data platform, and it’s been incredibly helpful.

While setting up my local development environment to fix some bugs, I found some formatting inconsistencies in the code.
Since my VSCode is configured to automatically format .ts files on save, these inconsistencies result in unintended diffs.

To avoid these diffs emerging on the bug fixes, I’d like to resolve these formatting issues first.

- [x] `bazel build cli` succeeds
- [x] `bazel test //core/...` succeeds

If there are any other behaviors or checks I need to verify, please let me know.