### PR TITLE
feat: show bigquery jobId when executing the job

### DIFF
--- a/cli/api/commands/run.ts
+++ b/cli/api/commands/run.ts
@@ -441,6 +441,11 @@ export class Runner {
           ? dataform.TaskResult.ExecutionStatus.CANCELLED
           : dataform.TaskResult.ExecutionStatus.FAILED;
         taskResult.errorMessage = `${this.graph.projectConfig.warehouse} error: ${e.message}`;
+        taskResult.metadata = {
+          bigquery: {
+            jobId: e.metadata?.bigquery?.jobId
+          }
+        };
       }
     }
     taskResult.timing = timer.end();

--- a/cli/api/commands/run.ts
+++ b/cli/api/commands/run.ts
@@ -441,11 +441,13 @@ export class Runner {
           ? dataform.TaskResult.ExecutionStatus.CANCELLED
           : dataform.TaskResult.ExecutionStatus.FAILED;
         taskResult.errorMessage = `${this.graph.projectConfig.warehouse} error: ${e.message}`;
-        taskResult.metadata = {
-          bigquery: {
-            jobId: e.metadata?.bigquery?.jobId
-          }
-        };
+        if (e.metadata?.bigquery?.jobId) {
+          taskResult.metadata = {
+            bigquery: {
+              jobId: e.metadata.bigquery.jobId
+            }
+          };
+        }
       }
     }
     taskResult.timing = timer.end();

--- a/cli/api/dbadapters/bigquery.ts
+++ b/cli/api/dbadapters/bigquery.ts
@@ -389,11 +389,13 @@ export class BigQueryDbAdapter implements IDbAdapter {
                   const [jobMetadata] = await job[0].getMetadata();
                   if (!!jobMetadata.status?.errorResult) {
                     const error: any = new Error(jobMetadata.status.errorResult.message);
+                    if (jobMetadata.jobReference && jobMetadata.jobReference.jobId) {
                     error.metadata = {
                       bigquery: {
-                        jobId: jobMetadata.jobReference.jobId,
-                      }
-                    };
+                          jobId: jobMetadata.jobReference.jobId,
+                        }
+                      };
+                    }
                     reject(error);
                     return;
                   }

--- a/cli/api/dbadapters/bigquery.ts
+++ b/cli/api/dbadapters/bigquery.ts
@@ -3,7 +3,7 @@ import { PromisePoolExecutor } from "promise-pool-executor";
 
 import { BigQuery, GetTablesResponse, TableField, TableMetadata } from "@google-cloud/bigquery";
 import { collectEvaluationQueries, QueryOrAction } from "df/cli/api/dbadapters/execution_sql";
-import { IDbAdapter, IDbClient, IExecutionResult, OnCancel } from "df/cli/api/dbadapters/index";
+import { IDbAdapter, IDbClient, IExecutionResult, OnCancel, BigQueryError } from "df/cli/api/dbadapters/index";
 import { parseBigqueryEvalError } from "df/cli/api/utils/error_parsing";
 import { LimitedResultSet } from "df/cli/api/utils/results";
 import { coerceAsError } from "df/common/errors/errors";
@@ -356,7 +356,7 @@ export class BigQueryDbAdapter implements IDbAdapter {
               byteLimit
             });
             resultStream
