### PR TITLE
feat: show bigquery jobId when executing the job

### DIFF
--- a/cli/api/commands/run.ts
+++ b/cli/api/commands/run.ts
@@ -366,7 +366,7 @@ export class Runner {
       actionResult.status === dataform.ActionResult.ExecutionStatus.RUNNING &&
       !(this.graph.runConfig && this.graph.runConfig.disableSetMetadata) &&
       // Only set metadata if not using BigQuery dry run
-      !this.executionOptions.bigquery?.dryRun && 
+      !this.executionOptions.bigquery?.dryRun &&
       action.type === "table"
     ) {
       try {
@@ -413,7 +413,7 @@ export class Runner {
     this.notifyListeners();
     if(options.bigquery?.dryRun && task.type === "assertion") {
       taskResult.status = dataform.TaskResult.ExecutionStatus.SUCCESSFUL;
-    } 
+    }
     else {
       try {
         // Retry this function a given number of times, configurable by user

--- a/cli/console.ts
+++ b/cli/console.ts
@@ -230,6 +230,11 @@ export function printExecutedAction(
 ) {
   switch (executedAction.status) {
     case dataform.ActionResult.ExecutionStatus.SUCCESSFUL: {
+      const jobIds = executedAction.tasks
+        .filter(task => task.metadata?.bigquery?.jobId)
+        .map(task => task.metadata.bigquery.jobId);
+      const jobIdSuffix = jobIds.length > 0 ? ` (jobId: ${jobIds.join(", ")})` : "";
+      
       switch (executionAction.type) {
         case "table": {
           writeStdOut(
@@ -237,7 +242,7 @@ export function printExecutedAction(
               executionAction.target,
               executionAction.tableType,
               executionAction.tasks.length === 0
-            )}`
+            )}${jobIdSuffix}`
           );
           return;
         }
@@ -245,7 +250,7 @@ export function printExecutedAction(
           writeStdOut(
             `${successOutput(
               `Assertion ${dryRun ? "dry run success" : "passed"}: `
-            )} ${assertionString(executionAction.target, executionAction.tasks.length === 0)}`
+            )} ${assertionString(executionAction.target, executionAction.tasks.length === 0)}${jobIdSuffix}`
           );
           return;
         }
@@ -253,7 +258,7 @@ export function printExecutedAction(
           writeStdOut(
             `${successOutput(
               `Operation ${dryRun ? "dry run success" : "completed successfully"}: `
-            )} ${operationString(executionAction.target, executionAction.tasks.length === 0)}`
+            )} ${operationString(executionAction.target, executionAction.tasks.length === 0)}${jobIdSuffix}`
           );
           return;
         }


### PR DESCRIPTION
Solves: https://github.com/dataform-co/dataform/issues/1944

Shows BigQuery jobId against each ran model as follows 

<img width="1215" alt="image" src="https://github.com/user-attachments/assets/0ecf0c7c-4174-49da-b88d-dec068bd2742" />


**Tests**

- [x] `bazel test //core/...` passes 
- [x] JobId shows against the correct model 
- [ ] JobId shows against failed model / assertion run 


**P.S.**

It will be good to have have the jobIds as hyperlinks but most default terminal emulators do not support this. From the terminals I have only Kitty supported it. Default MacOS terminal and Ghostty terminal did not support it. 