### PR TITLE
Fail compilation if onSchemaChange is set on incremental table.

### DIFF
--- a/core/actions/incremental_table.ts
+++ b/core/actions/incremental_table.ts
@@ -607,6 +607,12 @@ export class IncrementalTable extends ActionBuilder<dataform.Table> {
       checkConfigAdditionalOptionsOverlap(config, this.session);
     }
 
+    // Temporary fail the compilation if non-default `onSchemaChange` value is provided until the official release of the feature on Dataform GCP.
+    const onSchemaChange = this.mapOnSchemaChange(config.onSchemaChange)
+    if (onSchemaChange != dataform.OnSchemaChange.IGNORE) {
+      throw new Error(`OnSchemaChange is not supported yet. It will be available as soon as Dataform GCP will officially release this feature.`);
+    }
+
     return config;
   }
 

--- a/core/actions/incremental_table.ts
+++ b/core/actions/incremental_table.ts
@@ -609,7 +609,7 @@ export class IncrementalTable extends ActionBuilder<dataform.Table> {
 
     // Temporary fail the compilation if non-default `onSchemaChange` value is provided until the official release of the feature on Dataform GCP.
     const onSchemaChange = this.mapOnSchemaChange(config.onSchemaChange)
-    if (onSchemaChange != dataform.OnSchemaChange.IGNORE) {
+    if (onSchemaChange !== dataform.OnSchemaChange.IGNORE) {
       throw new Error(`OnSchemaChange is not supported yet. It will be available as soon as Dataform GCP will officially release this feature.`);
     }
 

--- a/core/actions/incremental_table_test.ts
+++ b/core/actions/incremental_table_test.ts
@@ -100,7 +100,8 @@ actions:
     dependOnDependencyAssertions: true,
     ${exampleBuiltInAssertions.inputAssertionBlock}
     hermetic: true,
-    onSchemaChange: "SYNCHRONIZE",
+    // Re-enable when Incremental Schema Update will be officially released on Dataform GCP.
+    // onSchemaChange: "SYNCHRONIZE",
 }
 `;
     [
@@ -147,7 +148,8 @@ SELECT 1`
             disabled: true,
             protected: false,
             hermeticity: "HERMETIC",
-            onSchemaChange: "SYNCHRONIZE",
+            // Replace when Incremental Schema Update will be officially released on Dataform GCP.
+            onSchemaChange: "IGNORE", // onSchemaChange: "SYNCHRONIZE",
             bigquery: {
               additionalOptions: {
                 option1Key: "option1",
@@ -277,7 +279,8 @@ actions:
     dependOnDependencyAssertions: true
     ${exampleBuiltInAssertionsAsYaml.inputActionConfigBlock}
     hermetic: true
-    onSchemaChange: FAIL
+    # Re-enable when Incremental Schema Update will be officially released on Dataform GCP.
+    # onSchemaChange: FAIL
   `
     );
 
@@ -300,7 +303,8 @@ actions:
         disabled: true,
         protected: true,
         hermeticity: "HERMETIC",
-        onSchemaChange: "FAIL",
+        // Replace when Incremental Schema Update will be officially released on Dataform GCP.
+        onSchemaChange: "IGNORE", // onSchemaChange: "FAIL",
         bigquery: {
           additionalOptions: {
             option1Key: "option1",


### PR DESCRIPTION
While Incremental Table Schema Update is not officially released on Dataform GCP, we need to fail the compilation if `onSchemaChange` field is set on incremental table config.

Resolves #1906. 