-              .on("error", async (e: any) => {
+              .on("error", async (e: BigQueryError) => {
                 // Dry run queries against BigQuery done by this package eagerly fail with
                 // "Not found: job". This is a workaround to avoid that.
                 // Example: https://github.com/googleapis/python-bigquery/issues/118.
@@ -367,15 +367,12 @@ export class BigQueryDbAdapter implements IDbAdapter {
                 
                 try {
                   const [jobMetadata] = await job[0].getMetadata();
-                  if (jobMetadata && jobMetadata.jobReference && jobMetadata.jobReference.jobId) {
-                    e.metadata = {
-                      bigquery: {
-                        jobId: jobMetadata.jobReference.jobId,
-                      }
-                    };
+                  if (!!jobMetadata.status?.errorResult) {
+                    const error = createBigQueryError(jobMetadata);
+                    reject(error);
                   }
                 } catch (metadataError) {
-                  reject(e);
+                  reject(metadataError);
                 }
                 reject(e);
               })
@@ -388,14 +385,7 @@ export class BigQueryDbAdapter implements IDbAdapter {
                 try {
                   const [jobMetadata] = await job[0].getMetadata();
                   if (!!jobMetadata.status?.errorResult) {
-                    const error: any = new Error(jobMetadata.status.errorResult.message);
-                    if (jobMetadata.jobReference && jobMetadata.jobReference.jobId) {
-                    error.metadata = {
-                      bigquery: {
-                          jobId: jobMetadata.jobReference.jobId,
-                        }
-                      };
-                    }
+                    const error = createBigQueryError(jobMetadata);
                     reject(error);
                     return;
                   }
@@ -526,4 +516,16 @@ function addDescriptionToMetadata(
     mapDescriptionToMetadata(metaItem, [metaItem.name])
   );
   return newMetadata;
+}
+
+function createBigQueryError(jobMetadata: any): BigQueryError {
+  const error: BigQueryError = new Error(jobMetadata.status.errorResult.message);
+  if (jobMetadata.jobReference && jobMetadata.jobReference.jobId) {
+    error.metadata = {
+      bigquery: {
+        jobId: jobMetadata.jobReference.jobId,
+      }
+    };
+  }
+  return error;
 }

--- a/cli/api/dbadapters/bigquery.ts
+++ b/cli/api/dbadapters/bigquery.ts
@@ -3,7 +3,7 @@ import { PromisePoolExecutor } from "promise-pool-executor";
 
 import { BigQuery, GetTablesResponse, TableField, TableMetadata } from "@google-cloud/bigquery";
 import { collectEvaluationQueries, QueryOrAction } from "df/cli/api/dbadapters/execution_sql";
-import { IDbAdapter, IDbClient, IExecutionResult, OnCancel, BigQueryError } from "df/cli/api/dbadapters/index";
+import { IBigQueryError, IDbAdapter, IDbClient, IExecutionResult, OnCancel } from "df/cli/api/dbadapters/index";
 import { parseBigqueryEvalError } from "df/cli/api/utils/error_parsing";
 import { LimitedResultSet } from "df/cli/api/utils/results";
 import { coerceAsError } from "df/common/errors/errors";
@@ -356,7 +356,7 @@ export class BigQueryDbAdapter implements IDbAdapter {
               byteLimit
             });
             resultStream
-              .on("error", async (e: BigQueryError) => {
+              .on("error", async (e: IBigQueryError) => {
                 // Dry run queries against BigQuery done by this package eagerly fail with
                 // "Not found: job". This is a workaround to avoid that.
                 // Example: https://github.com/googleapis/python-bigquery/issues/118.
@@ -518,8 +518,8 @@ function addDescriptionToMetadata(
   return newMetadata;
 }
 
-function createBigQueryError(jobMetadata: any): BigQueryError {
-  const error: BigQueryError = new Error(jobMetadata.status.errorResult.message);
+function createBigQueryError(jobMetadata: any): IBigQueryError {
+  const error: IBigQueryError = new Error(jobMetadata.status.errorResult.message);
   if (jobMetadata.jobReference && jobMetadata.jobReference.jobId) {
     error.metadata = {
       bigquery: {

--- a/cli/api/dbadapters/index.ts
+++ b/cli/api/dbadapters/index.ts
@@ -8,6 +8,10 @@ export interface IExecutionResult {
   metadata: dataform.IExecutionMetadata;
 }
 
+export interface BigQueryError extends Error {
+  metadata?: dataform.IExecutionMetadata
+}
+
 export interface IDbClient {
   execute(
     statement: string,

--- a/cli/api/dbadapters/index.ts
+++ b/cli/api/dbadapters/index.ts
@@ -8,7 +8,7 @@ export interface IExecutionResult {
   metadata: dataform.IExecutionMetadata;
 }
 
-export interface BigQueryError extends Error {
+export interface IBigQueryError extends Error {
   metadata?: dataform.IExecutionMetadata
 }
 

--- a/cli/console.ts
+++ b/cli/console.ts
@@ -265,6 +265,11 @@ export function printExecutedAction(
       }
     }
     case dataform.ActionResult.ExecutionStatus.FAILED: {
+      const jobIds = executedAction.tasks
+        .filter(task => task.metadata?.bigquery?.jobId)
+        .map(task => task.metadata.bigquery.jobId);
+      const jobIdSuffix = jobIds.length > 0 ? ` (jobId: ${jobIds.join(", ")})` : "";
+      
       switch (executionAction.type) {
         case "table": {
           writeStdErr(
@@ -272,7 +277,7 @@ export function printExecutedAction(
               executionAction.target,
               executionAction.tableType,
               executionAction.tasks.length === 0
-            )}`
+            )}${jobIdSuffix}`
           );
           break;
         }
@@ -281,7 +286,7 @@ export function printExecutedAction(
             `${errorOutput("Assertion failed: ")} ${assertionString(
               executionAction.target,
               executionAction.tasks.length === 0
-            )}`
+            )}${jobIdSuffix}`
           );
           break;
         }
@@ -290,7 +295,7 @@ export function printExecutedAction(
             `${errorOutput("Operation failed: ")} ${operationString(
               executionAction.target,
               executionAction.tasks.length === 0
-            )}`
+            )}${jobIdSuffix}`
           );
           break;
         }

--- a/cli/console.ts
+++ b/cli/console.ts
@@ -228,12 +228,12 @@ export function printExecutedAction(
   executionAction: dataform.IExecutionAction,
   dryRun?: boolean
 ) {
+  const jobIds = executedAction.tasks
+    .filter(task => task.metadata?.bigquery?.jobId)
+    .map(task => task.metadata.bigquery.jobId);
+  const jobIdSuffix = jobIds.length > 0 ? ` (jobId: ${jobIds.join(", ")})` : "";
   switch (executedAction.status) {
     case dataform.ActionResult.ExecutionStatus.SUCCESSFUL: {
-      const jobIds = executedAction.tasks
-        .filter(task => task.metadata?.bigquery?.jobId)
-        .map(task => task.metadata.bigquery.jobId);
-      const jobIdSuffix = jobIds.length > 0 ? ` (jobId: ${jobIds.join(", ")})` : "";
 
       switch (executionAction.type) {
         case "table": {
@@ -265,11 +265,6 @@ export function printExecutedAction(
       }
     }
     case dataform.ActionResult.ExecutionStatus.FAILED: {
-      const jobIds = executedAction.tasks
-        .filter(task => task.metadata?.bigquery?.jobId)
-        .map(task => task.metadata.bigquery.jobId);
-      const jobIdSuffix = jobIds.length > 0 ? ` (jobId: ${jobIds.join(", ")})` : "";
-      
       switch (executionAction.type) {
         case "table": {
           writeStdErr(

--- a/cli/console.ts
+++ b/cli/console.ts
@@ -230,6 +230,11 @@ export function printExecutedAction(
 ) {
   switch (executedAction.status) {
     case dataform.ActionResult.ExecutionStatus.SUCCESSFUL: {
+      const jobIds = executedAction.tasks
+        .filter(task => task.metadata?.bigquery?.jobId)
+        .map(task => task.metadata.bigquery.jobId);
+      const jobIdSuffix = jobIds.length > 0 ? ` (jobId: ${jobIds.join(", ")})` : "";
+
       switch (executionAction.type) {
         case "table": {
           writeStdOut(
@@ -237,7 +242,7 @@ export function printExecutedAction(
               executionAction.target,
               executionAction.tableType,
               executionAction.tasks.length === 0
-            )}`
+            )}${jobIdSuffix}`
           );
           return;
         }
@@ -245,7 +250,7 @@ export function printExecutedAction(
           writeStdOut(
             `${successOutput(
               `Assertion ${dryRun ? "dry run success" : "passed"}: `
-            )} ${assertionString(executionAction.target, executionAction.tasks.length === 0)}`
+            )} ${assertionString(executionAction.target, executionAction.tasks.length === 0)}${jobIdSuffix}`
           );
           return;
         }
@@ -253,7 +258,7 @@ export function printExecutedAction(
           writeStdOut(
             `${successOutput(
               `Operation ${dryRun ? "dry run success" : "completed successfully"}: `
-            )} ${operationString(executionAction.target, executionAction.tasks.length === 0)}`
+            )} ${operationString(executionAction.target, executionAction.tasks.length === 0)}${jobIdSuffix}`
           );
           return;
         }

--- a/contributing.md
+++ b/contributing.md
@@ -42,6 +42,14 @@ bazel test //core/...
 
 If you need to run integration tests, that rely on encrypted secrets, please [get in touch](mailto:opensource@dataform.co) with the team.
 
+### Lint
+
+The following command to check for any linting errors
+
+```bash
+./scripts/lint
+```
+
 ### Building
 
 Building the CLI will build most of the required components.


### PR DESCRIPTION
Solves: https://github.com/dataform-co/dataform/issues/1944

Shows BigQuery jobId against each ran model as follows. Happy to change the format the jobId is displayed 

<img width="1215" alt="image" src="https://github.com/user-attachments/assets/0ecf0c7c-4174-49da-b88d-dec068bd2742" />


**Tests**

- [x] `bazel test //core/...` passes 
- [x] JobId shows against the correct model 
- [x] JobId shows against failed model / assertion run 
- [x] Linting by running `./scripts/lint`


**P.S.**

It will be good to have have the jobIds as hyperlinks but most default terminal emulators do not support this. From the terminals I have only Kitty supported it. Default MacOS terminal and Ghostty terminal did not support it. 