### PR TITLE
feat: improve formatting for `dataform run` stdout

### DIFF
--- a/cli/util.ts
+++ b/cli/util.ts
@@ -21,12 +21,12 @@ export function compiledGraphHasErrors(graph: dataform.ICompiledGraph) {
 export function formatExecutionSuffix(jobIds: string[], bytesBilled: string[]): string {
   const jobMetadataParts: string[] = [];
   if (jobIds.length > 0) {
-    jobMetadataParts.push(`jobId: ${jobIds.join(", ")}`);
+    jobMetadataParts.push(`\n \t jobId: ${jobIds.join(", ")}`);
   }
   if (bytesBilled.length > 0) {
-    jobMetadataParts.push(`Bytes billed: ${bytesBilled.join(", ")}`);
+    jobMetadataParts.push(`\n \t Bytes billed: ${bytesBilled.join(", ")}`);
   }
-  return jobMetadataParts.length > 0 ? ` (${jobMetadataParts.join(" | ")})` : "";
+  return jobMetadataParts.length > 0 ? ` ${jobMetadataParts}` : "";
 }
 
 export function formatBytesInHumanReadableFormat(bytes: number): string {

--- a/cli/util_test.ts
+++ b/cli/util_test.ts
@@ -6,10 +6,10 @@ import { suite, test } from "df/testing";
 suite('format execution suffix', () => {
     test('format execution suffix', () => {
         expect(formatExecutionSuffix([], [])).deep.equals('');
-        expect(formatExecutionSuffix(["dataform-915a03fe1"], [])).deep.equals(" (jobId: dataform-915a03fe1)");
-        expect(formatExecutionSuffix([], ["10 MiB"])).deep.equals(" (Bytes billed: 10 MiB)");
-        expect(formatExecutionSuffix(["dataform-915a03fe1"], ["17 KiB"])).deep.equals(" (jobId: dataform-915a03fe1 | Bytes billed: 17 KiB)");
-        expect(formatExecutionSuffix(["dataform-915a03fe1", "dataform-915a03fe2"], ["17 KiB", "1 GiB"])).deep.equals(" (jobId: dataform-915a03fe1, dataform-915a03fe2 | Bytes billed: 17 KiB, 1 GiB)");
+        expect(formatExecutionSuffix(["dataform-915a03fe1"], [])).deep.equals(" \n \t jobId: dataform-915a03fe1");
+        expect(formatExecutionSuffix([], ["10 MiB"])).deep.equals(" \n \t Bytes billed: 10 MiB");
+        expect(formatExecutionSuffix(["dataform-915a03fe1"], ["17 KiB"])).deep.equals(" \n \t jobId: dataform-915a03fe1,\n \t Bytes billed: 17 KiB");
+        expect(formatExecutionSuffix(["dataform-915a03fe1", "dataform-915a03fe2"], ["17 KiB", "1 GiB"])).deep.equals(" \n \t jobId: dataform-915a03fe1, dataform-915a03fe2,\n \t Bytes billed: 17 KiB, 1 GiB");
     });
 });
 


### PR DESCRIPTION
Solves: https://github.com/dataform-co/dataform/issues/1993

Moves the metadata (jobId, Bytes billed) of dataform run for table/view/operation to a new line and indented to the right making the output more readable. 

<img src="https://github.com/user-attachments/assets/f18a1334-57e4-46cd-a2cd-c6aa7a269741" height="700" width="380" alt="" />


**Tests**

- [x] bazel test //core/... passes
- [x] Linting by running ./scripts/lint