### PR TITLE
fix: access of possibly undefined `toNumber` function call

### DIFF
--- a/cli/console.ts
+++ b/cli/console.ts
@@ -257,7 +257,7 @@ export function printExecutedAction(
   const bytesBilled = executedAction.tasks
     .filter(task => task.metadata?.bigquery?.jobId)
     .map(task => {
-        const bytes = task.metadata.bigquery?.totalBytesBilled?.toNumber() ?? 0;
+        const bytes = task.metadata.bigquery?.totalBytesBilled?.toNumber?.() ?? 0;
         return formatBytesInHumanReadableFormat(bytes);
     });
 


### PR DESCRIPTION
Solves issue highlighted in https://github.com/dataform-co/dataform/pull/1971 by [descampsk](https://github.com/descampsk) , https://github.com/dataform-co/dataform/pull/1971#issuecomment-2994067994 by calling toNumber without a guard using the suggestion https://github.com/dataform-co/dataform/pull/1971#issuecomment-2994105275


**Test**

- [x]  ./scripts/lint passes
- [x]  bazel test //core/... passes