### PR TITLE
Fix publish type backwards compatibility

### DIFF
--- a/core/actions/incremental_table.ts
+++ b/core/actions/incremental_table.ts
@@ -178,16 +178,26 @@ export class IncrementalTable extends ActionBuilder<dataform.Table> {
    * functions.
    */
   public type(type: TableType) {
-    if (type === "table") {
-      return new Table(this.session, this.unverifiedConfig, this.configPath);
+    let newAction: View | Table;
+    switch (type) {
+      case "table":
+        newAction = new Table(this.session, this.unverifiedConfig, this.configPath);
+        break;
+      case "incremental":
+        return this;
+      case "view":
+        newAction = new View(this.session, this.unverifiedConfig, this.configPath);
+        break;
+      default:
+        new Error(`Unexpected table type: ${type}`);
     }
-    if (type === "incremental") {
-      return new IncrementalTable(this.session, this.unverifiedConfig, this.configPath);
+    const existingAction = this.session.actions.indexOf(this);
+    if (existingAction == -1) {
+      throw Error(
+        "Expected pre-existing action, but none found. Please report this to the Dataform team."
+      );
     }
-    if (type === "view") {
-      return new View(this.session, this.unverifiedConfig, this.configPath);
-    }
-    throw new Error(`Unexpected table type: ${type}`);
+    this.session.actions[existingAction] = newAction;
   }
 
   public query(query: Contextable<ITableContext, string>) {

--- a/core/actions/incremental_table.ts
+++ b/core/actions/incremental_table.ts
@@ -8,6 +8,8 @@ import {
   TableType
 } from "df/core/actions";
 import { Assertion } from "df/core/actions/assertion";
+import { Table } from "df/core/actions/table";
+import { View } from "df/core/actions/view";
 import { ColumnDescriptors } from "df/core/column_descriptors";
 import { Contextable, Resolvable } from "df/core/common";
 import * as Path from "df/core/path";
@@ -26,8 +28,6 @@ import {
   validateQueryString
 } from "df/core/utils";
 import { dataform } from "df/protos/ts";
-import { View } from "df/core/actions/view";
-import { Table } from "df/core/actions/table";
 
 /**
  * @hidden
@@ -40,9 +40,6 @@ export class IncrementalTable extends ActionBuilder<dataform.Table> {
     disabled: false,
     tags: []
   });
-
-  private unverifiedConfig: any;
-  private configPath: string | undefined;
 
   // Hold a reference to the Session instance.
   public session: Session;
@@ -58,6 +55,9 @@ export class IncrementalTable extends ActionBuilder<dataform.Table> {
 
   private uniqueKeyAssertions: Assertion[] = [];
   private rowConditionsAssertion: Assertion;
+
+  private unverifiedConfig: any;
+  private configPath: string | undefined;
 
   constructor(session?: Session, unverifiedConfig?: any, configPath?: string) {
     super(session);
@@ -183,7 +183,7 @@ export class IncrementalTable extends ActionBuilder<dataform.Table> {
         throw new Error(`Unexpected table type: ${type}`);
     }
     const existingAction = this.session.actions.indexOf(this);
-    if (existingAction == -1) {
+    if (existingAction === -1) {
       throw Error(
         "Expected pre-existing action, but none found. Please report this to the Dataform team."
       );

--- a/core/actions/incremental_table.ts
+++ b/core/actions/incremental_table.ts
@@ -25,6 +25,8 @@ import {
   validateQueryString
 } from "df/core/utils";
 import { dataform } from "df/protos/ts";
+import { View } from "df/core/actions/view";
+import { Table } from "df/core/actions/table";
 
 /**
  * @hidden
@@ -176,12 +178,16 @@ export class IncrementalTable extends ActionBuilder<dataform.Table> {
    * functions.
    */
   public type(type: TableType) {
-    return LegacyConfigConverter.resetTableType(
-      type,
-      this.session,
-      this.unverifiedConfig,
-      this.configPath
-    );
+    if (type === "table") {
+      return new Table(this.session, this.unverifiedConfig, this.configPath);
+    }
+    if (type === "incremental") {
+      return new IncrementalTable(this.session, this.unverifiedConfig, this.configPath);
+    }
+    if (type === "view") {
+      return new View(this.session, this.unverifiedConfig, this.configPath);
+    }
+    throw new Error(`Unexpected table type: ${type}`);
   }
 
   public query(query: Contextable<ITableContext, string>) {

--- a/core/actions/incremental_table.ts
+++ b/core/actions/incremental_table.ts
@@ -62,8 +62,9 @@ export class IncrementalTable extends ActionBuilder<dataform.Table> {
   constructor(session?: Session, unverifiedConfig?: any, configPath?: string) {
     super(session);
     this.session = session;
-    this.unverifiedConfig = unverifiedConfig;
     this.configPath = configPath;
+    // A copy is used here to prevent manipulation of the original.
+    this.unverifiedConfig = Object.assign({}, unverifiedConfig);
 
     if (!unverifiedConfig) {
       return;
@@ -163,15 +164,23 @@ export class IncrementalTable extends ActionBuilder<dataform.Table> {
     let newAction: View | Table;
     switch (type) {
       case "table":
-        newAction = new Table(this.session, this.unverifiedConfig, this.configPath);
+        newAction = new Table(
+          this.session,
+          { ...this.unverifiedConfig, type: "table" },
+          this.configPath
+        );
         break;
       case "incremental":
         return this;
       case "view":
-        newAction = new View(this.session, this.unverifiedConfig, this.configPath);
+        newAction = new View(
+          this.session,
+          { ...this.unverifiedConfig, type: "view" },
+          this.configPath
+        );
         break;
       default:
-        new Error(`Unexpected table type: ${type}`);
+        throw new Error(`Unexpected table type: ${type}`);
     }
     const existingAction = this.session.actions.indexOf(this);
     if (existingAction == -1) {

--- a/core/actions/incremental_table.ts
+++ b/core/actions/incremental_table.ts
@@ -176,7 +176,7 @@ export class IncrementalTable extends ActionBuilder<dataform.Table> {
    * functions.
    */
   public type(type: TableType) {
-    LegacyConfigConverter.resetTableType(
+    return LegacyConfigConverter.resetTableType(
       type,
       this.session,
       this.unverifiedConfig,

--- a/core/actions/index.ts
+++ b/core/actions/index.ts
@@ -212,29 +212,6 @@ export class LegacyConfigConverter {
     }
     return legacyConfig;
   }
-
-  // Used by the deprecated `.type()` method.
-  public static resetTableType(
-    type: TableType,
-    session: Session,
-    unverifiedConfig: any,
-    configPath?: string
-  ) {
-    console.log("🚀 ~ LegacyConfigConverter ~ configPath:", configPath);
-    console.log("🚀 ~ LegacyConfigConverter ~ unverifiedConfig:", unverifiedConfig);
-    console.log("🚀 ~ LegacyConfigConverter ~ session:", session);
-    console.log("🚀 ~ LegacyConfigConverter ~ type:", type);
-    if (type === "table") {
-      return new Table(session, unverifiedConfig, configPath);
-    }
-    if (type === "incremental") {
-      return new IncrementalTable(session, unverifiedConfig, configPath);
-    }
-    if (type === "view") {
-      return new View(session, unverifiedConfig, configPath);
-    }
-    throw new Error(`Unexpected table type: ${type}`);
-  }
 }
 
 export interface ILegacyTableBigqueryConfig {

--- a/core/actions/index.ts
+++ b/core/actions/index.ts
@@ -213,7 +213,7 @@ export class LegacyConfigConverter {
     unverifiedConfig: T
   ): T {
     // Type `any` is used here to facilitate the type hacking for legacy compatibility.
-    let legacyConfig: any = unverifiedConfig;
+    const legacyConfig: any = unverifiedConfig;
     if (legacyConfig?.assertions) {
       if (typeof legacyConfig.assertions?.uniqueKey === "string") {
         legacyConfig.assertions.uniqueKey = [legacyConfig.assertions.uniqueKey];
@@ -236,7 +236,7 @@ export class LegacyConfigConverter {
     unverifiedConfig: T
   ): T {
     // Type `any` is used here to facilitate the type hacking for legacy compatibility.
-    let legacyConfig: any = unverifiedConfig;
+    const legacyConfig: any = unverifiedConfig;
     if (!legacyConfig?.bigquery) {
       return legacyConfig;
     }

--- a/core/actions/index.ts
+++ b/core/actions/index.ts
@@ -233,6 +233,7 @@ export class LegacyConfigConverter {
     if (type === "view") {
       return new View(session, unverifiedConfig, configPath);
     }
+    throw new Error(`Unexpected table type: ${type}`);
   }
 }
 

--- a/core/actions/index.ts
+++ b/core/actions/index.ts
@@ -114,6 +114,18 @@ export interface ITableContext extends ICommonContext {
   incremental: () => boolean;
 }
 
+/**
+ * @hidden
+ * @deprecated
+ * TODO(ekrekr): remove these in favor of the proto enum.
+ */
+export const TableType = ["table", "view", "incremental"] as const;
+/**
+ * @hidden
+ * @deprecated
+ */
+export type TableType = typeof TableType[number];
+
 export class LegacyConfigConverter {
   // This is a workaround to make bigquery options output empty fields with the same behaviour as
   // they did previously.
@@ -199,6 +211,28 @@ export class LegacyConfigConverter {
       delete legacyConfig.bigquery;
     }
     return legacyConfig;
+  }
+
+  // Used by the deprecated `.type()` method.
+  public static resetTableType(
+    type: TableType,
+    session: Session,
+    unverifiedConfig: any,
+    configPath?: string
+  ) {
+    console.log("🚀 ~ LegacyConfigConverter ~ configPath:", configPath);
+    console.log("🚀 ~ LegacyConfigConverter ~ unverifiedConfig:", unverifiedConfig);
+    console.log("🚀 ~ LegacyConfigConverter ~ session:", session);
+    console.log("🚀 ~ LegacyConfigConverter ~ type:", type);
+    if (type === "table") {
+      return new Table(session, unverifiedConfig, configPath);
+    }
+    if (type === "incremental") {
+      return new IncrementalTable(session, unverifiedConfig, configPath);
+    }
+    if (type === "view") {
+      return new View(session, unverifiedConfig, configPath);
+    }
   }
 }
 

--- a/core/actions/index.ts
+++ b/core/actions/index.ts
@@ -1,12 +1,19 @@
 import { Assertion } from "df/core/actions/assertion";
 import { DataPreparation } from "df/core/actions/data_preparation";
 import { Declaration } from "df/core/actions/declaration";
-import { ILegacyIncrementalTableConfig, IncrementalTable } from "df/core/actions/incremental_table";
+import { IncrementalTable } from "df/core/actions/incremental_table";
 import { Notebook } from "df/core/actions/notebook";
 import { Operation } from "df/core/actions/operation";
-import { ILegacyTableConfig, Table } from "df/core/actions/table";
-import { ILegacyViewConfig, View } from "df/core/actions/view";
-import { ICommonContext } from "df/core/common";
+import { Table } from "df/core/actions/table";
+import { View } from "df/core/actions/view";
+import {
+  IActionConfig,
+  ICommonContext,
+  IDependenciesConfig,
+  IDocumentableConfig,
+  INamedConfig,
+  ITargetableConfig
+} from "df/core/common";
 import { Session } from "df/core/session";
 import { dataform } from "df/protos/ts";
 
@@ -117,14 +124,67 @@ export interface ITableContext extends ICommonContext {
 /**
  * @hidden
  * @deprecated
- * TODO(ekrekr): remove these in favor of the proto enum.
+ * This is no longer needed other than for legacy backwards compatibility purposes, as tables are
+ * now configured in separate actions.
  */
-export const TableType = ["table", "view", "incremental"] as const;
+export type TableType = typeof TableType[number];
+
 /**
  * @hidden
  * @deprecated
+ * This is no longer needed other than for legacy backwards compatibility purposes, as tables are
+ * now configured in separate actions.
  */
-export type TableType = typeof TableType[number];
+export const TableType = ["table", "view", "incremental"] as const;
+
+/**
+ * @hidden
+ * @deprecated
+ * These options are only here to preserve backwards compatibility of legacy config options.
+ * consider breaking backwards compatability of this in v4.
+ */
+export interface ILegacyTableConfig
+  extends IActionConfig,
+    IDependenciesConfig,
+    IDocumentableConfig,
+    INamedConfig,
+    ITargetableConfig {
+  type?: TableType;
+  protected?: boolean;
+  bigquery?: ILegacyBigQueryOptions;
+  assertions?: ILegacyTableAssertions;
+  uniqueKey?: string[];
+  materialized?: boolean;
+}
+
+/**
+ * @hidden
+ * @deprecated
+ * These options are only here to preserve backwards compatibility of legacy config options.
+ * consider breaking backwards compatability of this in v4.
+ */
+export interface ILegacyBigQueryOptions {
+  partitionBy?: string;
+  clusterBy?: string[];
+  updatePartitionFilter?: string;
+  labels?: { [name: string]: string };
+  partitionExpirationDays?: number;
+  requirePartitionFilter?: boolean;
+  additionalOptions?: { [name: string]: string };
+}
+
+/**
+ * @hidden
+ * @deprecated
+ * These options are only here to preserve backwards compatibility of legacy config options.
+ * consider breaking backwards compatability of this in v4.
+ */
+export interface ILegacyTableAssertions {
+  uniqueKey?: string | string[];
+  uniqueKeys?: string[][];
+  nonNull?: string | string[];
+  rowConditions?: string[];
+}
 
 export class LegacyConfigConverter {
   // This is a workaround to make bigquery options output empty fields with the same behaviour as
@@ -149,9 +209,11 @@ export class LegacyConfigConverter {
     return bigqueryFiltered;
   }
 
-  public static insertLegacyInlineAssertionsToConfigProto<
-    T extends ILegacyTableConfig | ILegacyIncrementalTableConfig | ILegacyViewConfig
-  >(legacyConfig: T): T {
+  public static insertLegacyInlineAssertionsToConfigProto<T extends ILegacyTableConfig>(
+    unverifiedConfig: T
+  ): T {
+    // Type `any` is used here to facilitate the type hacking for legacy compatibility.
+    let legacyConfig: any = unverifiedConfig;
     if (legacyConfig?.assertions) {
       if (typeof legacyConfig.assertions?.uniqueKey === "string") {
         legacyConfig.assertions.uniqueKey = [legacyConfig.assertions.uniqueKey];
@@ -170,9 +232,11 @@ export class LegacyConfigConverter {
     return legacyConfig;
   }
 
-  public static insertLegacyBigQueryOptionsToConfigProto<
-    T extends ILegacyTableConfig | ILegacyIncrementalTableConfig
-  >(legacyConfig: T): T {
+  public static insertLegacyBigQueryOptionsToConfigProto<T extends ILegacyTableConfig>(
+    unverifiedConfig: T
+  ): T {
+    // Type `any` is used here to facilitate the type hacking for legacy compatibility.
+    let legacyConfig: any = unverifiedConfig;
     if (!legacyConfig?.bigquery) {
       return legacyConfig;
     }
@@ -185,8 +249,7 @@ export class LegacyConfigConverter {
       delete legacyConfig.bigquery.clusterBy;
     }
     if (!!legacyConfig.bigquery.updatePartitionFilter) {
-      (legacyConfig as ILegacyIncrementalTableConfig).updatePartitionFilter =
-        legacyConfig.bigquery.updatePartitionFilter;
+      legacyConfig.updatePartitionFilter = legacyConfig.bigquery.updatePartitionFilter;
       delete legacyConfig.bigquery.updatePartitionFilter;
     }
     if (!!legacyConfig.bigquery.labels) {
@@ -212,14 +275,4 @@ export class LegacyConfigConverter {
     }
     return legacyConfig;
   }
-}
-
-export interface ILegacyTableBigqueryConfig {
-  partitionBy?: string;
-  clusterBy?: string[];
-  updatePartitionFilter?: string;
-  labels?: { [key: string]: string };
-  partitionExpirationDays?: number;
-  requirePartitionFilter?: boolean;
-  additionalOptions?: { [key: string]: string };
 }

--- a/core/actions/table.ts
+++ b/core/actions/table.ts
@@ -156,7 +156,7 @@ export class Table extends ActionBuilder<dataform.Table> {
    * functions.
    */
   public type(type: TableType) {
-    LegacyConfigConverter.resetTableType(
+    return LegacyConfigConverter.resetTableType(
       type,
       this.session,
       this.unverifiedConfig,

--- a/core/actions/table.ts
+++ b/core/actions/table.ts
@@ -8,6 +8,8 @@ import {
   TableType
 } from "df/core/actions";
 import { Assertion } from "df/core/actions/assertion";
+import { IncrementalTable } from "df/core/actions/incremental_table";
+import { View } from "df/core/actions/view";
 import { ColumnDescriptors } from "df/core/column_descriptors";
 import { Contextable, Resolvable } from "df/core/common";
 import * as Path from "df/core/path";
@@ -25,8 +27,6 @@ import {
   validateQueryString
 } from "df/core/utils";
 import { dataform } from "df/protos/ts";
-import { View } from "df/core/actions/view";
-import { IncrementalTable } from "./incremental_table";
 
 /**
  * @hidden
@@ -39,9 +39,6 @@ export class Table extends ActionBuilder<dataform.Table> {
     disabled: false,
     tags: []
   });
-
-  private unverifiedConfig: any;
-  private configPath: string | undefined;
 
   // Hold a reference to the Session instance.
   public session: Session;
@@ -57,6 +54,9 @@ export class Table extends ActionBuilder<dataform.Table> {
 
   private uniqueKeyAssertions: Assertion[] = [];
   private rowConditionsAssertion: Assertion;
+
+  private unverifiedConfig: any;
+  private configPath: string | undefined;
 
   constructor(session?: Session, unverifiedConfig?: any, configPath?: string) {
     super(session);
@@ -165,7 +165,7 @@ export class Table extends ActionBuilder<dataform.Table> {
         throw new Error(`Unexpected table type: ${type}`);
     }
     const existingAction = this.session.actions.indexOf(this);
-    if (existingAction == -1) {
+    if (existingAction === -1) {
       throw Error(
         "Expected pre-existing action, but none found. Please report this to the Dataform team."
       );

--- a/core/actions/table.ts
+++ b/core/actions/table.ts
@@ -24,6 +24,8 @@ import {
   validateQueryString
 } from "df/core/utils";
 import { dataform } from "df/protos/ts";
+import { IncrementalTable } from "df/core/actions/incremental_table";
+import { View } from "df/core/actions/view";
 
 /**
  * @hidden
@@ -156,12 +158,16 @@ export class Table extends ActionBuilder<dataform.Table> {
    * functions.
    */
   public type(type: TableType) {
-    return LegacyConfigConverter.resetTableType(
-      type,
-      this.session,
-      this.unverifiedConfig,
-      this.configPath
-    );
+    if (type === "table") {
+      return new Table(this.session, this.unverifiedConfig, this.configPath);
+    }
+    if (type === "incremental") {
+      return new IncrementalTable(this.session, this.unverifiedConfig, this.configPath);
+    }
+    if (type === "view") {
+      return new View(this.session, this.unverifiedConfig, this.configPath);
+    }
+    throw new Error(`Unexpected table type: ${type}`);
   }
 
   public query(query: Contextable<ITableContext, string>) {

--- a/core/actions/table.ts
+++ b/core/actions/table.ts
@@ -158,16 +158,26 @@ export class Table extends ActionBuilder<dataform.Table> {
    * functions.
    */
   public type(type: TableType) {
-    if (type === "table") {
-      return new Table(this.session, this.unverifiedConfig, this.configPath);
+    let newAction: View | Table;
+    switch (type) {
+      case "table":
+        return this;
+      case "incremental":
+        newAction = new Table(this.session, this.unverifiedConfig, this.configPath);
+        break;
+      case "view":
+        newAction = new View(this.session, this.unverifiedConfig, this.configPath);
+        break;
+      default:
+        new Error(`Unexpected table type: ${type}`);
     }
-    if (type === "incremental") {
-      return new IncrementalTable(this.session, this.unverifiedConfig, this.configPath);
+    const existingAction = this.session.actions.indexOf(this);
+    if (existingAction == -1) {
+      throw Error(
+        "Expected pre-existing action, but none found. Please report this to the Dataform team."
+      );
     }
-    if (type === "view") {
-      return new View(this.session, this.unverifiedConfig, this.configPath);
-    }
-    throw new Error(`Unexpected table type: ${type}`);
+    this.session.actions[existingAction] = newAction;
   }
 
   public query(query: Contextable<ITableContext, string>) {

--- a/core/actions/test.ts
+++ b/core/actions/test.ts
@@ -1,7 +1,7 @@
 import { verifyObjectMatchesProto, VerifyProtoErrorBehaviour } from "df/common/protos";
 import { StringifiedMap } from "df/common/strings/stringifier";
-import { ActionBuilder, ITableContext } from "df/core/actions";
-import * as table from "df/core/actions/table";
+import { ActionBuilder, ITableContext, TableType } from "df/core/actions";
+import { Table } from "df/core/actions/table";
 import { View } from "df/core/actions/view";
 import { Contextable, ICommonContext, INamedConfig, Resolvable } from "df/core/common";
 import { Session } from "df/core/session";
@@ -107,7 +107,7 @@ export class Test extends ActionBuilder<dataform.Test> {
         );
       }
       const dataset = allResolved.length > 0 ? allResolved[0] : undefined;
-      if (!(dataset && (dataset instanceof table.Table || dataset instanceof View))) {
+      if (!(dataset && (dataset instanceof Table || dataset instanceof View))) {
         this.session.compileError(
           new Error(`Dataset ${stringifyResolvable(this.datasetToTest)} could not be found.`),
           this.proto.fileName
@@ -201,7 +201,7 @@ class RefReplacingContext implements ITableContext {
     return "";
   }
 
-  public type(type: table.TableType) {
+  public type(type: TableType) {
     return "";
   }
 

--- a/core/actions/view.ts
+++ b/core/actions/view.ts
@@ -170,7 +170,7 @@ export class View extends ActionBuilder<dataform.Table> {
    * functions.
    */
   public type(type: TableType) {
-    LegacyConfigConverter.resetTableType(
+    return LegacyConfigConverter.resetTableType(
       type,
       this.session,
       this.unverifiedConfig,

--- a/core/actions/view.ts
+++ b/core/actions/view.ts
@@ -7,6 +7,8 @@ import {
   TableType
 } from "df/core/actions";
 import { Assertion } from "df/core/actions/assertion";
+import { IncrementalTable } from "df/core/actions/incremental_table";
+import { Table } from "df/core/actions/table";
 import { ColumnDescriptors } from "df/core/column_descriptors";
 import { Contextable, Resolvable } from "df/core/common";
 import * as Path from "df/core/path";
@@ -25,8 +27,6 @@ import {
   validateQueryString
 } from "df/core/utils";
 import { dataform } from "df/protos/ts";
-import { Table } from "./table";
-import { IncrementalTable } from "./incremental_table";
 
 /**
  * @hidden
@@ -51,9 +51,6 @@ export class View extends ActionBuilder<dataform.Table> {
     tags: []
   });
 
-  private unverifiedConfig: any;
-  private configPath: string | undefined;
-
   // Hold a reference to the Session instance.
   public session: Session;
 
@@ -68,6 +65,9 @@ export class View extends ActionBuilder<dataform.Table> {
 
   private uniqueKeyAssertions: Assertion[] = [];
   private rowConditionsAssertion: Assertion;
+
+  private unverifiedConfig: any;
+  private configPath: string | undefined;
 
   constructor(session?: Session, unverifiedConfig?: any, configPath?: string) {
     super(session);
@@ -185,7 +185,7 @@ export class View extends ActionBuilder<dataform.Table> {
         throw new Error(`Unexpected table type: ${type}`);
     }
     const existingAction = this.session.actions.indexOf(this);
-    if (existingAction == -1) {
+    if (existingAction === -1) {
       throw Error(
         "Expected pre-existing action, but none found. Please report this to the Dataform team."
       );

--- a/core/actions/view.ts
+++ b/core/actions/view.ts
@@ -1,5 +1,5 @@
 import { verifyObjectMatchesProto, VerifyProtoErrorBehaviour } from "df/common/protos";
-import { ActionBuilder, ITableContext, LegacyConfigConverter } from "df/core/actions";
+import { ActionBuilder, ITableContext, LegacyConfigConverter, TableType } from "df/core/actions";
 import { Assertion } from "df/core/actions/assertion";
 import { ColumnDescriptors } from "df/core/column_descriptors";
 import { Contextable, Resolvable } from "df/core/common";
@@ -59,6 +59,9 @@ export class View extends ActionBuilder<dataform.Table> {
     tags: []
   });
 
+  private unverifiedConfig: any;
+  private configPath: string | undefined;
+
   // Hold a reference to the Session instance.
   public session: Session;
 
@@ -77,6 +80,8 @@ export class View extends ActionBuilder<dataform.Table> {
   constructor(session?: Session, unverifiedConfig?: any, configPath?: string) {
     super(session);
     this.session = session;
+    this.unverifiedConfig = unverifiedConfig;
+    this.configPath = configPath;
 
     if (!unverifiedConfig) {
       return;
@@ -156,6 +161,21 @@ export class View extends ActionBuilder<dataform.Table> {
     }
 
     return this;
+  }
+
+  /**
+   * @hidden
+   * @deprecated
+   * Deprecated in favor of action type can being set in the configs passed to action constructor
+   * functions.
+   */
+  public type(type: TableType) {
+    LegacyConfigConverter.resetTableType(
+      type,
+      this.session,
+      this.unverifiedConfig,
+      this.configPath
+    );
   }
 
   public query(query: Contextable<ITableContext, string>) {

--- a/core/actions/view.ts
+++ b/core/actions/view.ts
@@ -19,6 +19,8 @@ import {
   validateQueryString
 } from "df/core/utils";
 import { dataform } from "df/protos/ts";
+import { Table } from "./table";
+import { IncrementalTable } from "./incremental_table";
 
 /**
  * @hidden
@@ -170,12 +172,16 @@ export class View extends ActionBuilder<dataform.Table> {
    * functions.
    */
   public type(type: TableType) {
-    return LegacyConfigConverter.resetTableType(
-      type,
-      this.session,
-      this.unverifiedConfig,
-      this.configPath
-    );
+    if (type === "table") {
+      return new Table(this.session, this.unverifiedConfig, this.configPath);
+    }
+    if (type === "incremental") {
+      return new IncrementalTable(this.session, this.unverifiedConfig, this.configPath);
+    }
+    if (type === "view") {
+      return new View(this.session, this.unverifiedConfig, this.configPath);
+    }
+    throw new Error(`Unexpected table type: ${type}`);
   }
 
   public query(query: Contextable<ITableContext, string>) {

--- a/core/actions/view.ts
+++ b/core/actions/view.ts
@@ -172,16 +172,26 @@ export class View extends ActionBuilder<dataform.Table> {
    * functions.
    */
   public type(type: TableType) {
-    if (type === "table") {
-      return new Table(this.session, this.unverifiedConfig, this.configPath);
+    let newAction: IncrementalTable | Table;
+    switch (type) {
+      case "table":
+        newAction = new Table(this.session, this.unverifiedConfig, this.configPath);
+        break;
+      case "incremental":
+        newAction = new IncrementalTable(this.session, this.unverifiedConfig, this.configPath);
+        break;
+      case "view":
+        return this;
+      default:
+        new Error(`Unexpected table type: ${type}`);
     }
-    if (type === "incremental") {
-      return new IncrementalTable(this.session, this.unverifiedConfig, this.configPath);
+    const existingAction = this.session.actions.indexOf(this);
+    if (existingAction == -1) {
+      throw Error(
+        "Expected pre-existing action, but none found. Please report this to the Dataform team."
+      );
     }
-    if (type === "view") {
-      return new View(this.session, this.unverifiedConfig, this.configPath);
-    }
-    throw new Error(`Unexpected table type: ${type}`);
+    this.session.actions[existingAction] = newAction;
   }
 
   public query(query: Contextable<ITableContext, string>) {

--- a/core/actions/view.ts
+++ b/core/actions/view.ts
@@ -72,8 +72,9 @@ export class View extends ActionBuilder<dataform.Table> {
   constructor(session?: Session, unverifiedConfig?: any, configPath?: string) {
     super(session);
     this.session = session;
-    this.unverifiedConfig = unverifiedConfig;
     this.configPath = configPath;
+    // A copy is used here to prevent manipulation of the original.
+    this.unverifiedConfig = Object.assign({}, unverifiedConfig);
 
     if (!unverifiedConfig) {
       return;
@@ -165,15 +166,23 @@ export class View extends ActionBuilder<dataform.Table> {
     let newAction: IncrementalTable | Table;
     switch (type) {
       case "table":
-        newAction = new Table(this.session, this.unverifiedConfig, this.configPath);
+        newAction = new Table(
+          this.session,
+          { ...this.unverifiedConfig, type: "table" },
+          this.configPath
+        );
         break;
       case "incremental":
-        newAction = new IncrementalTable(this.session, this.unverifiedConfig, this.configPath);
+        newAction = new IncrementalTable(
+          this.session,
+          { ...this.unverifiedConfig, type: "incremental" },
+          this.configPath
+        );
         break;
       case "view":
         return this;
       default:
-        new Error(`Unexpected table type: ${type}`);
+        throw new Error(`Unexpected table type: ${type}`);
     }
     const existingAction = this.session.actions.indexOf(this);
     if (existingAction == -1) {

--- a/core/common.ts
+++ b/core/common.ts
@@ -61,6 +61,8 @@ export interface ICommonContext {
 
 /**
  * @hidden
+ * @deprecated
+ * Use core.proto config options instead.
  */
 export interface INamedConfig {
   /**
@@ -80,6 +82,8 @@ export interface INamedConfig {
 
 /**
  * @hidden
+ * @deprecated
+ * Use core.proto config options instead.
  */
 export interface IActionConfig {
   /**
@@ -103,6 +107,8 @@ export interface IActionConfig {
 
 /**
  * @hidden
+ * @deprecated
+ * Use core.proto config options instead.
  */
 export interface ITargetableConfig {
   /**
@@ -118,6 +124,8 @@ export interface ITargetableConfig {
 
 /**
  * @hidden
+ * @deprecated
+ * Use core.proto config options instead.
  */
 export interface IDependenciesConfig {
   /**
@@ -144,6 +152,8 @@ export interface IDependenciesConfig {
 
 /**
  * @hidden
+ * @deprecated
+ * Use core.proto config options instead.
  */
 export interface IDocumentableConfig {
   /**
@@ -158,6 +168,8 @@ export interface IDocumentableConfig {
 }
 
 /**
+ * @deprecated
+ * Use core.proto config options instead.
  * Describes columns in a dataset.
  */
 export interface IColumnsDescriptor {
@@ -165,6 +177,8 @@ export interface IColumnsDescriptor {
 }
 
 /**
+ * @deprecated
+ * Use core.proto config options instead.
  * Describes a struct, object or record in a dataset that has nested columns.
  */
 export interface IRecordDescriptor {
@@ -205,8 +219,8 @@ export interface IRecordDescriptor {
 
 /**
  * @hidden
- *
- * TODO: This needs to be a method, I'm really not sure why, but it hits a runtime failure otherwise.
+ * @deprecated
+ * Use core.proto config options instead.
  */
 export const IRecordDescriptorProperties = () =>
   strictKeysOf<IRecordDescriptor>()([
@@ -218,6 +232,8 @@ export const IRecordDescriptorProperties = () =>
   ]);
 
 /**
+ * @deprecated
+ * Use core.proto config options instead.
  * A reference to a dataset within the warehouse.
  */
 export interface ITarget {

--- a/core/main_test.ts
+++ b/core/main_test.ts
@@ -1058,7 +1058,8 @@ defaultNotebookRuntimeOptions:
         defaultLocation: "US",
         defaultNotebookRuntimeOptions: {
           outputBucket: "gs://some-bucket",
-          runtimeTemplateName: "projects/test-project/locations/us-central1/notebookRuntimeTemplates/test-template"
+          runtimeTemplateName:
+            "projects/test-project/locations/us-central1/notebookRuntimeTemplates/test-template"
         },
         warehouse: "bigquery"
       });
@@ -1068,7 +1069,7 @@ defaultNotebookRuntimeOptions:
   suite("data preparations", () => {
     const createSimpleDataPreparationProject = (
       workflowSettingsYaml = VALID_WORKFLOW_SETTINGS_YAML,
-      writeActionsYaml = true,
+      writeActionsYaml = true
     ): string => {
       const projectDir = tmpDirFixture.createNewTmpDir();
       fs.writeFileSync(path.join(projectDir, "workflow_settings.yaml"), workflowSettingsYaml);
@@ -1092,44 +1093,44 @@ defaultNotebookRuntimeOptions:
 `;
 
       fs.writeFileSync(
-          path.join(projectDir, "definitions/data_preparation.dp.yaml"),
-          dataPreparationYaml
+        path.join(projectDir, "definitions/data_preparation.dp.yaml"),
+        dataPreparationYaml
       );
 
       const result = runMainInVm(coreExecutionRequestFromPath(projectDir));
 
       expect(result.compile.compiledGraph.graphErrors.compilationErrors).deep.equals([]);
       expect(asPlainObject(result.compile.compiledGraph.dataPreparations)).deep.equals(
-          asPlainObject([
-            {
-              target: {
+        asPlainObject([
+          {
+            target: {
+              database: "defaultProject",
+              schema: "defaultDataset",
+              name: "data_preparation"
+            },
+            canonicalTarget: {
+              database: "defaultProject",
+              schema: "defaultDataset",
+              name: "data_preparation"
+            },
+            targets: [
+              {
                 database: "defaultProject",
                 schema: "defaultDataset",
                 name: "data_preparation"
-              },
-              canonicalTarget: {
+              }
+            ],
+            canonicalTargets: [
+              {
                 database: "defaultProject",
                 schema: "defaultDataset",
                 name: "data_preparation"
-              },
-              targets: [
-                {
-                  database: "defaultProject",
-                  schema: "defaultDataset",
-                  name: "data_preparation"
-                }
-              ],
-              canonicalTargets: [
-                {
-                  database: "defaultProject",
-                  schema: "defaultDataset",
-                  name: "data_preparation"
-                }
-              ],
-              fileName: "definitions/data_preparation.dp.yaml",
-              dataPreparationYaml: ""
-            }
-          ])
+              }
+            ],
+            fileName: "definitions/data_preparation.dp.yaml",
+            dataPreparationYaml: ""
+          }
+        ])
       );
     });
 
@@ -1159,44 +1160,44 @@ nodes:
 `;
 
       fs.writeFileSync(
-          path.join(projectDir, "definitions/data_preparation.dp.yaml"),
-          dataPreparationYaml
+        path.join(projectDir, "definitions/data_preparation.dp.yaml"),
+        dataPreparationYaml
       );
 
       const result = runMainInVm(coreExecutionRequestFromPath(projectDir));
 
       expect(result.compile.compiledGraph.graphErrors.compilationErrors).deep.equals([]);
       expect(asPlainObject(result.compile.compiledGraph.dataPreparations)).deep.equals(
-          asPlainObject([
-            {
-              target: {
+        asPlainObject([
+          {
+            target: {
+              database: "defaultProject",
+              schema: "defaultDataset",
+              name: "data_preparation"
+            },
+            canonicalTarget: {
+              database: "defaultProject",
+              schema: "defaultDataset",
+              name: "data_preparation"
+            },
+            targets: [
+              {
                 database: "defaultProject",
                 schema: "defaultDataset",
                 name: "data_preparation"
-              },
-              canonicalTarget: {
+              }
+            ],
+            canonicalTargets: [
+              {
                 database: "defaultProject",
                 schema: "defaultDataset",
                 name: "data_preparation"
-              },
-              targets: [
-                {
-                  database: "defaultProject",
-                  schema: "defaultDataset",
-                  name: "data_preparation"
-                }
-              ],
-              canonicalTargets: [
-                {
-                  database: "defaultProject",
-                  schema: "defaultDataset",
-                  name: "data_preparation"
-                }
-              ],
-              fileName: "definitions/data_preparation.dp.yaml",
-              dataPreparationYaml: dumpYaml(loadYaml(dataPreparationYaml))
-            }
-          ])
+              }
+            ],
+            fileName: "definitions/data_preparation.dp.yaml",
+            dataPreparationYaml: dumpYaml(loadYaml(dataPreparationYaml))
+          }
+        ])
       );
     });
 
@@ -1277,7 +1278,7 @@ $\{when(true, "|> SELECT *", "|> SELECT 1")\}
               schema: "errorDs",
               name: "errorTable"
             },
-            errorTableRetentionDays: 0,
+            errorTableRetentionDays: 0
           }
         ])
       );
@@ -1299,18 +1300,18 @@ FROM x
 `;
 
       fs.writeFileSync(
-          path.join(projectDir, "definitions/data_preparation.sqlx"),
-          dataPreparationSqlx
+        path.join(projectDir, "definitions/data_preparation.sqlx"),
+        dataPreparationSqlx
       );
 
-      const coreExecutionRequest =  dataform.CoreExecutionRequest.create({
+      const coreExecutionRequest = dataform.CoreExecutionRequest.create({
         compile: {
           compileConfig: {
             projectDir,
             filePaths: ["definitions/data_preparation.sqlx"],
             projectConfigOverride: {
               defaultDatabase: "projectOverride",
-              defaultSchema: "datasetOverride",
+              defaultSchema: "datasetOverride"
             }
           }
         }
@@ -1320,52 +1321,52 @@ FROM x
 
       expect(result.compile.compiledGraph.graphErrors.compilationErrors).deep.equals([]);
       expect(asPlainObject(result.compile.compiledGraph.dataPreparations)).deep.equals(
-          asPlainObject([
-            {
-              target: {
+        asPlainObject([
+          {
+            target: {
+              database: "projectOverride",
+              schema: "datasetOverride",
+              name: "dest"
+            },
+            canonicalTarget: {
+              database: "projectOverride",
+              schema: "datasetOverride",
+              name: "dest"
+            },
+            targets: [
+              {
                 database: "projectOverride",
                 schema: "datasetOverride",
                 name: "dest"
               },
-              canonicalTarget: {
-                database: "projectOverride",
-                schema: "datasetOverride",
-                name: "dest"
-              },
-              targets: [
-                {
-                  database: "projectOverride",
-                  schema: "datasetOverride",
-                  name: "dest"
-                },
-                {
-                  database: "projectOverride",
-                  schema: "datasetOverride",
-                  name: "errorTable"
-                }
-              ],
-              canonicalTargets: [
-                {
-                  database: "projectOverride",
-                  schema: "datasetOverride",
-                  name: "dest"
-                },
-                {
-                  database: "projectOverride",
-                  schema: "datasetOverride",
-                  name: "errorTable"
-                }
-              ],
-              fileName: "definitions/data_preparation.sqlx",
-              query: "FROM x\n|> SELECT *",
-              errorTable: {
+              {
                 database: "projectOverride",
                 schema: "datasetOverride",
                 name: "errorTable"
+              }
+            ],
+            canonicalTargets: [
+              {
+                database: "projectOverride",
+                schema: "datasetOverride",
+                name: "dest"
               },
-              errorTableRetentionDays: 0,
-            }
-          ])
+              {
+                database: "projectOverride",
+                schema: "datasetOverride",
+                name: "errorTable"
+              }
+            ],
+            fileName: "definitions/data_preparation.sqlx",
+            query: "FROM x\n|> SELECT *",
+            errorTable: {
+              database: "projectOverride",
+              schema: "datasetOverride",
+              name: "errorTable"
+            },
+            errorTableRetentionDays: 0
+          }
+        ])
       );
     });
 
@@ -1436,7 +1437,7 @@ FROM x
               schema: "defaultDataset",
               name: "errorTable"
             },
-            errorTableRetentionDays: 0,
+            errorTableRetentionDays: 0
           }
         ])
       );
@@ -4072,7 +4073,7 @@ publish("name", {
                           incrementalPreOps: ["pre_op"],
                           incrementalQuery: "SELECT 1",
                           protected: true,
-                          onSchemaChange: "IGNORE",
+                          onSchemaChange: "IGNORE"
                         }
                       : {})
                   }
@@ -4137,7 +4138,7 @@ publish("name", {
                 ? {
                     incrementalQuery: "SELECT * FROM `defaultProject.defaultDataset.operation`",
                     protected: true,
-                    onSchemaChange: "IGNORE",
+                    onSchemaChange: "IGNORE"
                   }
                 : {})
             }
@@ -4501,6 +4502,25 @@ publish("name", {
           ).deep.equals([testParameters.expectedError]);
         });
       });
+    });
+
+    test(`legacy publish().type() can still be called`, () => {
+      const projectDir = tmpDirFixture.createNewTmpDir();
+      fs.writeFileSync(
+        path.join(projectDir, "workflow_settings.yaml"),
+        dumpYaml(dataform.WorkflowSettings.create(TestConfigs.bigqueryWithDefaultProjectAndDataset))
+      );
+      fs.mkdirSync(path.join(projectDir, "definitions"));
+      fs.writeFileSync(
+        path.join(projectDir, "definitions/publish.js"),
+        `
+  publish("name").type("incremental")`
+      );
+
+      const result = runMainInVm(coreExecutionRequestFromPath(projectDir));
+
+      expect(result.compile.compiledGraph.graphErrors.compilationErrors).deep.equals([]);
+      expect(asPlainObject(result.compile.compiledGraph.tables)).deep.equals(asPlainObject([]));
     });
   });
 });

--- a/core/main_test.ts
+++ b/core/main_test.ts
@@ -4514,7 +4514,7 @@ publish("name", {
       fs.writeFileSync(
         path.join(projectDir, "definitions/publish.js"),
         `
-  publish("name").type("incremental")`
+publish("name").type("incremental")`
       );
 
       const result = runMainInVm(coreExecutionRequestFromPath(projectDir));

--- a/core/main_test.ts
+++ b/core/main_test.ts
@@ -4514,13 +4514,34 @@ publish("name", {
       fs.writeFileSync(
         path.join(projectDir, "definitions/publish.js"),
         `
-publish("name").type("incremental")`
+publish("name", {schema: "schemaOverride"}).type("incremental")`
       );
 
       const result = runMainInVm(coreExecutionRequestFromPath(projectDir));
 
       expect(result.compile.compiledGraph.graphErrors.compilationErrors).deep.equals([]);
-      expect(asPlainObject(result.compile.compiledGraph.tables)).deep.equals(asPlainObject([]));
+      expect(asPlainObject(result.compile.compiledGraph.tables)).deep.equals(
+        asPlainObject([
+          {
+            canonicalTarget: {
+              database: "defaultProject",
+              name: "name",
+              schema: "schemaOverride"
+            },
+            disabled: false,
+            enumType: "INCREMENTAL",
+            hermeticity: "NON_HERMETIC",
+            onSchemaChange: "IGNORE",
+            protected: false,
+            target: {
+              database: "defaultProject_suffix",
+              name: "name",
+              schema: "schemaOverride"
+            },
+            type: "incremental"
+          }
+        ])
+      );
     });
   });
 });

--- a/core/session.ts
+++ b/core/session.ts
@@ -2,14 +2,18 @@ import { default as TarjanGraphConstructor, Graph as TarjanGraph } from "tarjan-
 
 import { encode64, verifyObjectMatchesProto, VerifyProtoErrorBehaviour } from "df/common/protos";
 import { StringifiedMap, StringifiedSet } from "df/common/strings/stringifier";
-import { Action, ITableContext } from "df/core/actions";
+import { Action, ITableContext, TableType } from "df/core/actions";
 import { AContextable, Assertion, AssertionContext } from "df/core/actions/assertion";
-import { DataPreparation, DataPreparationContext, IDataPreparationContext } from "df/core/actions/data_preparation";
+import {
+  DataPreparation,
+  DataPreparationContext,
+  IDataPreparationContext
+} from "df/core/actions/data_preparation";
 import { Declaration } from "df/core/actions/declaration";
 import { ILegacyIncrementalTableConfig, IncrementalTable } from "df/core/actions/incremental_table";
 import { Notebook } from "df/core/actions/notebook";
 import { Operation, OperationContext } from "df/core/actions/operation";
-import { ILegacyTableConfig, Table, TableContext, TableType } from "df/core/actions/table";
+import { ILegacyTableConfig, Table, TableContext } from "df/core/actions/table";
 import { Test } from "df/core/actions/test";
 import { ILegacyViewConfig, View } from "df/core/actions/view";
 import { Contextable, ICommonContext, ITarget, Resolvable } from "df/core/common";
@@ -93,7 +97,13 @@ export class Session {
     sqlxConfig: any;
     sqlStatementCount: number;
     sqlContextable: (
-      ctx: TableContext | AssertionContext | OperationContext | DataPreparationContext | IDataPreparationContext | ICommonContext
+      ctx:
+        | TableContext
+        | AssertionContext
+        | OperationContext
+        | DataPreparationContext
+        | IDataPreparationContext
+        | ICommonContext
     ) => string[];
     incrementalWhereContextable: (ctx: ITableContext) => string;
     preOperationsContextable: (ctx: ITableContext) => string[];
@@ -190,7 +200,9 @@ export class Session {
         break;
       case "dataPreparation":
         sqlxConfig.filename = utils.getCallerFile(this.rootDir);
-        const dataPreparation = new DataPreparation(this, sqlxConfig).query(ctx => actionOptions.sqlContextable(ctx)[0]);
+        const dataPreparation = new DataPreparation(this, sqlxConfig).query(
+          ctx => actionOptions.sqlContextable(ctx)[0]
+        );
         this.actions.push(dataPreparation);
         break;
       case "operations":
@@ -272,6 +284,7 @@ export class Session {
       | ILegacyViewConfig
       | ILegacyIncrementalTableConfig
   ): Table | IncrementalTable | View {
+    console.log("PUBLISH CALLED");
     let newTable: Table | IncrementalTable | View = new View(this, { type: "view", name });
     if (!!queryOrConfig) {
       if (typeof queryOrConfig === "object") {

--- a/core/session.ts
+++ b/core/session.ts
@@ -288,12 +288,12 @@ export class Session {
     let newTable: Table | IncrementalTable | View = new View(this, { type: "view", name });
     if (!!queryOrConfig) {
       if (typeof queryOrConfig === "object") {
-        if (queryOrConfig?.type === "table" || queryOrConfig.type === undefined) {
-          newTable = new Table(this, { type: "table", name, ...queryOrConfig });
+        if (queryOrConfig?.type === "view" || queryOrConfig.type === undefined) {
+          newTable = new View(this, { type: "view", name, ...queryOrConfig });
         } else if (queryOrConfig?.type === "incremental") {
           newTable = new IncrementalTable(this, { type: "incremental", name, ...queryOrConfig });
-        } else if (queryOrConfig?.type === "view") {
-          newTable = new View(this, { type: "view", name, ...queryOrConfig });
+        } else if (queryOrConfig?.type === "table") {
+          newTable = new Table(this, { type: "table", name, ...queryOrConfig });
         } else {
           throw Error(`Unrecognized table type: ${queryOrConfig.type}`);
         }

--- a/core/session.ts
+++ b/core/session.ts
@@ -2,7 +2,7 @@ import { default as TarjanGraphConstructor, Graph as TarjanGraph } from "tarjan-
 
 import { encode64, verifyObjectMatchesProto, VerifyProtoErrorBehaviour } from "df/common/protos";
 import { StringifiedMap, StringifiedSet } from "df/common/strings/stringifier";
-import { Action, ITableContext, TableType } from "df/core/actions";
+import { Action, ILegacyTableConfig, ITableContext, TableType } from "df/core/actions";
 import { AContextable, Assertion, AssertionContext } from "df/core/actions/assertion";
 import {
   DataPreparation,
@@ -10,12 +10,12 @@ import {
   IDataPreparationContext
 } from "df/core/actions/data_preparation";
 import { Declaration } from "df/core/actions/declaration";
-import { ILegacyIncrementalTableConfig, IncrementalTable } from "df/core/actions/incremental_table";
+import { IncrementalTable } from "df/core/actions/incremental_table";
 import { Notebook } from "df/core/actions/notebook";
 import { Operation, OperationContext } from "df/core/actions/operation";
-import { ILegacyTableConfig, Table, TableContext } from "df/core/actions/table";
+import { Table, TableContext } from "df/core/actions/table";
 import { Test } from "df/core/actions/test";
-import { ILegacyViewConfig, View } from "df/core/actions/view";
+import { View } from "df/core/actions/view";
 import { Contextable, ICommonContext, ITarget, Resolvable } from "df/core/common";
 import { CompilationSql } from "df/core/compilation_sql";
 import { targetAsReadableString, targetStringifier } from "df/core/targets";
@@ -276,15 +276,19 @@ export class Session {
     return operation;
   }
 
+  // In v4, consider replacing publish with separate methods for each action type.
   public publish(
     name: string,
     queryOrConfig?:
       | Contextable<ITableContext, string>
+      | dataform.ActionConfig.TableConfig
+      | dataform.ActionConfig.ViewConfig
+      | dataform.ActionConfig.IncrementalTableConfig
       | ILegacyTableConfig
-      | ILegacyViewConfig
-      | ILegacyIncrementalTableConfig
+      // `any` is used here to facilitate the type merging of legacy table configs, which are very
+      // different to the new structures.
+      | any
   ): Table | IncrementalTable | View {
-    console.log("PUBLISH CALLED");
     let newTable: Table | IncrementalTable | View = new View(this, { type: "view", name });
     if (!!queryOrConfig) {
       if (typeof queryOrConfig === "object") {

--- a/version.bzl
+++ b/version.bzl
@@ -1,1 +1,1 @@
-DF_VERSION = "3.0.12"
+DF_VERSION = "3.0.13"


### PR DESCRIPTION
in 3.0.10 to 3.0.12, the new test cases added to `core/main.test` in this PR would throw errors - but in 3.0.9 and prior they were supported. This re-adds backwards compatibility of this support.

It also fixes some typing used, though unfortunately disabling build type safety has to be done to facilitate it.

Fixes https://github.com/dataform-co/dataform/issues/1908
Fixes https://github.com/dataform-co/dataform/issues/1907