### PR TITLE
Make action protos private

### DIFF
--- a/core/actions/assertion.ts
+++ b/core/actions/assertion.ts
@@ -80,10 +80,8 @@ export type AContextable<T> = T | ((ctx: AssertionContext) => T);
 export class Assertion extends ActionBuilder<dataform.Assertion> {
   /**
    * @hidden Stores the generated proto for the compiled graph.
-   * <!-- TODO(ekrekr): make this field private, to enforce proto update logic to happen in this
-   * class. -->
    */
-  public proto = dataform.Assertion.create();
+  private proto = dataform.Assertion.create();
 
   /** @hidden Hold a reference to the Session instance. */
   public session: Session;
@@ -275,6 +273,21 @@ export class Assertion extends ActionBuilder<dataform.Assertion> {
   }
 
   /** @hidden */
+  public getParentAction() {
+    return dataform.Target.create(this.proto.parentAction);
+  }
+
+  /** @hidden */
+  public setParentAction(target: dataform.Target) {
+    return (this.proto.parentAction = target);
+  }
+
+  /** @hidden */
+  public setFilename(filename: string) {
+    return (this.proto.fileName = filename);
+  }
+
+  /** @hidden */
   public compile() {
     const context = new AssertionContext(this);
 
@@ -341,11 +354,11 @@ export class AssertionContext implements IActionContext {
   }
 
   public self(): string {
-    return this.resolve(this.assertion.proto.target);
+    return this.resolve(this.assertion.getTarget());
   }
 
   public name(): string {
-    return this.assertion.session.finalizeName(this.assertion.proto.target.name);
+    return this.assertion.session.finalizeName(this.assertion.getTarget().name);
   }
 
   public ref(ref: Resolvable | string[], ...rest: string[]) {
@@ -363,18 +376,18 @@ export class AssertionContext implements IActionContext {
   }
 
   public schema(): string {
-    return this.assertion.session.finalizeSchema(this.assertion.proto.target.schema);
+    return this.assertion.session.finalizeSchema(this.assertion.getTarget().schema);
   }
 
   public database(): string {
-    if (!this.assertion.proto.target.database) {
+    if (!this.assertion.getTarget().database) {
       this.assertion.session.compileError(
         new Error(`Warehouse does not support multiple databases`)
       );
       return "";
     }
 
-    return this.assertion.session.finalizeDatabase(this.assertion.proto.target.database);
+    return this.assertion.session.finalizeDatabase(this.assertion.getTarget().database);
   }
 
   public dependencies(name: Resolvable | Resolvable[]) {

--- a/core/actions/assertion.ts
+++ b/core/actions/assertion.ts
@@ -78,13 +78,13 @@ export type AContextable<T> = T | ((ctx: AssertionContext) => T);
  * This is where `query` comes from.
  */
 export class Assertion extends ActionBuilder<dataform.Assertion> {
+  /** @hidden Hold a reference to the Session instance. */
+  public session: Session;
+
   /**
    * @hidden Stores the generated proto for the compiled graph.
    */
   private proto = dataform.Assertion.create();
-
-  /** @hidden Hold a reference to the Session instance. */
-  public session: Session;
 
   /** @hidden We delay contextification until the final compile step, so hold these here for now. */
   private contextableQuery: AContextable<string>;

--- a/core/actions/assertion.ts
+++ b/core/actions/assertion.ts
@@ -279,12 +279,7 @@ export class Assertion extends ActionBuilder<dataform.Assertion> {
 
   /** @hidden */
   public setParentAction(target: dataform.Target) {
-    return (this.proto.parentAction = target);
-  }
-
-  /** @hidden */
-  public setFilename(filename: string) {
-    return (this.proto.fileName = filename);
+    this.proto.parentAction = target;
   }
 
   /** @hidden */

--- a/core/actions/data_preparation.ts
+++ b/core/actions/data_preparation.ts
@@ -26,8 +26,7 @@ export class DataPreparation extends ActionBuilder<dataform.DataPreparation> {
   // We delay contextification until the final compile step, so hold these here for now.
   public contextableQuery: Contextable<IDataPreparationContext, string>;
 
-  // TODO: make this field private, to enforce proto update logic to happen in this class.
-  public proto = dataform.DataPreparation.create();
+  private proto = dataform.DataPreparation.create();
 
   constructor(
     session?: Session,
@@ -432,11 +431,11 @@ export class DataPreparationContext implements IDataPreparationContext {
   }
 
   public self(): string {
-    return this.resolve(this.dataPreparation.proto.target);
+    return this.resolve(this.dataPreparation.getTarget());
   }
 
   public name(): string {
-    return this.dataPreparation.session.finalizeName(this.dataPreparation.proto.target.name);
+    return this.dataPreparation.session.finalizeName(this.dataPreparation.getTarget().name);
   }
 
   public ref(ref: Resolvable | string[], ...rest: string[]): string {
@@ -454,20 +453,18 @@ export class DataPreparationContext implements IDataPreparationContext {
   }
 
   public schema(): string {
-    return this.dataPreparation.session.finalizeSchema(this.dataPreparation.proto.target.schema);
+    return this.dataPreparation.session.finalizeSchema(this.dataPreparation.getTarget().schema);
   }
 
   public database(): string {
-    if (!this.dataPreparation.proto.target.database) {
+    if (!this.dataPreparation.getTarget().database) {
       this.dataPreparation.session.compileError(
         new Error(`Warehouse does not support multiple databases`)
       );
       return "";
     }
 
-    return this.dataPreparation.session.finalizeDatabase(
-      this.dataPreparation.proto.target.database
-    );
+    return this.dataPreparation.session.finalizeDatabase(this.dataPreparation.getTarget().database);
   }
 
   // TODO: Add support for incremental conditions in compilation output

--- a/core/actions/data_preparation.ts
+++ b/core/actions/data_preparation.ts
@@ -7,7 +7,7 @@ import * as Path from "df/core/path";
 import { Session } from "df/core/session";
 import {
   actionConfigToCompiledGraphTarget,
-  addDependenciesToActionDependencyTargets,
+  checkAssertionsForDependency,
   configTargetToCompiledGraphTarget,
   nativeRequire,
   resolvableAsTarget,
@@ -86,7 +86,7 @@ export class DataPreparation extends ActionBuilder<dataform.DataPreparation> {
   public dependencies(value: Resolvable | Resolvable[]) {
     const newDependencies = Array.isArray(value) ? value : [value];
     newDependencies.forEach(resolvable =>
-      addDependenciesToActionDependencyTargets(this, resolvable)
+      this.proto.dependencyTargets.push(checkAssertionsForDependency(this, resolvable))
     );
     return this;
   }

--- a/core/actions/declaration.ts
+++ b/core/actions/declaration.ts
@@ -60,13 +60,13 @@ interface ILegacyDeclarationConfig extends dataform.ActionConfig.DeclarationConf
  * ```
  */
 export class Declaration extends ActionBuilder<dataform.Declaration> {
+  /** @hidden Hold a reference to the Session instance. */
+  public session: Session;
+
   /**
    * @hidden Stores the generated proto for the compiled graph.
    */
   private proto = dataform.Declaration.create();
-
-  /** @hidden Hold a reference to the Session instance. */
-  public session: Session;
 
   /** @hidden */
   constructor(session?: Session, unverifiedConfig?: any) {

--- a/core/actions/declaration.ts
+++ b/core/actions/declaration.ts
@@ -62,10 +62,8 @@ interface ILegacyDeclarationConfig extends dataform.ActionConfig.DeclarationConf
 export class Declaration extends ActionBuilder<dataform.Declaration> {
   /**
    * @hidden Stores the generated proto for the compiled graph.
-   * <!-- TODO(ekrekr): make this field private, to enforce proto update logic to happen in this
-   * class. -->
    */
-  public proto = dataform.Declaration.create();
+  private proto = dataform.Declaration.create();
 
   /** @hidden Hold a reference to the Session instance. */
   public session: Session;
@@ -140,6 +138,11 @@ export class Declaration extends ActionBuilder<dataform.Declaration> {
   /** @hidden */
   public getTarget() {
     return dataform.Target.create(this.proto.target);
+  }
+
+  /** @hidden */
+  public setFilename(filename: string) {
+    return (this.proto.fileName = filename);
   }
 
   /** @hidden */

--- a/core/actions/declaration.ts
+++ b/core/actions/declaration.ts
@@ -69,7 +69,7 @@ export class Declaration extends ActionBuilder<dataform.Declaration> {
   private proto = dataform.Declaration.create();
 
   /** @hidden */
-  constructor(session?: Session, unverifiedConfig?: any) {
+  constructor(session?: Session, unverifiedConfig?: any, filename?: string) {
     super(session);
     this.session = session;
 
@@ -97,6 +97,7 @@ export class Declaration extends ActionBuilder<dataform.Declaration> {
         )
       );
     }
+    this.proto.fileName = filename;
     return this;
   }
 
@@ -138,11 +139,6 @@ export class Declaration extends ActionBuilder<dataform.Declaration> {
   /** @hidden */
   public getTarget() {
     return dataform.Target.create(this.proto.target);
-  }
-
-  /** @hidden */
-  public setFilename(filename: string) {
-    return (this.proto.fileName = filename);
   }
 
   /** @hidden */

--- a/core/actions/incremental_table.ts
+++ b/core/actions/incremental_table.ts
@@ -536,11 +536,6 @@ export class IncrementalTable extends ActionBuilder<dataform.Table> {
   }
 
   /** @hidden */
-  public setFilename(filename: string) {
-    return (this.proto.fileName = filename);
-  }
-
-  /** @hidden */
   public compile() {
     const context = new IncrementalTableContext(this);
     const incrementalContext = new IncrementalTableContext(this, true);

--- a/core/actions/incremental_table.ts
+++ b/core/actions/incremental_table.ts
@@ -16,7 +16,7 @@ import * as Path from "df/core/path";
 import { Session } from "df/core/session";
 import {
   actionConfigToCompiledGraphTarget,
-  addDependenciesToActionDependencyTargets,
+  checkAssertionsForDependency,
   checkExcessProperties,
   configTargetToCompiledGraphTarget,
   nativeRequire,
@@ -349,7 +349,7 @@ export class IncrementalTable extends ActionBuilder<dataform.Table> {
   public dependencies(value: Resolvable | Resolvable[]) {
     const newDependencies = Array.isArray(value) ? value : [value];
     newDependencies.forEach(resolvable =>
-      addDependenciesToActionDependencyTargets(this, resolvable)
+      this.proto.dependencyTargets.push(checkAssertionsForDependency(this, resolvable))
     );
     return this;
   }

--- a/core/actions/incremental_table.ts
+++ b/core/actions/incremental_table.ts
@@ -67,10 +67,8 @@ import { dataform } from "df/protos/ts";
 export class IncrementalTable extends ActionBuilder<dataform.Table> {
   /**
    * @hidden Stores the generated proto for the compiled graph.
-   * <!-- TODO(ekrekr): make this field private, to enforce proto update logic to happen in this
-   * class. -->
    */
-  public proto = dataform.Table.create({
+  private proto = dataform.Table.create({
     type: "incremental",
     enumType: dataform.TableType.INCREMENTAL,
     disabled: false,
@@ -456,6 +454,7 @@ export class IncrementalTable extends ActionBuilder<dataform.Table> {
    * <!-- Note: this both applies in-line assertions, and acts as a method available via the JS API.
    * Usage of it via the JS API is deprecated, but the way it applies in-line assertions is still
    * needed -->
+   * <!-- TODO(ekrekr): move this to a shared definition -->
    */
   public assertions(assertions: dataform.ActionConfig.TableAssertionsConfig) {
     if (!!assertions.uniqueKey?.length && !!assertions.uniqueKeys?.length) {
@@ -482,7 +481,7 @@ export class IncrementalTable extends ActionBuilder<dataform.Table> {
         if (this.proto.tags) {
           uniqueKeyAssertion.tags(this.proto.tags);
         }
-        uniqueKeyAssertion.proto.parentAction = this.proto.target;
+        uniqueKeyAssertion.setParentAction(dataform.Target.create(this.proto.target));
         if (this.proto.disabled) {
           uniqueKeyAssertion.disabled();
         }
@@ -503,7 +502,7 @@ export class IncrementalTable extends ActionBuilder<dataform.Table> {
             .compilationSql()
             .rowConditionsAssertion(ctx.ref(this.proto.target), mergedRowConditions)
       );
-      this.rowConditionsAssertion.proto.parentAction = this.proto.target;
+      this.rowConditionsAssertion.setParentAction(dataform.Target.create(this.proto.target));
       if (this.proto.disabled) {
         this.rowConditionsAssertion.disabled();
       }
@@ -534,6 +533,11 @@ export class IncrementalTable extends ActionBuilder<dataform.Table> {
   /** @hidden */
   public getTarget() {
     return dataform.Target.create(this.proto.target);
+  }
+
+  /** @hidden */
+  public setFilename(filename: string) {
+    return (this.proto.fileName = filename);
   }
 
   /** @hidden */
@@ -710,11 +714,11 @@ export class IncrementalTableContext implements ITableContext {
   constructor(private incrementalTable: IncrementalTable, private isIncremental = false) {}
 
   public self(): string {
-    return this.resolve(this.incrementalTable.proto.target);
+    return this.resolve(this.incrementalTable.getTarget());
   }
 
   public name(): string {
-    return this.incrementalTable.session.finalizeName(this.incrementalTable.proto.target.name);
+    return this.incrementalTable.session.finalizeName(this.incrementalTable.getTarget().name);
   }
 
   public ref(ref: Resolvable | string[], ...rest: string[]): string {
@@ -732,11 +736,11 @@ export class IncrementalTableContext implements ITableContext {
   }
 
   public schema(): string {
-    return this.incrementalTable.session.finalizeSchema(this.incrementalTable.proto.target.schema);
+    return this.incrementalTable.session.finalizeSchema(this.incrementalTable.getTarget().schema);
   }
 
   public database(): string {
-    if (!this.incrementalTable.proto.target.database) {
+    if (!this.incrementalTable.getTarget().database) {
       this.incrementalTable.session.compileError(
         new Error(`Warehouse does not support multiple databases`)
       );
@@ -744,7 +748,7 @@ export class IncrementalTableContext implements ITableContext {
     }
 
     return this.incrementalTable.session.finalizeDatabase(
-      this.incrementalTable.proto.target.database
+      this.incrementalTable.getTarget().database
     );
   }
 

--- a/core/actions/incremental_table.ts
+++ b/core/actions/incremental_table.ts
@@ -65,16 +65,6 @@ import { dataform } from "df/protos/ts";
  * This is where `query` comes from.
  */
 export class IncrementalTable extends ActionBuilder<dataform.Table> {
-  /**
-   * @hidden Stores the generated proto for the compiled graph.
-   */
-  private proto = dataform.Table.create({
-    type: "incremental",
-    enumType: dataform.TableType.INCREMENTAL,
-    disabled: false,
-    tags: []
-  });
-
   /** @hidden Hold a reference to the Session instance. */
   public session: Session;
 
@@ -89,6 +79,16 @@ export class IncrementalTable extends ActionBuilder<dataform.Table> {
   private contextableWhere: Contextable<ITableContext, string>;
   private contextablePreOps: Array<Contextable<ITableContext, string | string[]>> = [];
   private contextablePostOps: Array<Contextable<ITableContext, string | string[]>> = [];
+
+  /**
+   * @hidden Stores the generated proto for the compiled graph.
+   */
+  private proto = dataform.Table.create({
+    type: "incremental",
+    enumType: dataform.TableType.INCREMENTAL,
+    disabled: false,
+    tags: []
+  });
 
   /** @hidden */
   private uniqueKeyAssertions: Assertion[] = [];

--- a/core/actions/notebook.ts
+++ b/core/actions/notebook.ts
@@ -49,10 +49,8 @@ import { dataform } from "df/protos/ts";
 export class Notebook extends ActionBuilder<dataform.Notebook> {
   /**
    * @hidden Stores the generated proto for the compiled graph.
-   * <!-- TODO(ekrekr): make this field private, to enforce proto update logic to happen in this
-   * class. -->
    */
-  public proto = dataform.Notebook.create();
+  private proto = dataform.Notebook.create();
 
   /** @hidden Hold a reference to the Session instance. */
   public session: Session;

--- a/core/actions/notebook.ts
+++ b/core/actions/notebook.ts
@@ -112,9 +112,12 @@ export class Notebook extends ActionBuilder<dataform.Notebook> {
   /** @hidden */
   public dependencies(value: Resolvable | Resolvable[]) {
     const newDependencies = Array.isArray(value) ? value : [value];
-    newDependencies.forEach(resolvable =>
-      this.proto.dependencyTargets.push(checkAssertionsForDependency(this, resolvable))
-    );
+    newDependencies.forEach(resolvable => {
+      const dependencyTarget = checkAssertionsForDependency(this, resolvable);
+      if (!!dependencyTarget) {
+        this.proto.dependencyTargets.push(dependencyTarget);
+      }
+    });
     return this;
   }
 

--- a/core/actions/notebook.ts
+++ b/core/actions/notebook.ts
@@ -47,19 +47,18 @@ import { dataform } from "df/protos/ts";
  * ```
  */
 export class Notebook extends ActionBuilder<dataform.Notebook> {
-  /**
-   * @hidden Stores the generated proto for the compiled graph.
-   */
-  private proto = dataform.Notebook.create();
-
   /** @hidden Hold a reference to the Session instance. */
   public session: Session;
-
   /**
    * @hidden If true, adds the inline assertions of dependencies as direct dependencies for this
    * action.
    */
   public dependOnDependencyAssertions: boolean = false;
+
+  /**
+   * @hidden Stores the generated proto for the compiled graph.
+   */
+  private proto = dataform.Notebook.create();
 
   /** @hidden */
   constructor(session?: Session, unverifiedConfig?: any, configPath?: string) {

--- a/core/actions/notebook.ts
+++ b/core/actions/notebook.ts
@@ -5,7 +5,7 @@ import * as Path from "df/core/path";
 import { Session } from "df/core/session";
 import {
   actionConfigToCompiledGraphTarget,
-  addDependenciesToActionDependencyTargets,
+  checkAssertionsForDependency,
   configTargetToCompiledGraphTarget,
   nativeRequire,
   resolveActionsConfigFilename
@@ -113,7 +113,7 @@ export class Notebook extends ActionBuilder<dataform.Notebook> {
   public dependencies(value: Resolvable | Resolvable[]) {
     const newDependencies = Array.isArray(value) ? value : [value];
     newDependencies.forEach(resolvable =>
-      addDependenciesToActionDependencyTargets(this, resolvable)
+      this.proto.dependencyTargets.push(checkAssertionsForDependency(this, resolvable))
     );
     return this;
   }

--- a/core/actions/operation.ts
+++ b/core/actions/operation.ts
@@ -176,9 +176,12 @@ export class Operation extends ActionBuilder<dataform.Operation> {
    */
   public dependencies(value: Resolvable | Resolvable[]) {
     const newDependencies = Array.isArray(value) ? value : [value];
-    newDependencies.forEach(resolvable =>
-      this.proto.dependencyTargets.push(checkAssertionsForDependency(this, resolvable))
-    );
+    newDependencies.forEach(resolvable => {
+      const dependencyTarget = checkAssertionsForDependency(this, resolvable);
+      if (!!dependencyTarget) {
+        this.proto.dependencyTargets.push(dependencyTarget);
+      }
+    });
     return this;
   }
 

--- a/core/actions/operation.ts
+++ b/core/actions/operation.ts
@@ -72,11 +72,6 @@ interface ILegacyOperationConfig extends dataform.ActionConfig.OperationConfig {
  * This is where `query` comes from.
  */
 export class Operation extends ActionBuilder<dataform.Operation> {
-  /**
-   * @hidden Stores the generated proto for the compiled graph.
-   */
-  private proto = dataform.Operation.create();
-
   /** @hidden Hold a reference to the Session instance. */
   public session: Session;
 
@@ -85,6 +80,11 @@ export class Operation extends ActionBuilder<dataform.Operation> {
    * action.
    */
   public dependOnDependencyAssertions: boolean = false;
+
+  /**
+   * @hidden Stores the generated proto for the compiled graph.
+   */
+  private proto = dataform.Operation.create();
 
   /** @hidden We delay contextification until the final compile step, so hold these here for now. */
   private contextableQueries: Contextable<IActionContext, string | string[]>;

--- a/core/actions/operation.ts
+++ b/core/actions/operation.ts
@@ -325,7 +325,7 @@ export class Operation extends ActionBuilder<dataform.Operation> {
   }
 
   /** @hidden */
-  public getHasOutput(): Boolean {
+  public getHasOutput(): boolean {
     return this.proto.hasOutput;
   }
 

--- a/core/actions/operation.ts
+++ b/core/actions/operation.ts
@@ -325,12 +325,7 @@ export class Operation extends ActionBuilder<dataform.Operation> {
   }
 
   /** @hidden */
-  public getHasOutput() {
-    return this.proto.hasOutput;
-  }
-
-  /** @hidden */
-  public setFilename() {
+  public getHasOutput(): Boolean {
     return this.proto.hasOutput;
   }
 

--- a/core/actions/table.ts
+++ b/core/actions/table.ts
@@ -16,7 +16,7 @@ import * as Path from "df/core/path";
 import { Session } from "df/core/session";
 import {
   actionConfigToCompiledGraphTarget,
-  addDependenciesToActionDependencyTargets,
+  checkAssertionsForDependency,
   checkExcessProperties,
   nativeRequire,
   resolvableAsTarget,
@@ -315,7 +315,7 @@ export class Table extends ActionBuilder<dataform.Table> {
   public dependencies(value: Resolvable | Resolvable[]) {
     const newDependencies = Array.isArray(value) ? value : [value];
     newDependencies.forEach(resolvable =>
-      addDependenciesToActionDependencyTargets(this, resolvable)
+      this.proto.dependencyTargets.push(checkAssertionsForDependency(this, resolvable))
     );
     return this;
   }

--- a/core/actions/table.ts
+++ b/core/actions/table.ts
@@ -71,19 +71,8 @@ import { dataform } from "df/protos/ts";
  * This is where `query` comes from.
  */
 export class Table extends ActionBuilder<dataform.Table> {
-  /**
-   * @hidden Stores the generated proto for the compiled graph.
-   */
-  private proto = dataform.Table.create({
-    type: "table",
-    enumType: dataform.TableType.TABLE,
-    disabled: false,
-    tags: []
-  });
-
   /** @hidden Hold a reference to the Session instance. */
   public session: Session;
-
   /**
    * @hidden If true, adds the inline assertions of dependencies as direct dependencies for this
    * action.
@@ -95,6 +84,16 @@ export class Table extends ActionBuilder<dataform.Table> {
   private contextableWhere: Contextable<ITableContext, string>;
   private contextablePreOps: Array<Contextable<ITableContext, string | string[]>> = [];
   private contextablePostOps: Array<Contextable<ITableContext, string | string[]>> = [];
+
+  /**
+   * @hidden Stores the generated proto for the compiled graph.
+   */
+  private proto = dataform.Table.create({
+    type: "table",
+    enumType: dataform.TableType.TABLE,
+    disabled: false,
+    tags: []
+  });
 
   /** @hidden */
   private uniqueKeyAssertions: Assertion[] = [];

--- a/core/actions/table.ts
+++ b/core/actions/table.ts
@@ -314,9 +314,12 @@ export class Table extends ActionBuilder<dataform.Table> {
    */
   public dependencies(value: Resolvable | Resolvable[]) {
     const newDependencies = Array.isArray(value) ? value : [value];
-    newDependencies.forEach(resolvable =>
-      this.proto.dependencyTargets.push(checkAssertionsForDependency(this, resolvable))
-    );
+    newDependencies.forEach(resolvable => {
+      const dependencyTarget = checkAssertionsForDependency(this, resolvable);
+      if (!!dependencyTarget) {
+        this.proto.dependencyTargets.push(dependencyTarget);
+      }
+    });
     return this;
   }
 

--- a/core/actions/table.ts
+++ b/core/actions/table.ts
@@ -503,11 +503,6 @@ export class Table extends ActionBuilder<dataform.Table> {
   }
 
   /** @hidden */
-  public setFilename(filename: string) {
-    return (this.proto.fileName = filename);
-  }
-
-  /** @hidden */
   public compile() {
     const context = new TableContext(this);
     const incrementalContext = new TableContext(this, true);

--- a/core/actions/test.ts
+++ b/core/actions/test.ts
@@ -69,11 +69,6 @@ const ITestConfigProperties = strictKeysOf<ITestConfig>()(["type", "dataset", "n
  * This is where `input` and `expect` come from.
  */
 export class Test extends ActionBuilder<dataform.Test> {
-  /**
-   * @hidden Stores the generated proto for the compiled graph.
-   */
-  private proto = dataform.Test.create();
-
   /** @hidden Hold a reference to the Session instance. */
   public session: Session;
 
@@ -81,6 +76,11 @@ export class Test extends ActionBuilder<dataform.Test> {
   public contextableInputs = new Map<string, Contextable<IActionContext, string>>();
   private contextableQuery: Contextable<IActionContext, string>;
   private datasetToTest: Resolvable;
+
+  /**
+   * @hidden Stores the generated proto for the compiled graph.
+   */
+  private proto = dataform.Test.create();
 
   /** @hidden */
   constructor(session?: Session, config?: ITestConfig) {

--- a/core/actions/test.ts
+++ b/core/actions/test.ts
@@ -149,7 +149,7 @@ export class Test extends ActionBuilder<dataform.Test> {
 
   /** @hidden */
   public setFilename(filename: string) {
-    return (this.proto.fileName = filename);
+    this.proto.fileName = filename;
   }
 
   /** @hidden */

--- a/core/actions/view.ts
+++ b/core/actions/view.ts
@@ -81,16 +81,6 @@ export interface ILegacyViewBigqueryConfig {
  * This is where `query` comes from.
  */
 export class View extends ActionBuilder<dataform.Table> {
-  /**
-   * @hidden Stores the generated proto for the compiled graph.
-   */
-  private proto = dataform.Table.create({
-    type: "view",
-    enumType: dataform.TableType.VIEW,
-    disabled: false,
-    tags: []
-  });
-
   /** @hidden Hold a reference to the Session instance. */
   public session: Session;
 
@@ -105,6 +95,16 @@ export class View extends ActionBuilder<dataform.Table> {
   private contextableWhere: Contextable<ITableContext, string>;
   private contextablePreOps: Array<Contextable<ITableContext, string | string[]>> = [];
   private contextablePostOps: Array<Contextable<ITableContext, string | string[]>> = [];
+
+  /**
+   * @hidden Stores the generated proto for the compiled graph.
+   */
+  private proto = dataform.Table.create({
+    type: "view",
+    enumType: dataform.TableType.VIEW,
+    disabled: false,
+    tags: []
+  });
 
   /** @hidden */
   private uniqueKeyAssertions: Assertion[] = [];

--- a/core/actions/view.ts
+++ b/core/actions/view.ts
@@ -530,11 +530,6 @@ export class View extends ActionBuilder<dataform.Table> {
   }
 
   /** @hidden */
-  public setFilename(filename: string) {
-    return (this.proto.fileName = filename);
-  }
-
-  /** @hidden */
   public compile() {
     const context = new ViewContext(this);
     const incrementalContext = new ViewContext(this, true);

--- a/core/actions/view.ts
+++ b/core/actions/view.ts
@@ -339,9 +339,12 @@ export class View extends ActionBuilder<dataform.Table> {
    */
   public dependencies(value: Resolvable | Resolvable[]) {
     const newDependencies = Array.isArray(value) ? value : [value];
-    newDependencies.forEach(resolvable =>
-      this.proto.dependencyTargets.push(checkAssertionsForDependency(this, resolvable))
-    );
+    newDependencies.forEach(resolvable => {
+      const dependencyTarget = checkAssertionsForDependency(this, resolvable);
+      if (!!dependencyTarget) {
+        this.proto.dependencyTargets.push(dependencyTarget);
+      }
+    });
     return this;
   }
 

--- a/core/actions/view.ts
+++ b/core/actions/view.ts
@@ -14,7 +14,7 @@ import * as Path from "df/core/path";
 import { Session } from "df/core/session";
 import {
   actionConfigToCompiledGraphTarget,
-  addDependenciesToActionDependencyTargets,
+  checkAssertionsForDependency,
   checkExcessProperties,
   configTargetToCompiledGraphTarget,
   nativeRequire,
@@ -340,7 +340,7 @@ export class View extends ActionBuilder<dataform.Table> {
   public dependencies(value: Resolvable | Resolvable[]) {
     const newDependencies = Array.isArray(value) ? value : [value];
     newDependencies.forEach(resolvable =>
-      addDependenciesToActionDependencyTargets(this, resolvable)
+      this.proto.dependencyTargets.push(checkAssertionsForDependency(this, resolvable))
     );
     return this;
   }

--- a/core/session.ts
+++ b/core/session.ts
@@ -206,7 +206,7 @@ export class Session {
         break;
       case "declaration":
         const declaration = new Declaration(this, sqlxConfig);
-        declaration.proto.fileName = utils.getCallerFile(this.rootDir);
+        declaration.setFilename(utils.getCallerFile(this.rootDir));
         this.actions.push(declaration);
         break;
       case "test":
@@ -240,7 +240,7 @@ export class Session {
 
     if (resolved) {
       if (resolved instanceof Declaration) {
-        return this.compilationSql().resolveTarget(resolved.proto.target);
+        return this.compilationSql().resolveTarget(resolved.getTarget());
       }
       return this.compilationSql().resolveTarget({
         ...resolved.getTarget(),
@@ -321,7 +321,7 @@ export class Session {
         newTable.query(queryOrConfig);
       }
     }
-    newTable.proto.fileName = utils.getCallerFile(this.rootDir);
+    newTable.setFilename(utils.getCallerFile(this.rootDir));
     this.actions.push(newTable);
     return newTable;
   }
@@ -346,7 +346,7 @@ export class Session {
         assertion.query(queryOrConfig as AContextable<string>);
       }
     }
-    assertion.proto.fileName = utils.getCallerFile(this.rootDir);
+    assertion.setFilename(utils.getCallerFile(this.rootDir));
     this.actions.push(assertion);
     return assertion;
   }
@@ -366,7 +366,7 @@ export class Session {
       | any
   ): Declaration {
     const declaration = new Declaration(this, config);
-    declaration.proto.fileName = utils.getCallerFile(this.rootDir);
+    declaration.setFilename(utils.getCallerFile(this.rootDir));
     this.actions.push(declaration);
     return declaration;
   }
@@ -383,10 +383,9 @@ export class Session {
    * <!-- TODO(ekrekr): add tests for this method -->
    */
   public test(name: string): Test {
-    const newTest = new Test();
+    const newTest = new Test(this, { name });
     newTest.session = this;
-    newTest.proto.name = name;
-    newTest.proto.fileName = utils.getCallerFile(this.rootDir);
+    newTest.setFilename(utils.getCallerFile(this.rootDir));
     // Add it to global index.
     this.tests[name] = newTest;
     return newTest;


### PR DESCRIPTION
This prevents proto update logic from happening outside of actions. This makes action update logic more strict by having it happen inside the action files where they are configured.