### PR TITLE
Remove unused import which broke unit tests.

### DIFF
--- a/core/actions/data_preparation.ts
+++ b/core/actions/data_preparation.ts
@@ -12,7 +12,6 @@ import {
   resolveActionsConfigFilename
 } from "df/core/utils";
 import { dataform } from "df/protos/ts";
-import {filename} from 'df/core/path';
 
 /**
  * @hidden


### PR DESCRIPTION
Currently unit tests are broken because #1895 introduced an unused import (I believe it was added by accident) in core/actions/data_preparations.ts