### PR TITLE
fix: Correctly resolve legacy dependencies with qualified name.

### DIFF
--- a/core/actions/assertion.ts
+++ b/core/actions/assertion.ts
@@ -308,7 +308,6 @@ export class Assertion extends ActionBuilder<dataform.Assertion> {
     if (unverifiedConfig.dependencies) {
       unverifiedConfig.dependencyTargets = unverifiedConfig.dependencies.map(
         (dependency: string | object) => resolvableAsActionConfigTarget(dependency)
-        // typeof dependency === "string" ? { name: dependency } : dependency
       );
       delete unverifiedConfig.dependencies;
     }

--- a/core/actions/assertion.ts
+++ b/core/actions/assertion.ts
@@ -7,6 +7,7 @@ import {
   actionConfigToCompiledGraphTarget,
   configTargetToCompiledGraphTarget,
   nativeRequire,
+  resolvableAsActionConfigTarget,
   resolvableAsTarget,
   resolveActionsConfigFilename,
   toResolvable,
@@ -306,8 +307,8 @@ export class Assertion extends ActionBuilder<dataform.Assertion> {
   ): dataform.ActionConfig.AssertionConfig {
     if (unverifiedConfig.dependencies) {
       unverifiedConfig.dependencyTargets = unverifiedConfig.dependencies.map(
-        (dependency: string | object) =>
-          typeof dependency === "string" ? { name: dependency } : dependency
+        (dependency: string | object) => resolvableAsActionConfigTarget(dependency)
+        // typeof dependency === "string" ? { name: dependency } : dependency
       );
       delete unverifiedConfig.dependencies;
     }

--- a/core/actions/incremental_table.ts
+++ b/core/actions/incremental_table.ts
@@ -20,6 +20,7 @@ import {
   checkExcessProperties,
   configTargetToCompiledGraphTarget,
   nativeRequire,
+  resolvableAsActionConfigTarget,
   resolvableAsTarget,
   resolveActionsConfigFilename,
   strictKeysOf,
@@ -549,8 +550,7 @@ export class IncrementalTable extends ActionBuilder<dataform.Table> {
       delete unverifiedConfig.type;
       if (unverifiedConfig.dependencies) {
         unverifiedConfig.dependencyTargets = unverifiedConfig.dependencies.map(
-          (dependency: string | object) =>
-            typeof dependency === "string" ? { name: dependency } : dependency
+          (dependency: string | object) => resolvableAsActionConfigTarget(dependency)
         );
         delete unverifiedConfig.dependencies;
       }

--- a/core/actions/operation.ts
+++ b/core/actions/operation.ts
@@ -9,6 +9,7 @@ import {
   checkAssertionsForDependency,
   configTargetToCompiledGraphTarget,
   nativeRequire,
+  resolvableAsActionConfigTarget,
   resolvableAsTarget,
   resolveActionsConfigFilename,
   toResolvable
@@ -366,8 +367,7 @@ export class Operation extends ActionBuilder<dataform.Operation> {
       delete unverifiedConfig.type;
       if (unverifiedConfig.dependencies) {
         unverifiedConfig.dependencyTargets = unverifiedConfig.dependencies.map(
-          (dependency: string | object) =>
-            typeof dependency === "string" ? { name: dependency } : dependency
+          (dependency: string | object) => resolvableAsActionConfigTarget(dependency)
         );
         delete unverifiedConfig.dependencies;
       }

--- a/core/actions/table.ts
+++ b/core/actions/table.ts
@@ -19,6 +19,7 @@ import {
   checkAssertionsForDependency,
   checkExcessProperties,
   nativeRequire,
+  resolvableAsActionConfigTarget,
   resolvableAsTarget,
   resolveActionsConfigFilename,
   strictKeysOf,
@@ -523,8 +524,8 @@ export class Table extends ActionBuilder<dataform.Table> {
       delete unverifiedConfig.type;
       if (unverifiedConfig.dependencies) {
         unverifiedConfig.dependencyTargets = unverifiedConfig.dependencies.map(
-          (dependency: string | object) =>
-            typeof dependency === "string" ? { name: dependency } : dependency
+          (dependency: string | object) => resolvableAsActionConfigTarget(dependency)
+            // typeof dependency === "string" ? { name: dependency } : dependency
         );
         delete unverifiedConfig.dependencies;
       }

--- a/core/actions/table.ts
+++ b/core/actions/table.ts
@@ -525,7 +525,6 @@ export class Table extends ActionBuilder<dataform.Table> {
       if (unverifiedConfig.dependencies) {
         unverifiedConfig.dependencyTargets = unverifiedConfig.dependencies.map(
           (dependency: string | object) => resolvableAsActionConfigTarget(dependency)
-            // typeof dependency === "string" ? { name: dependency } : dependency
         );
         delete unverifiedConfig.dependencies;
       }

--- a/core/actions/view.ts
+++ b/core/actions/view.ts
@@ -18,11 +18,12 @@ import {
   checkExcessProperties,
   configTargetToCompiledGraphTarget,
   nativeRequire,
+  resolvableAsActionConfigTarget,
   resolvableAsTarget,
   resolveActionsConfigFilename,
   strictKeysOf,
   toResolvable,
-  validateQueryString
+  validateQueryString,
 } from "df/core/utils";
 import { dataform } from "df/protos/ts";
 
@@ -544,8 +545,7 @@ export class View extends ActionBuilder<dataform.Table> {
       delete unverifiedConfig.type;
       if (unverifiedConfig.dependencies) {
         unverifiedConfig.dependencyTargets = unverifiedConfig.dependencies.map(
-          (dependency: string | object) =>
-            typeof dependency === "string" ? { name: dependency } : dependency
+          (dependency: string | object) => resolvableAsActionConfigTarget(dependency)
         );
         delete unverifiedConfig.dependencies;
       }


### PR DESCRIPTION
Legacy dependencies with a qualified names like: `dataset_name.table_name` wasn't resolved  correctly, see #1896 

The current change fixes this behavior and properly parses `config.dependencies` when it contains string values.