### PR TITLE
Dataform API: Interactive Check - Fixing BQ Job Priority

### DIFF
--- a/cli/api/dbadapters/bigquery.ts
+++ b/cli/api/dbadapters/bigquery.ts
@@ -333,6 +333,7 @@ export class BigQueryDbAdapter implements IDbAdapter {
           const job = await this.getClient().createQueryJob({
             useLegacySql: false,
             jobPrefix: "dataform-" + (jobPrefix ? `${jobPrefix}-` : ""),
+            priority: "BATCH",
             query,
             params,
             labels,


### PR DESCRIPTION
Dataform API:

The BigQueryDbAdapter is executed by default with interactive mode as false and createQueryJob method is called in such cases. 

But the createQueryJob API is invoked without explicitly setting the priority because of which the default INTERACTIVE mode is always executed. Hence, dataform jobs are always submitted only in INTERACTIVE mode. 

However, running the ELT pipeline jobs in BATCH mode is very critical for BigQuery's analytics performance which is drastically impacted by this behaviour. 

This is been fixed as part of this commit by passing the priority as BATCH while submitting the query jobs for BigQuery.  