### PR TITLE
Remove reviewer 

### DIFF
--- a/cloudbuild-version.yaml
+++ b/cloudbuild-version.yaml
@@ -18,6 +18,6 @@ steps:
     set -e
     echo "Create PR..."
     gh auth login --with-token < token.txt
-    gh pr create -t "Publishing Dataform security patches" -b "Updating NPM package version to $(cat version.bzl | grep DF_VERSION | awk '{ print $3 }' | sed "s/\"//g")" -B $BRANCH_NAME -H $(cat git_branch_name.txt) -r dataform-co/dataform-reviewers
+    gh pr create -t "Publishing Dataform security patches" -b "Updating NPM package version to $(cat version.bzl | grep DF_VERSION | awk '{ print $3 }' | sed "s/\"//g")" -B $BRANCH_NAME -H $(cat git_branch_name.txt)
 options:
   automapSubstitutions: true


### PR DESCRIPTION
Removing reviewer flag when creating a new PR. We assign `dataform-co/dataform-reviewer` as reviewer for every new PR. Trying to add this as part of create PR command was throwing error as this is not allowed.