### PR TITLE
Protected incremental table ignores full-refresh

### DIFF
--- a/cli/api/commands/build.ts
+++ b/cli/api/commands/build.ts
@@ -78,10 +78,6 @@ export class Builder {
     tableMetadata: dataform.ITableMetadata,
     runConfig: dataform.IRunConfig
   ) {
-    if (table.protected && this.runConfig.fullRefresh) {
-      throw new Error("Protected datasets cannot be fully refreshed.");
-    }
-
     return {
       ...this.toPartialExecutionAction(table),
       type: "table",

--- a/cli/api/dbadapters/execution_sql.ts
+++ b/cli/api/dbadapters/execution_sql.ts
@@ -74,11 +74,12 @@ from (${query}) as insertions`;
   }
 
   public shouldWriteIncrementally(
+    table: dataform.ITable,
     runConfig: dataform.IRunConfig,
     tableMetadata?: dataform.ITableMetadata
   ) {
     return (
-      !runConfig.fullRefresh &&
+      (!runConfig.fullRefresh || table.protected) &&
       tableMetadata &&
       tableMetadata.type !== dataform.TableMetadata.Type.VIEW
     );
@@ -93,7 +94,7 @@ from (${query}) as insertions`;
     if (
       semver.gt(this.dataformCoreVersion, "1.4.8") &&
       table.enumType === dataform.TableType.INCREMENTAL &&
-      this.shouldWriteIncrementally(runConfig, tableMetadata)
+      this.shouldWriteIncrementally(table, runConfig, tableMetadata)
     ) {
       preOps = table.incrementalPreOps;
     }
@@ -109,7 +110,7 @@ from (${query}) as insertions`;
     if (
       semver.gt(this.dataformCoreVersion, "1.4.8") &&
       table.enumType === dataform.TableType.INCREMENTAL &&
-      this.shouldWriteIncrementally(runConfig, tableMetadata)
+      this.shouldWriteIncrementally(table, runConfig, tableMetadata)
     ) {
       postOps = table.incrementalPostOps;
     }
@@ -137,7 +138,7 @@ from (${query}) as insertions`;
     }
 
     if (table.enumType === dataform.TableType.INCREMENTAL) {
-      if (!this.shouldWriteIncrementally(runConfig, tableMetadata)) {
+      if (!this.shouldWriteIncrementally(table, runConfig, tableMetadata)) {
         tasks.add(Task.statement(this.createOrReplace(table)));
       } else {
         tasks.add(


### PR DESCRIPTION
According to the documentation in https://cloud.google.com/dataform/docs/reference/dataform-core-reference#itableconfig:


> __protected__ | boolean
>
> Only allowed for the incremental table type. If set to true, running this action ignores the full-refresh option. This is useful for tables which are built from transient data, to ensure that historical data is never lost.

Our current behavior: the `run` command of Dataform CLI fails with an error `Protected datasets cannot be fully refreshed.` However, on GCP the behavior is correct and the action is executed in incremental mode (basically ignoring `full refresh`).

This PR makes CLI behavior aligned with the documentation and GCP.

Closes #1892.