### PR TITLE
Add `--check` option to format command

### DIFF
--- a/cli/console.ts
+++ b/cli/console.ts
@@ -234,7 +234,6 @@ export function printExecutedAction(
   const jobIdSuffix = jobIds.length > 0 ? ` (jobId: ${jobIds.join(", ")})` : "";
   switch (executedAction.status) {
     case dataform.ActionResult.ExecutionStatus.SUCCESSFUL: {
-
       switch (executionAction.type) {
         case "table": {
           writeStdOut(
@@ -250,7 +249,10 @@ export function printExecutedAction(
           writeStdOut(
             `${successOutput(
               `Assertion ${dryRun ? "dry run success" : "passed"}: `
-            )} ${assertionString(executionAction.target, executionAction.tasks.length === 0)}${jobIdSuffix}`
+            )} ${assertionString(
+              executionAction.target,
+              executionAction.tasks.length === 0
+            )}${jobIdSuffix}`
           );
           return;
         }
@@ -258,7 +260,10 @@ export function printExecutedAction(
           writeStdOut(
             `${successOutput(
               `Operation ${dryRun ? "dry run success" : "completed successfully"}: `
-            )} ${operationString(executionAction.target, executionAction.tasks.length === 0)}${jobIdSuffix}`
+            )} ${operationString(
+              executionAction.target,
+              executionAction.tasks.length === 0
+            )}${jobIdSuffix}`
           );
           return;
         }
@@ -371,15 +376,24 @@ export function printFormatFilesResult(
   formatResults: Array<{
     filename: string;
     err?: Error;
+    needsFormatting?: boolean;
   }>
 ) {
   const sorted = formatResults.sort((a, b) => a.filename.localeCompare(b.filename));
-  const successfulFormatResults = sorted.filter(result => !result.err);
+  const successfulFormatResults = sorted.filter(result => !result.err && !result.needsFormatting);
+  const needsFormattingResults = sorted.filter(result => !result.err && result.needsFormatting);
   const failedFormatResults = sorted.filter(result => !!result.err);
+
   if (successfulFormatResults.length > 0) {
     printSuccess("Successfully formatted:");
     successfulFormatResults.forEach(result => writeStdOut(result.filename, 1));
   }
+
+  if (needsFormattingResults.length > 0) {
+    printError("Files that need formatting:");
+    needsFormattingResults.forEach(result => writeStdOut(result.filename, 1));
+  }
+
   if (failedFormatResults.length > 0) {
     printError("Errors encountered during formatting:");
     failedFormatResults.forEach(result =>

--- a/cli/console.ts
+++ b/cli/console.ts
@@ -391,7 +391,7 @@ export function printFormatFilesResult(
 
   if (needsFormattingResults.length > 0) {
     printError("Files that need formatting:");
-    needsFormattingResults.forEach(result => writeStdOut(result.filename, 1));
+    needsFormattingResults.forEach(result => writeStdErr(result.filename, 1));
   }
 
   if (failedFormatResults.length > 0) {

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -648,6 +648,12 @@ export function runCli() {
 
           printFormatFilesResult(results);
 
+          // Return error code if there are any formatting errors
+          const failedFormatResults = results.filter(result => !!result.err);
+          if (failedFormatResults.length > 0) {
+            return 1;
+          }
+
           // In check mode, return an error code if any files need formatting
           if (isCheckMode) {
             const filesNeedingFormatting = results.filter(result => result.needsFormatting);

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -651,6 +651,7 @@ export function runCli() {
           // Return error code if there are any formatting errors
           const failedFormatResults = results.filter(result => !!result.err);
           if (failedFormatResults.length > 0) {
+            printError(`${failedFormatResults.length} file(s) failed to format.`);
             return 1;
           }
 

--- a/cli/index_test.ts
+++ b/cli/index_test.ts
@@ -303,6 +303,43 @@ select 1 as \${dataform.projectConfig.vars.testVar2}
       },
       warehouseState: {}
     });
+  });
+
+  test("test for format command", async () => {
+    const projectDir = tmpDirFixture.createNewTmpDir();
+    const npmCacheDir = tmpDirFixture.createNewTmpDir();
+    const workflowSettingsPath = path.join(projectDir, "workflow_settings.yaml");
+    const packageJsonPath = path.join(projectDir, "package.json");
+
+    // Initialize a project using the CLI, don't install packages.
+    await getProcessResult(
+      execFile(nodePath, [cliEntryPointPath, "init", projectDir, "dataform-open-source", "US"])
+    );
+
+    // Install packages manually to get around bazel read-only sandbox issues.
+    const workflowSettings = dataform.WorkflowSettings.create(
+      loadYaml(fs.readFileSync(workflowSettingsPath, "utf8"))
+    );
+    delete workflowSettings.dataformCoreVersion;
+    fs.writeFileSync(workflowSettingsPath, dumpYaml(workflowSettings));
+    fs.writeFileSync(
+      packageJsonPath,
+      `{
+  "dependencies":{
+    "@dataform/core": "${version}"
+  }
+}`
+    );
+    await getProcessResult(
+      execFile(npmPath, [
+        "install",
+        "--prefix",
+        projectDir,
+        "--cache",
+        npmCacheDir,
+        corePackageTarPath
+      ])
+    );
 
     // Create a correctly formatted file
     const formattedFilePath = path.join(projectDir, "definitions", "formatted.sqlx");
@@ -331,17 +368,20 @@ SELECT  1  as   test
     );
 
     // Test with --check flag on a project with files needing formatting
-    const checkResult = await getProcessResult(
+    const beforeFormatCheckResult = await getProcessResult(
       execFile(nodePath, [cliEntryPointPath, "format", projectDir, "--check"])
     );
 
     // Should exit with code 1 when files need formatting
-    expect(checkResult.exitCode).equals(1);
-    expect(checkResult.stderr).contains("Files that need formatting");
-    expect(checkResult.stderr).contains("unformatted.sqlx");
+    expect(beforeFormatCheckResult.exitCode).equals(1);
+    expect(beforeFormatCheckResult.stderr).contains("Files that need formatting");
+    expect(beforeFormatCheckResult.stderr).contains("unformatted.sqlx");
 
     // Format the files (without check flag)
-    await getProcessResult(execFile(nodePath, [cliEntryPointPath, "format", projectDir]));
+    const formatCheckResult = await getProcessResult(
+      execFile(nodePath, [cliEntryPointPath, "format", projectDir])
+    );
+    expect(formatCheckResult.exitCode).equals(0);
 
     // Test with --check flag after formatting
     const afterFormatCheckResult = await getProcessResult(


### PR DESCRIPTION
## Overview

This PR implements the Feature Request to add a `--check` flag to the `format` command.

## Changes

- Added a new `--check` flag to the format command
- Modified the format command implementation to support check mode without modifying files
- Enhanced the output formatting to clearly show which files need formatting
- Made the command return exit code 1 if any files need formatting in check mode

## How it works

When used with `--check`, the command:
1. Analyzes each file that would be formatted
2. Compares the current content with what it would be if formatted
3. Reports files needing formatting without modifying them
4. Returns exit code 1 if any files need formatting

## Example usage

```bash
# Check if all files are formatted correctly without modifying them
dataform format --check

# Check specific files
dataform format --check --actions="definitions/my_model.sqlx" 
```

## Testing

I've tested both the regular format mode (which continues to work as before) and the new check mode.

In check mode:
- When all files are formatted correctly: displays success message and returns exit code 0
- When files need formatting: displays the list of files needing formatting and returns exit code 1

This implementation follows similar patterns used in other code formatting tools like Prettier, ESLint, and Black, making Dataform better suited for modern CI/CD pipelines and development workflows.

Closes #1961
