### PR TITLE
Add notebook js support

### DIFF
--- a/core/actions/notebook.ts
+++ b/core/actions/notebook.ts
@@ -64,12 +64,10 @@ export class Notebook extends ActionBuilder<dataform.Notebook> {
   public dependOnDependencyAssertions: boolean = false;
 
   /** @hidden */
-  constructor(
-    session?: Session,
-    config?: dataform.ActionConfig.NotebookConfig,
-    configPath?: string
-  ) {
+  constructor(session?: Session, unverifiedConfig?: any, configPath?: string) {
     super(session);
+
+    const config = this.verifyConfig(unverifiedConfig);
 
     if (!config.name) {
       config.name = Path.basename(config.filename);
@@ -114,10 +112,16 @@ export class Notebook extends ActionBuilder<dataform.Notebook> {
     return this;
   }
 
-  /** @hidden Verifies that the passed action config is a valid Notebook action config. */
-  public config(config: any) {
-    // TODO(ekrekr): call verifyObjectMatchesProto here.
-    return this;
+  /**
+   * @hidden Verify config checks that the constructor provided config matches the expected proto
+   * structure.
+   */
+  private verifyConfig(unverifiedConfig: any): dataform.ActionConfig.NotebookConfig {
+    return verifyObjectMatchesProto(
+      dataform.ActionConfig.NotebookConfig,
+      unverifiedConfig,
+      VerifyProtoErrorBehaviour.SHOW_DOCS_LINK
+    );
   }
 
   /** @hidden */

--- a/core/actions/notebook.ts
+++ b/core/actions/notebook.ts
@@ -112,18 +112,6 @@ export class Notebook extends ActionBuilder<dataform.Notebook> {
     return this;
   }
 
-  /**
-   * @hidden Verify config checks that the constructor provided config matches the expected proto
-   * structure.
-   */
-  private verifyConfig(unverifiedConfig: any): dataform.ActionConfig.NotebookConfig {
-    return verifyObjectMatchesProto(
-      dataform.ActionConfig.NotebookConfig,
-      unverifiedConfig,
-      VerifyProtoErrorBehaviour.SHOW_DOCS_LINK
-    );
-  }
-
   /** @hidden */
   public dependencies(value: Resolvable | Resolvable[]) {
     const newDependencies = Array.isArray(value) ? value : [value];
@@ -149,6 +137,18 @@ export class Notebook extends ActionBuilder<dataform.Notebook> {
       dataform.Notebook,
       this.proto,
       VerifyProtoErrorBehaviour.SUGGEST_REPORTING_TO_DATAFORM_TEAM
+    );
+  }
+
+  /**
+   * @hidden Verify config checks that the constructor provided config matches the expected proto
+   * structure.
+   */
+  private verifyConfig(unverifiedConfig: any): dataform.ActionConfig.NotebookConfig {
+    return verifyObjectMatchesProto(
+      dataform.ActionConfig.NotebookConfig,
+      unverifiedConfig,
+      VerifyProtoErrorBehaviour.SHOW_DOCS_LINK
     );
   }
 }

--- a/core/session.ts
+++ b/core/session.ts
@@ -394,16 +394,10 @@ export class Session {
    * Available only in the `/definitions` directory.
    *
    * @see [Notebook](Notebook) for examples on how to use.
-   *
-   * <!-- TODO(ekrekr): safely allow passing of config blocks as the second argument, similar to
-   * publish. -->
-   * <!-- TODO(ekrekr): add tests for this method -->
    */
-  public notebook(name: string): Notebook {
-    const notebook = new Notebook();
-    notebook.session = this;
-    utils.setNameAndTarget(this, notebook.proto, name);
-    notebook.proto.fileName = utils.getCallerFile(this.rootDir);
+  public notebook(config: dataform.ActionConfig.NotebookConfig): Notebook {
+    const configFileName = utils.getCallerFile(this.rootDir);
+    const notebook = new Notebook(this, config, configFileName);
     this.actions.push(notebook);
     return notebook;
   }

--- a/docs/reference/session.md
+++ b/docs/reference/session.md
@@ -87,7 +87,7 @@ ___
 
 ###  notebook
 
-▸ **notebook**(`name`: string): *[Notebook](_core_actions_notebook_.notebook.md)*
+▸ **notebook**(`config`: NotebookConfig): *[Notebook](_core_actions_notebook_.notebook.md)*
 
 Creates a Notebook action.
 
@@ -95,15 +95,11 @@ Available only in the `/definitions` directory.
 
 **`see`** [Notebook](Notebook) for examples on how to use.
 
-<!-- TODO(ekrekr): safely allow passing of config blocks as the second argument, similar to
-publish. -->
-<!-- TODO(ekrekr): add tests for this method -->
-
 **Parameters:**
 
 Name | Type |
 ------ | ------ |
-`name` | string |
+`config` | NotebookConfig |
 
 **Returns:** *[Notebook](_core_actions_notebook_.notebook.md)*
 


### PR DESCRIPTION
This tests and properly configures being able to create notebooks using the JS API.

Updating the parameter structure in a backwards breaking way is fine here because:
* It was broken and untested before.
* Therefore no one was using it.