### PR TITLE
Allow passing config options to assert()

### DIFF
--- a/core/actions/index.ts
+++ b/core/actions/index.ts
@@ -45,7 +45,7 @@ export abstract class ActionBuilder<T> {
     useDefaultAssertionDataset = false
   ): dataform.Target {
     const defaultSchema = useDefaultAssertionDataset
-      ? projectConfig.assertionSchema
+      ? projectConfig.assertionSchema || projectConfig.defaultSchema
       : projectConfig.defaultSchema;
     const target = dataform.Target.create({
       name: targetFromConfig.name,

--- a/core/session.ts
+++ b/core/session.ts
@@ -344,12 +344,19 @@ export class Session {
    *
    * @see [assertion](Assertion) for examples on how to use.
    */
-  public assert(name: string, query?: AContextable<string>): Assertion {
-    const assertion = new Assertion();
-    assertion.session = this;
-    utils.setNameAndTarget(this, assertion.proto, name, this.projectConfig.assertionSchema);
-    if (query) {
-      assertion.query(query);
+  public assert(
+    name: string,
+    queryOrConfig?: AContextable<string> | dataform.ActionConfig.AssertionConfig
+  ): Assertion {
+    let assertion = new Assertion();
+    if (!!queryOrConfig && typeof queryOrConfig === "object") {
+      assertion = new Assertion(this, { name, ...queryOrConfig });
+    } else {
+      assertion.session = this;
+      utils.setNameAndTarget(this, assertion.proto, name, this.projectConfig.assertionSchema);
+      if (queryOrConfig) {
+        assertion.query(queryOrConfig as AContextable<string>);
+      }
     }
     assertion.proto.fileName = utils.getCallerFile(this.rootDir);
     this.actions.push(assertion);

--- a/docs/reference/session.md
+++ b/docs/reference/session.md
@@ -43,7 +43,7 @@ dataform.projectConfig.vars.myVariableName === "myVariableValue"
 
 ###  assert
 
-▸ **assert**(`name`: string, `query?`: AContextable‹string›): *[Assertion](_core_actions_assertion_.assertion.md)*
+▸ **assert**(`name`: string, `queryOrConfig?`: AContextable‹string› | AssertionConfig): *[Assertion](_core_actions_assertion_.assertion.md)*
 
 Adds a Dataform assertion the compiled graph.
 
@@ -56,7 +56,7 @@ Available only in the `/definitions` directory.
 Name | Type |
 ------ | ------ |
 `name` | string |
-`query?` | AContextable‹string› |
+`queryOrConfig?` | AContextable‹string› &#124; AssertionConfig |
 
 **Returns:** *[Assertion](_core_actions_assertion_.assertion.md)*
 


### PR DESCRIPTION
This follows a similar model to what is already available with `publish()`, which is preferred over using the builder methods