### PR TITLE
Make  field on Incremental tables default to false as it was before.

### DIFF
--- a/core/actions/incremental_table.ts
+++ b/core/actions/incremental_table.ts
@@ -300,7 +300,8 @@ export class IncrementalTable extends ActionBuilder<dataform.Table> {
    * If called with `true`, prevents the dataset from being rebuilt from scratch.
    */
   public protected(isProtected: boolean) {
-    this.proto.protected = isProtected;
+    // To prevent accidental data deletion, protected defaults to true if unspecified.
+    this.proto.protected = isProtected === undefined || isProtected === null || isProtected;
     return this;
   }
 
@@ -593,11 +594,6 @@ export class IncrementalTable extends ActionBuilder<dataform.Table> {
           ]),
           "BigQuery table config"
         );
-      }
-
-      // To prevent accidental data deletion, protected defaults to true if unspecified.
-      if (unverifiedConfig.protected === undefined || unverifiedConfig.protected === null) {
-        unverifiedConfig.protected = true;
       }
     }
 

--- a/core/main_test.ts
+++ b/core/main_test.ts
@@ -1097,7 +1097,7 @@ publish("name", {
                           incrementalPostOps: ["post_op"],
                           incrementalPreOps: ["pre_op"],
                           incrementalQuery: "SELECT 1",
-                          protected: true,
+                          protected: false,
                           onSchemaChange: "IGNORE"
                         }
                       : {})
@@ -1162,13 +1162,63 @@ publish("name", {
               ...(tableType === "incremental"
                 ? {
                     incrementalQuery: "SELECT * FROM `defaultProject.defaultDataset.operation`",
-                    protected: true,
+                    protected: false,
                     onSchemaChange: "IGNORE"
                   }
                 : {})
             }
           ]);
         });
+
+        if (tableType === "incremental") {
+          test("protected resolved correctly", () => {
+            const projectDir = tmpDirFixture.createNewTmpDir();
+            fs.writeFileSync(
+              path.join(projectDir, "workflow_settings.yaml"),
+              VALID_WORKFLOW_SETTINGS_YAML
+            );
+            fs.mkdirSync(path.join(projectDir, "definitions"));
+            fs.writeFileSync(
+              path.join(projectDir, "definitions/publish.js"),
+              `
+publish("name", {
+  type: "incremental",
+}).query(_ => "SELECT 1")
+  .protected()`
+            );
+  
+            const result = runMainInVm(coreExecutionRequestFromPath(projectDir));
+  
+            expect(result.compile.compiledGraph.graphErrors.compilationErrors).deep.equals([]);
+            expect(asPlainObject(result.compile.compiledGraph.tables)).deep.equals([
+              {
+                canonicalTarget: {
+                  database: "defaultProject",
+                  name: "name",
+                  schema: "defaultDataset"
+                },
+                disabled: false,
+                enumType: tableType.toUpperCase(),
+                fileName: "definitions/publish.js",
+                hermeticity: "NON_HERMETIC",
+                query: "SELECT 1",
+                target: {
+                  database: "defaultProject",
+                  name: "name",
+                  schema: "defaultDataset"
+                },
+                type: tableType,
+                ...(tableType === "incremental"
+                  ? {
+                      incrementalQuery: "SELECT 1",
+                      protected: true,
+                      onSchemaChange: "IGNORE"
+                    }
+                  : {})
+              }
+            ]);
+          }); 
+        }
       });
     });
 

--- a/core/main_test.ts
+++ b/core/main_test.ts
@@ -1208,13 +1208,9 @@ publish("name", {
                   schema: "defaultDataset"
                 },
                 type: tableType,
-                ...(tableType === "incremental"
-                  ? {
-                      incrementalQuery: "SELECT 1",
-                      protected: true,
-                      onSchemaChange: "IGNORE"
-                    }
-                  : {})
+                incrementalQuery: "SELECT 1",
+                protected: true,
+                onSchemaChange: "IGNORE",
               }
             ]);
           }); 


### PR DESCRIPTION
Configs refactoring introduced by #1780 changes the default behavior of `protected` field on Incremental tables, see #1914

The current PR changes the default behavior to make it consistent with what we had before:

1. If config has `protected` field set, then the value of the field will be used.
2. If config omits `protected` field, it will be set to false.
3. JavaScript API will be slightly __changed__: by default, `protected` will be set to false.
4. If in JavaScript API `.protected()` will be called without arguments (like it was possible before) then the field will be set to through.
5. If in JavaScript API `.protected()` will be called with argument (true or false) then the field will be set to the value of the argument passed.

The logic is quite complicated here but we are trying to mimic the previous behavior to preserve backward compatibility.

Closes #1914