### PR TITLE
fix(actions): gracefully exit when no actions to run

### DIFF
--- a/cli/index.ts
+++ b/cli/index.ts
@@ -532,11 +532,6 @@ export function runCli() {
             printSuccess("Unit tests completed successfully.\n");
           }
 
-          if (argv[dryRunOptionName]) {
-            print("Dry running (no changes to the warehouse will be applied)...");
-          } else {
-            print("Running...\n");
-          }
           let bigqueryOptions: {} = {
             actionRetryLimit: argv[actionRetryLimitName]
           };
@@ -555,6 +550,18 @@ export function runCli() {
           executionGraph.actions.forEach(action => {
             actionsByName.set(targetAsReadableString(action.target), action);
           });
+
+          if (actionsByName.size === 0) {
+            print("No actions to run...\n");
+            return 0;
+          } 
+
+          if (argv[dryRunOptionName]) {
+            print("Dry running (no changes to the warehouse will be applied)...");
+          } else {
+            print("Running...\n");
+          }
+
           const alreadyPrintedActions = new Set<string>();
 
           const printExecutedGraph = (executedGraph: dataform.IRunResult) => {

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -541,10 +541,6 @@ export function runCli() {
           if (argv[jobPrefixOption.name]) {
             bigqueryOptions = { ...bigqueryOptions, jobPrefix: argv[jobPrefixOption.name] };
           }
-          const runner = run(dbadapter, executionGraph, { bigquery: bigqueryOptions });
-          process.on("SIGINT", () => {
-            runner.cancel();
-          });
 
           const actionsByName = new Map<string, dataform.IExecutionAction>();
           executionGraph.actions.forEach(action => {
@@ -552,9 +548,14 @@ export function runCli() {
           });
 
           if (actionsByName.size === 0) {
-            print("No actions to run...\n");
+            print("No actions to run.\n");
             return 0;
-          } 
+          }
+
+          const runner = run(dbadapter, executionGraph, { bigquery: bigqueryOptions });
+          process.on("SIGINT", () => {
+            runner.cancel();
+          });
 
           if (argv[dryRunOptionName]) {
             print("Dry running (no changes to the warehouse will be applied)...");

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -552,16 +552,16 @@ export function runCli() {
             return 0;
           }
 
-          const runner = run(dbadapter, executionGraph, { bigquery: bigqueryOptions });
-          process.on("SIGINT", () => {
-            runner.cancel();
-          });
-
           if (argv[dryRunOptionName]) {
             print("Dry running (no changes to the warehouse will be applied)...");
           } else {
             print("Running...\n");
           }
+
+          const runner = run(dbadapter, executionGraph, { bigquery: bigqueryOptions });
+          process.on("SIGINT", () => {
+            runner.cancel();
+          });
 
           const alreadyPrintedActions = new Set<string>();
 


### PR DESCRIPTION
Fixes: https://github.com/dataform-co/dataform/issues/1945

Show user a log message that there is no actions to run instead of prematurely showing running

<img src="https://github.com/user-attachments/assets/b7bc26e4-9c15-4166-9454-eca87fd027e9" height="400" width="400" alt="" />

Tests

- [x] `./scripts/lint` passes
- [x] `bazel test //core/...` passes 

