### PR TITLE
Split unit and integration tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,8 +11,14 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Run tests
+      - name: Run unit tests
         uses: gcr.io/cloud-builders/bazel:5.4.0
         entrypoint: bash
         with:
           args: ./scripts/run_tests
+
+      - name: Run integration tests
+        uses: gcr.io/cloud-builders/bazel:5.4.0
+        entrypoint: bash
+        with:
+          args: ./scripts/run_integration_tests

--- a/scripts/run_integration_tests
+++ b/scripts/run_integration_tests
@@ -7,5 +7,6 @@ bazel build @npm//tslint/bin:tslint && bazel-bin/external/npm/tslint/bin/tslint.
 
 # Run all the tests
 bazel test ... \
-  --test_tag_filters=-integration \
+  --test_tag_filters=integration \
   --build_tests_only \
+  --test_env=USE_CLOUD_BUILD_NETWORK=true

--- a/scripts/run_integration_tests
+++ b/scripts/run_integration_tests
@@ -5,7 +5,7 @@ set -e
 bazel run @nodejs//:yarn
 bazel build @npm//tslint/bin:tslint && bazel-bin/external/npm/tslint/bin/tslint.sh --project .
 
-# Run all the tests
+# Run integration tests
 bazel test ... \
   --test_tag_filters=integration \
   --build_tests_only \

--- a/scripts/run_tests
+++ b/scripts/run_tests
@@ -8,4 +8,4 @@ bazel build @npm//tslint/bin:tslint && bazel-bin/external/npm/tslint/bin/tslint.
 # Run all the tests
 bazel test ... \
   --test_tag_filters=-integration \
-  --build_tests_only \
+  --build_tests_only

--- a/scripts/run_tests
+++ b/scripts/run_tests
@@ -5,7 +5,7 @@ set -e
 bazel run @nodejs//:yarn
 bazel build @npm//tslint/bin:tslint && bazel-bin/external/npm/tslint/bin/tslint.sh --project .
 
-# Run all the tests
+# Run unit tests
 bazel test ... \
   --test_tag_filters=-integration \
   --build_tests_only

--- a/scripts/run_tests_on_cloudbuild
+++ b/scripts/run_tests_on_cloudbuild
@@ -4,4 +4,8 @@ set -e
 bazel run @nodejs//:yarn config set registry https://us-npm.pkg.dev/artifact-foundry-prod/npm-3p-trusted/
 bazel run @nodejs//:npm install
 
+# Run unit tests
 ./scripts/run_tests
+
+# Run integration tests
+./scripts/run_integration_tests

--- a/tests/api/BUILD
+++ b/tests/api/BUILD
@@ -11,6 +11,7 @@ ts_test_suite(
         "//tests/api/projects/never_finishes_compiling:files",
         "//tests/api/projects/never_finishes_compiling:node_modules",
     ],
+    tags = ["integration"],
     deps = [
         "//cli/api",
         "//cli/api/utils",

--- a/tests/integration/BUILD
+++ b/tests/integration/BUILD
@@ -1,18 +1,19 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//testing:index.bzl", "ts_test_suite")
+
+package(default_visibility = ["//visibility:public"])
 
 ts_test_suite(
     name = "tests",
     srcs = [
-        "utils.ts",
         "bigquery.spec.ts",
+        "utils.ts",
     ],
     data = [
         "//test_credentials:bigquery.json",
         "//tests/integration/bigquery_project:files",
         "//tests/integration/bigquery_project:node_modules",
     ],
+    tags = ["integration"],
     deps = [
         "//cli/api",
         "//cli/api/utils",


### PR DESCRIPTION
At the moment external contributors can't run integration tests because they have no access to the GCP project used for tests. Split allows external contributors to run `./scripts/run_tests` without any issues (in fact only unit tests will run). Integration tests will run on PR.

Related issue: #1755
