### PR TITLE
Enable setting default values for storageUri substrings when constructing an Iceberg table.

### DIFF
--- a/core/actions/incremental_table.ts
+++ b/core/actions/incremental_table.ts
@@ -199,9 +199,9 @@ export class IncrementalTable extends ActionBuilder<dataform.Table> {
         fileFormat: getFileFormatValueForIcebergTable(config.iceberg.fileFormat?.toString()),
         tableFormat: dataform.TableFormat.ICEBERG,
         storageUri: getStorageUriForIcebergTable(
-          getEffectiveBucketName(session.projectConfig.defaultBucketName, config.iceberg.bucketName),
-          getEffectiveTableFolderRoot(session.projectConfig.defaultTableFolderRoot, config.iceberg.tableFolderRoot),
-          getEffectiveTableFolderSubpath(this.proto.target.schema, this.proto.target.name, session.projectConfig.defaultTableFolderSubpath, config.iceberg.tableFolderSubpath),
+          getEffectiveBucketName(session.projectConfig.defaultIcebergConfigs?.defaultBucketName, config.iceberg.bucketName),
+          getEffectiveTableFolderRoot(session.projectConfig.defaultIcebergConfigs?.defaultTableFolderRoot, config.iceberg.tableFolderRoot),
+          getEffectiveTableFolderSubpath(this.proto.target.schema, this.proto.target.name, session.projectConfig.defaultIcebergConfigs?.defaultTableFolderSubpath, config.iceberg.tableFolderSubpath),
         ),
       } : {}),
     });

--- a/core/actions/incremental_table.ts
+++ b/core/actions/incremental_table.ts
@@ -199,9 +199,9 @@ export class IncrementalTable extends ActionBuilder<dataform.Table> {
         fileFormat: getFileFormatValueForIcebergTable(config.iceberg.fileFormat?.toString()),
         tableFormat: dataform.TableFormat.ICEBERG,
         storageUri: getStorageUriForIcebergTable(
-          getEffectiveBucketName(session.projectConfig.defaultIcebergConfigs?.defaultBucketName, config.iceberg.bucketName),
-          getEffectiveTableFolderRoot(session.projectConfig.defaultIcebergConfigs?.defaultTableFolderRoot, config.iceberg.tableFolderRoot),
-          getEffectiveTableFolderSubpath(this.proto.target.schema, this.proto.target.name, session.projectConfig.defaultIcebergConfigs?.defaultTableFolderSubpath, config.iceberg.tableFolderSubpath),
+          getEffectiveBucketName(session.projectConfig.defaultIcebergConfig?.defaultBucketName, config.iceberg.bucketName),
+          getEffectiveTableFolderRoot(session.projectConfig.defaultIcebergConfig?.defaultTableFolderRoot, config.iceberg.tableFolderRoot),
+          getEffectiveTableFolderSubpath(this.proto.target.schema, this.proto.target.name, session.projectConfig.defaultIcebergConfig?.defaultTableFolderSubpath, config.iceberg.tableFolderSubpath),
         ),
       } : {}),
     });

--- a/core/actions/incremental_table.ts
+++ b/core/actions/incremental_table.ts
@@ -20,6 +20,8 @@ import {
   checkExcessProperties,
   configTargetToCompiledGraphTarget,
   getConnectionForIcebergTable,
+  getEffectiveBucketName,
+  getEffectiveTableFolderRoot,
   getEffectiveTableFolderSubpath,
   getFileFormatValueForIcebergTable,
   getStorageUriForIcebergTable,
@@ -197,9 +199,9 @@ export class IncrementalTable extends ActionBuilder<dataform.Table> {
         fileFormat: getFileFormatValueForIcebergTable(config.iceberg.fileFormat?.toString()),
         tableFormat: dataform.TableFormat.ICEBERG,
         storageUri: getStorageUriForIcebergTable(
-          config.iceberg.bucketName,
-          getEffectiveTableFolderSubpath(this.proto.target.schema, this.proto.target.name, config.iceberg.tableFolderSubpath),
-          config.iceberg.tableFolderRoot,
+          getEffectiveBucketName(session.projectConfig.defaultBucketName, config.iceberg.bucketName),
+          getEffectiveTableFolderRoot(session.projectConfig.defaultTableFolderRoot, config.iceberg.tableFolderRoot),
+          getEffectiveTableFolderSubpath(this.proto.target.schema, this.proto.target.name, session.projectConfig.defaultTableFolderSubpath, config.iceberg.tableFolderSubpath),
         ),
       } : {}),
     });
@@ -602,11 +604,6 @@ export class IncrementalTable extends ActionBuilder<dataform.Table> {
         ) {
           throw new ReferenceError(
             `Unexpected file format; only "PARQUET" is allowed, got "${unverifiedConfig.iceberg.fileFormat}".`
-          );
-        }
-        if (!unverifiedConfig.iceberg.bucketName) {
-          throw new ReferenceError(
-            'Reference error: bucket_name must be defined in an iceberg subblock.'
           );
         }
       }

--- a/core/actions/incremental_table_test.ts
+++ b/core/actions/incremental_table_test.ts
@@ -273,8 +273,8 @@ actions:
     labels:
         key: val
     additionalOptions:
-        option1Key: option1
-        option2Key: option2
+        option1Key: "option1"
+        option2Key: "option2"
     dependOnDependencyAssertions: true
     ${exampleBuiltInAssertionsAsYaml.inputActionConfigBlock}
     hermetic: true
@@ -352,6 +352,25 @@ actions:
       fs.writeFileSync(path.join(projectDir, `definitions/${filename}`), fileContents);
     };
 
+    // Helper to set up files with custom workflow settings
+    const setupFilesWithCustomWs = (projectDir: string, filename: string, fileContents: string, wsContent: string) => {
+      fs.writeFileSync(
+        path.join(projectDir, "workflow_settings.yaml"),
+        wsContent
+      );
+      fs.mkdirSync(path.join(projectDir, "definitions"));
+      fs.writeFileSync(path.join(projectDir, `definitions/${filename}`), fileContents);
+    };
+
+    const CUSTOM_WORKFLOW_SETTINGS_WITH_ICEBERG_DEFAULTS = `
+defaultProject: "defaultProject"
+defaultDataset: "defaultDataset"
+defaultLocation: "us-central1"
+defaultBucketName: "ws-default-bucket"
+defaultTableFolderRoot: "ws-default-root"
+defaultTableFolderSubpath: "ws-default-sub"
+`;
+
     const testCases = [
       {
         testName: "with all values provided and resource form connection",
@@ -376,6 +395,7 @@ actions:
           },
         },
         expectError: false,
+        wsContent: VALID_WORKFLOW_SETTINGS_YAML,
       },
       {
         testName: "with all values provided and dot form connection",
@@ -400,6 +420,7 @@ actions:
           },
         },
         expectError: false,
+        wsContent: VALID_WORKFLOW_SETTINGS_YAML,
       },
       {
         testName: "defaults to \`_dataform\` for tableFolderRoot",
@@ -423,6 +444,7 @@ actions:
           },
         },
         expectError: false,
+        wsContent: VALID_WORKFLOW_SETTINGS_YAML,
       },
       {
         testName: "defaults to dataset and name for tableFolderSubpath with dataset and table name provided",
@@ -446,6 +468,7 @@ actions:
           },
         },
         expectError: false,
+        wsContent: VALID_WORKFLOW_SETTINGS_YAML,
       },
       {
         testName: "defaults to dataset and name for tableFolderSubpath with dataset from workflow settings",
@@ -468,6 +491,7 @@ actions:
           },
         },
         expectError: false,
+        wsContent: VALID_WORKFLOW_SETTINGS_YAML,
       },
       {
         testName: "defaults to PARQUET when file format is not set",
@@ -491,6 +515,7 @@ actions:
           },
         },
         expectError: false,
+        wsContent: VALID_WORKFLOW_SETTINGS_YAML,
       },
       {
         testName: "defaults to DEFAULT connection",
@@ -514,6 +539,7 @@ actions:
           },
         },
         expectError: false,
+        wsContent: VALID_WORKFLOW_SETTINGS_YAML,
       },
       {
         testName: "defaults to PARQUET when file format is empty",
@@ -538,6 +564,7 @@ actions:
           },
         },
         expectError: false,
+        wsContent: VALID_WORKFLOW_SETTINGS_YAML,
       },
       {
         testName: "invalid connection format",
@@ -552,6 +579,7 @@ actions:
             tableFolderSubpath: "my-subpath",
         }`,
         expectError: "The connection must be in the format `{project}.{location}.{connection_id}` or `projects/{project}/locations/{location}/connections/{connection_id}`, or be set to `DEFAULT`.",
+        wsContent: VALID_WORKFLOW_SETTINGS_YAML,
       },
       {
         testName: "invalid file format",
@@ -563,6 +591,7 @@ actions:
             bucketName: "my-bucket",
         }`,
         expectError: "Unexpected file format; only \"PARQUET\" is allowed, got \"AVRO\".",
+        wsContent: VALID_WORKFLOW_SETTINGS_YAML,
       },
       {
         testName: "bucketName not defined",
@@ -575,7 +604,8 @@ actions:
             tableFolderRoot: "my-root",
             tableFolderSubpath: "my-subpath",
         }`,
-        expectError: "Reference error: bucket_name must be defined in an iceberg subblock.",
+        expectError: "When defining an Iceberg table, bucket name must be defined in workspace_settings.yaml or the config block.",
+        wsContent: VALID_WORKFLOW_SETTINGS_YAML,
       },
       {
         testName: "with Iceberg options and other BigQuery options",
@@ -610,6 +640,144 @@ actions:
           },
         },
         expectError: false,
+        wsContent: VALID_WORKFLOW_SETTINGS_YAML,
+      },
+      {
+        testName: "uses defaultBucketName from workspace_settings.yaml",
+        wsContent: CUSTOM_WORKFLOW_SETTINGS_WITH_ICEBERG_DEFAULTS,
+        configBlock: `
+          type: "incremental",
+          name: "incremental_ws_bucket",
+          dataset: "dataset_ws",
+          iceberg: {
+              fileFormat: "PARQUET",
+              connection: "gcp.us.conn-id",
+              // bucketName omitted
+              tableFolderRoot: "my-root",
+              tableFolderSubpath: "my-subpath",
+          }`,
+        expected: {
+          target: { name: "incremental_ws_bucket", schema: "dataset_ws", database: "defaultProject" },
+          bigquery: {
+            tableFormat: "ICEBERG",
+            fileFormat: "PARQUET",
+            connection: "gcp.us.conn-id",
+            storageUri: "gs://ws-default-bucket/my-root/my-subpath",
+          },
+        },
+        expectError: false,
+      },
+      {
+        testName: "uses defaultTableFolderRoot from workspace_settings.yaml",
+        wsContent: CUSTOM_WORKFLOW_SETTINGS_WITH_ICEBERG_DEFAULTS,
+        configBlock: `
+          type: "incremental",
+          name: "incremental_ws_root",
+          dataset: "dataset_ws",
+          iceberg: {
+              fileFormat: "PARQUET",
+              connection: "gcp.us.conn-id",
+              bucketName: "my-bucket",
+              // tableFolderRoot omitted
+              tableFolderSubpath: "my-subpath",
+          }`,
+        expected: {
+          target: { name: "incremental_ws_root", schema: "dataset_ws", database: "defaultProject" },
+          bigquery: {
+            tableFormat: "ICEBERG",
+            fileFormat: "PARQUET",
+            connection: "gcp.us.conn-id",
+            storageUri: "gs://my-bucket/ws-default-root/my-subpath",
+          },
+        },
+        expectError: false,
+      },
+      {
+        testName: "uses defaultTableFolderSubpath from workspace_settings.yaml",
+        wsContent: CUSTOM_WORKFLOW_SETTINGS_WITH_ICEBERG_DEFAULTS,
+        configBlock: `
+          type: "incremental",
+          name: "incremental_ws_sub",
+          dataset: "dataset_ws",
+          iceberg: {
+              fileFormat: "PARQUET",
+              connection: "gcp.us.conn-id",
+              bucketName: "my-bucket",
+              tableFolderRoot: "my-root",
+              // tableFolderSubpath omitted
+          }`,
+        expected: {
+          target: { name: "incremental_ws_sub", schema: "dataset_ws", database: "defaultProject" },
+          bigquery: {
+            tableFormat: "ICEBERG",
+            fileFormat: "PARQUET",
+            connection: "gcp.us.conn-id",
+            storageUri: "gs://my-bucket/my-root/ws-default-sub",
+          },
+        },
+        expectError: false,
+      },
+      {
+        testName: "uses all Iceberg defaults from workspace_settings.yaml",
+        wsContent: CUSTOM_WORKFLOW_SETTINGS_WITH_ICEBERG_DEFAULTS,
+        configBlock: `
+          type: "incremental",
+          name: "incremental_ws_all",
+          dataset: "dataset_ws",
+          iceberg: {
+              fileFormat: "PARQUET",
+              connection: "gcp.us.conn-id",
+              // All path components omitted
+          }`,
+        expected: {
+          target: { name: "incremental_ws_all", schema: "dataset_ws", database: "defaultProject" },
+          bigquery: {
+            tableFormat: "ICEBERG",
+            fileFormat: "PARQUET",
+            connection: "gcp.us.conn-id",
+            storageUri: "gs://ws-default-bucket/ws-default-root/ws-default-sub",
+          },
+        },
+        expectError: false,
+      },
+      {
+        testName: "config values override workspace defaults for Iceberg paths",
+        wsContent: CUSTOM_WORKFLOW_SETTINGS_WITH_ICEBERG_DEFAULTS,
+        configBlock: `
+          type: "incremental",
+          name: "incremental_override",
+          dataset: "dataset_ovr",
+          iceberg: {
+              fileFormat: "PARQUET",
+              connection: "gcp.us.conn-id",
+              bucketName: "config-bucket",
+              tableFolderRoot: "config-root",
+              tableFolderSubpath: "config-sub",
+          }`,
+        expected: {
+          target: { name: "incremental_override", schema: "dataset_ovr", database: "defaultProject" },
+          bigquery: {
+            tableFormat: "ICEBERG",
+            fileFormat: "PARQUET",
+            connection: "gcp.us.conn-id",
+            storageUri: "gs://config-bucket/config-root/config-sub",
+          },
+        },
+        expectError: false,
+      },
+       {
+        testName: "bucketName not defined in config or workspace settings",
+        configBlock: `
+        type: "incremental",
+        name: "incremental_no_bucket",
+        iceberg: {
+            fileFormat: "PARQUET",
+            connection: "projects/gcp/locations/us/connections/conn-id",
+            tableFolderRoot: "my-root",
+            tableFolderSubpath: "my-subpath",
+        }`,
+        expectError: "When defining an Iceberg table, bucket name must be defined in workspace_settings.yaml or the config block.",
+        wsContent: VALID_WORKFLOW_SETTINGS_YAML, // Ensure no defaults are set here
       },
     ];
 
@@ -631,7 +799,8 @@ actions:
       paramsToTest.forEach(params => {
         test(`${testCase.testName} in ${params.filename}`, () => {
           const projectDir = tmpDirFixture.createNewTmpDir();
-          setupFiles(projectDir, params.filename, params.fileContents);
+          // Use the custom setup function with the specified wsContent
+          setupFilesWithCustomWs(projectDir, params.filename, params.fileContents, testCase.wsContent);
 
           const result = runMainInVm(coreExecutionRequestFromPath(projectDir));
 

--- a/core/actions/incremental_table_test.ts
+++ b/core/actions/incremental_table_test.ts
@@ -343,17 +343,7 @@ actions:
   });
 
   suite("Iceberg incremental table options", () => {
-    const setupFiles = (projectDir: string, filename: string, fileContents: string) => {
-      fs.writeFileSync(
-        path.join(projectDir, "workflow_settings.yaml"),
-        VALID_WORKFLOW_SETTINGS_YAML
-      );
-      fs.mkdirSync(path.join(projectDir, "definitions"));
-      fs.writeFileSync(path.join(projectDir, `definitions/${filename}`), fileContents);
-    };
-
-    // Helper to set up files with custom workflow settings
-    const setupFilesWithCustomWs = (projectDir: string, filename: string, fileContents: string, wsContent: string) => {
+    const setupFiles = (projectDir: string, filename: string, fileContents: string, wsContent: string) => {
       fs.writeFileSync(
         path.join(projectDir, "workflow_settings.yaml"),
         wsContent
@@ -800,8 +790,7 @@ defaultIcebergConfigs:
       paramsToTest.forEach(params => {
         test(`${testCase.testName} in ${params.filename}`, () => {
           const projectDir = tmpDirFixture.createNewTmpDir();
-          // Use the custom setup function with the specified wsContent
-          setupFilesWithCustomWs(projectDir, params.filename, params.fileContents, testCase.wsContent);
+          setupFiles(projectDir, params.filename, params.fileContents, testCase.wsContent);
 
           const result = runMainInVm(coreExecutionRequestFromPath(projectDir));
 

--- a/core/actions/incremental_table_test.ts
+++ b/core/actions/incremental_table_test.ts
@@ -366,9 +366,10 @@ actions:
 defaultProject: "defaultProject"
 defaultDataset: "defaultDataset"
 defaultLocation: "us-central1"
-defaultBucketName: "ws-default-bucket"
-defaultTableFolderRoot: "ws-default-root"
-defaultTableFolderSubpath: "ws-default-sub"
+defaultIcebergConfigs:
+  defaultBucketName: "ws-default-bucket"
+  defaultTableFolderRoot: "ws-default-root"
+  defaultTableFolderSubpath: "ws-default-sub"
 `;
 
     const testCases = [

--- a/core/actions/incremental_table_test.ts
+++ b/core/actions/incremental_table_test.ts
@@ -356,7 +356,7 @@ actions:
 defaultProject: "defaultProject"
 defaultDataset: "defaultDataset"
 defaultLocation: "us-central1"
-defaultIcebergConfigs:
+defaultIcebergConfig:
   defaultBucketName: "ws-default-bucket"
   defaultTableFolderRoot: "ws-default-root"
   defaultTableFolderSubpath: "ws-default-sub"

--- a/core/actions/table.ts
+++ b/core/actions/table.ts
@@ -192,9 +192,9 @@ export class Table extends ActionBuilder<dataform.Table> {
         fileFormat: getFileFormatValueForIcebergTable(config.iceberg.fileFormat?.toString()),
         tableFormat: dataform.TableFormat.ICEBERG,
         storageUri: getStorageUriForIcebergTable(
-          getEffectiveBucketName(session.projectConfig.defaultBucketName, config.iceberg.bucketName),
-          getEffectiveTableFolderRoot(session.projectConfig.defaultTableFolderRoot, config.iceberg.tableFolderRoot),
-          getEffectiveTableFolderSubpath(this.proto.target.schema, this.proto.target.name, session.projectConfig.defaultTableFolderSubpath, config.iceberg.tableFolderSubpath),
+          getEffectiveBucketName(session.projectConfig.defaultIcebergConfigs?.defaultBucketName, config.iceberg.bucketName),
+          getEffectiveTableFolderRoot(session.projectConfig.defaultIcebergConfigs?.defaultTableFolderRoot, config.iceberg.tableFolderRoot),
+          getEffectiveTableFolderSubpath(this.proto.target.schema, this.proto.target.name, session.projectConfig.defaultIcebergConfigs?.defaultTableFolderSubpath, config.iceberg.tableFolderSubpath),
         ),
       } : {}),
     });

--- a/core/actions/table.ts
+++ b/core/actions/table.ts
@@ -192,9 +192,9 @@ export class Table extends ActionBuilder<dataform.Table> {
         fileFormat: getFileFormatValueForIcebergTable(config.iceberg.fileFormat?.toString()),
         tableFormat: dataform.TableFormat.ICEBERG,
         storageUri: getStorageUriForIcebergTable(
-          getEffectiveBucketName(session.projectConfig.defaultIcebergConfigs?.defaultBucketName, config.iceberg.bucketName),
-          getEffectiveTableFolderRoot(session.projectConfig.defaultIcebergConfigs?.defaultTableFolderRoot, config.iceberg.tableFolderRoot),
-          getEffectiveTableFolderSubpath(this.proto.target.schema, this.proto.target.name, session.projectConfig.defaultIcebergConfigs?.defaultTableFolderSubpath, config.iceberg.tableFolderSubpath),
+          getEffectiveBucketName(session.projectConfig.defaultIcebergConfig?.defaultBucketName, config.iceberg.bucketName),
+          getEffectiveTableFolderRoot(session.projectConfig.defaultIcebergConfig?.defaultTableFolderRoot, config.iceberg.tableFolderRoot),
+          getEffectiveTableFolderSubpath(this.proto.target.schema, this.proto.target.name, session.projectConfig.defaultIcebergConfig?.defaultTableFolderSubpath, config.iceberg.tableFolderSubpath),
         ),
       } : {}),
     });

--- a/core/actions/table.ts
+++ b/core/actions/table.ts
@@ -23,6 +23,8 @@ import {
   checkAssertionsForDependency,
   checkExcessProperties,
   getConnectionForIcebergTable,
+  getEffectiveBucketName,
+  getEffectiveTableFolderRoot,
   getEffectiveTableFolderSubpath,
   getFileFormatValueForIcebergTable,
   getStorageUriForIcebergTable,
@@ -190,9 +192,9 @@ export class Table extends ActionBuilder<dataform.Table> {
         fileFormat: getFileFormatValueForIcebergTable(config.iceberg.fileFormat?.toString()),
         tableFormat: dataform.TableFormat.ICEBERG,
         storageUri: getStorageUriForIcebergTable(
-          config.iceberg.bucketName,
-          getEffectiveTableFolderSubpath(this.proto.target.schema, this.proto.target.name, config.iceberg.tableFolderSubpath),
-          config.iceberg.tableFolderRoot,
+          getEffectiveBucketName(session.projectConfig.defaultBucketName, config.iceberg.bucketName),
+          getEffectiveTableFolderRoot(session.projectConfig.defaultTableFolderRoot, config.iceberg.tableFolderRoot),
+          getEffectiveTableFolderSubpath(this.proto.target.schema, this.proto.target.name, session.projectConfig.defaultTableFolderSubpath, config.iceberg.tableFolderSubpath),
         ),
       } : {}),
     });
@@ -580,11 +582,6 @@ export class Table extends ActionBuilder<dataform.Table> {
         ) {
           throw new ReferenceError(
             `Unexpected file format; only "PARQUET" is allowed, got "${unverifiedConfig.iceberg.fileFormat}".`
-          );
-        }
-        if (!unverifiedConfig.iceberg.bucketName) {
-          throw new ReferenceError(
-            'Reference error: bucket_name must be defined in an iceberg subblock.'
           );
         }
       }

--- a/core/actions/table_test.ts
+++ b/core/actions/table_test.ts
@@ -287,7 +287,7 @@ ${exampleBuiltInAssertionsAsYaml.inputActionConfigBlock}
 defaultProject: "defaultProject"
 defaultDataset: "defaultDataset"
 defaultLocation: "us-central1"
-defaultIcebergConfigs:
+defaultIcebergConfig:
   defaultBucketName: "ws-default-bucket"
   defaultTableFolderRoot: "ws-default-root"
   defaultTableFolderSubpath: "ws-default-sub"

--- a/core/actions/table_test.ts
+++ b/core/actions/table_test.ts
@@ -278,6 +278,25 @@ ${exampleBuiltInAssertionsAsYaml.inputActionConfigBlock}
       fs.writeFileSync(path.join(projectDir, `definitions/${filename}`), fileContents);
     };
 
+    // Set up files with custom workflow settings
+    const setupFilesWithCustomWs = (projectDir: string, filename: string, fileContents: string, wsContent: string) => {
+      fs.writeFileSync(
+        path.join(projectDir, "workflow_settings.yaml"),
+        wsContent
+      );
+      fs.mkdirSync(path.join(projectDir, "definitions"));
+      fs.writeFileSync(path.join(projectDir, `definitions/${filename}`), fileContents);
+    };
+
+    const CUSTOM_WORKFLOW_SETTINGS_WITH_ICEBERG_DEFAULTS = `
+defaultProject: "defaultProject"
+defaultDataset: "defaultDataset"
+defaultLocation: "us-central1"
+defaultBucketName: "ws-default-bucket"
+defaultTableFolderRoot: "ws-default-root"
+defaultTableFolderSubpath: "ws-default-sub"
+`;
+
     const testCases = [
       {
         testName: "with all values provided and resource form connection",
@@ -301,6 +320,7 @@ ${exampleBuiltInAssertionsAsYaml.inputActionConfigBlock}
         },
         },
         expectError: false,
+        wsContent: VALID_WORKFLOW_SETTINGS_YAML,
       },
       {
         testName: "with all values provided and dot form connection",
@@ -324,6 +344,7 @@ ${exampleBuiltInAssertionsAsYaml.inputActionConfigBlock}
         },
         },
         expectError: false,
+        wsContent: VALID_WORKFLOW_SETTINGS_YAML,
       },
       {
         testName: "defaults to \`_dataform\` for tableFolderRoot",
@@ -346,6 +367,7 @@ ${exampleBuiltInAssertionsAsYaml.inputActionConfigBlock}
         },
         },
         expectError: false,
+        wsContent: VALID_WORKFLOW_SETTINGS_YAML,
       },
       {
         testName: "defaults to dataset and name for tableFolderSubpath with dataset and table name provided",
@@ -368,6 +390,7 @@ ${exampleBuiltInAssertionsAsYaml.inputActionConfigBlock}
         },
         },
         expectError: false,
+        wsContent: VALID_WORKFLOW_SETTINGS_YAML,
       },
       {
         testName: "defaults to dataset and name for tableFolderSubpath with dataset from workflow settings",
@@ -389,6 +412,7 @@ ${exampleBuiltInAssertionsAsYaml.inputActionConfigBlock}
         },
         },
         expectError: false,
+        wsContent: VALID_WORKFLOW_SETTINGS_YAML,
       },
       {
         testName: "defaults to PARQUET when file format is not set",
@@ -411,6 +435,7 @@ ${exampleBuiltInAssertionsAsYaml.inputActionConfigBlock}
         },
         },
         expectError: false,
+        wsContent: VALID_WORKFLOW_SETTINGS_YAML,
       },
       {
         testName: "defaults to DEFAULT connection",
@@ -433,6 +458,7 @@ ${exampleBuiltInAssertionsAsYaml.inputActionConfigBlock}
         },
         },
         expectError: false,
+        wsContent: VALID_WORKFLOW_SETTINGS_YAML,
       },
       {
         testName: "defaults to PARQUET when file format is empty",
@@ -456,6 +482,7 @@ ${exampleBuiltInAssertionsAsYaml.inputActionConfigBlock}
         },
         },
         expectError: false,
+        wsContent: VALID_WORKFLOW_SETTINGS_YAML,
       },
       {
         testName: "invalid connection format",
@@ -469,6 +496,7 @@ ${exampleBuiltInAssertionsAsYaml.inputActionConfigBlock}
             tableFolderSubpath: "my-subpath",
         }`,
         expectError: "The connection must be in the format `{project}.{location}.{connection_id}` or `projects/{project}/locations/{location}/connections/{connection_id}`, or be set to `DEFAULT`.",
+        wsContent: VALID_WORKFLOW_SETTINGS_YAML,
       },
       {
         testName: "invalid file format",
@@ -478,6 +506,7 @@ ${exampleBuiltInAssertionsAsYaml.inputActionConfigBlock}
             bucketName: "my-bucket",
         }`,
         expectError: "Unexpected file format; only \"PARQUET\" is allowed, got \"AVRO\".",
+        wsContent: VALID_WORKFLOW_SETTINGS_YAML,
       },
       {
         testName: "bucketName not defined",
@@ -488,7 +517,8 @@ ${exampleBuiltInAssertionsAsYaml.inputActionConfigBlock}
             tableFolderRoot: "my-root",
             tableFolderSubpath: "my-subpath",
         }`,
-        expectError: "Reference error: bucket_name must be defined in an iceberg subblock.",
+        expectError: "When defining an Iceberg table, bucket name must be defined in workspace_settings.yaml or the config block.",
+        wsContent: VALID_WORKFLOW_SETTINGS_YAML,
       },
       {
         testName: "with Iceberg options and other BigQuery options",
@@ -522,6 +552,121 @@ ${exampleBuiltInAssertionsAsYaml.inputActionConfigBlock}
           },
         },
         expectError: false,
+        wsContent: VALID_WORKFLOW_SETTINGS_YAML,
+      },
+      {
+        testName: "uses defaultBucketName from workspace_settings.yaml",
+        wsContent: CUSTOM_WORKFLOW_SETTINGS_WITH_ICEBERG_DEFAULTS,
+        configBlock: `
+          name: "table_ws_bucket",
+          dataset: "dataset_ws",
+          iceberg: {
+              fileFormat: "PARQUET",
+              connection: "gcp.us.conn-id",
+              tableFolderRoot: "my-root",
+              tableFolderSubpath: "my-subpath",
+          }`,
+        expected: {
+          target: { name: "table_ws_bucket", schema: "dataset_ws", database: "project" },
+          bigquery: {
+            tableFormat: "ICEBERG",
+            fileFormat: "PARQUET",
+            connection: "gcp.us.conn-id",
+            storageUri: "gs://ws-default-bucket/my-root/my-subpath",
+          },
+        },
+        expectError: false,
+      },
+      {
+        testName: "uses defaultTableFolderRoot from workspace_settings.yaml",
+        wsContent: CUSTOM_WORKFLOW_SETTINGS_WITH_ICEBERG_DEFAULTS,
+        configBlock: `
+          name: "table_ws_root",
+          dataset: "dataset_ws",
+          iceberg: {
+              fileFormat: "PARQUET",
+              connection: "gcp.us.conn-id",
+              bucketName: "my-bucket",
+              tableFolderSubpath: "my-subpath",
+          }`,
+        expected: {
+          target: { name: "table_ws_root", schema: "dataset_ws", database: "project" },
+          bigquery: {
+            tableFormat: "ICEBERG",
+            fileFormat: "PARQUET",
+            connection: "gcp.us.conn-id",
+            storageUri: "gs://my-bucket/ws-default-root/my-subpath",
+          },
+        },
+        expectError: false,
+      },
+      {
+        testName: "uses defaultTableFolderSubpath from workspace_settings.yaml",
+        wsContent: CUSTOM_WORKFLOW_SETTINGS_WITH_ICEBERG_DEFAULTS,
+        configBlock: `
+          name: "table_ws_sub",
+          dataset: "dataset_ws",
+          iceberg: {
+              fileFormat: "PARQUET",
+              connection: "gcp.us.conn-id",
+              bucketName: "my-bucket",
+              tableFolderRoot: "my-root",
+          }`,
+        expected: {
+          target: { name: "table_ws_sub", schema: "dataset_ws", database: "project" },
+          bigquery: {
+            tableFormat: "ICEBERG",
+            fileFormat: "PARQUET",
+            connection: "gcp.us.conn-id",
+            storageUri: "gs://my-bucket/my-root/ws-default-sub",
+          },
+        },
+        expectError: false,
+      },
+      {
+        testName: "uses all Iceberg defaults from workspace_settings.yaml",
+        wsContent: CUSTOM_WORKFLOW_SETTINGS_WITH_ICEBERG_DEFAULTS,
+        configBlock: `
+          name: "table_ws_all",
+          dataset: "dataset_ws",
+          iceberg: {
+              fileFormat: "PARQUET",
+              connection: "gcp.us.conn-id",
+          }`,
+        expected: {
+          target: { name: "table_ws_all", schema: "dataset_ws", database: "project" },
+          bigquery: {
+            tableFormat: "ICEBERG",
+            fileFormat: "PARQUET",
+            connection: "gcp.us.conn-id",
+            storageUri: "gs://ws-default-bucket/ws-default-root/ws-default-sub",
+          },
+        },
+        expectError: false,
+      },
+      {
+        testName: "config values override workspace defaults for Iceberg paths",
+        wsContent: CUSTOM_WORKFLOW_SETTINGS_WITH_ICEBERG_DEFAULTS,
+        configBlock: `
+          name: "table_override",
+          dataset: "dataset_ovr",
+          iceberg: {
+              fileFormat: "PARQUET",
+              connection: "gcp.us.conn-id",
+              bucketName: "config-bucket",
+              tableFolderRoot: "config-root",
+              tableFolderSubpath: "config-sub",
+          }`,
+        expected: {
+          target: { name: "table_override", schema: "dataset_ovr", database: "project" },
+          bigquery: {
+            tableFormat: "ICEBERG",
+            fileFormat: "PARQUET",
+            connection: "gcp.us.conn-id",
+            storageUri: "gs://config-bucket/config-root/config-sub",
+          },
+        },
+        expectError: false,
       },
     ];
 
@@ -547,7 +692,12 @@ ${exampleBuiltInAssertionsAsYaml.inputActionConfigBlock}
       paramsToTest.forEach(params => {
         test(`${testCase.testName} in ${params.filename}`, () => {
           const projectDir = tmpDirFixture.createNewTmpDir();
-          setupFiles(projectDir, params.filename, params.fileContents);
+          // Use the custom setup function if wsContent is specified, otherwise default to VALID_WORKFLOW_SETTINGS_YAML
+          if (testCase.wsContent) {
+            setupFilesWithCustomWs(projectDir, params.filename, params.fileContents, testCase.wsContent);
+          } else {
+             setupFiles(projectDir, params.filename, params.fileContents);
+          }
 
           const result = runMainInVm(coreExecutionRequestFromPath(projectDir));
 

--- a/core/actions/table_test.ts
+++ b/core/actions/table_test.ts
@@ -269,17 +269,12 @@ ${exampleBuiltInAssertionsAsYaml.inputActionConfigBlock}
   });
 
   suite("Iceberg table options", () => {
-    const setupFiles = (projectDir: string, filename: string, fileContents: string) => {
-      fs.writeFileSync(
-        path.join(projectDir, "workflow_settings.yaml"),
-        VALID_WORKFLOW_SETTINGS_YAML
-      );
-      fs.mkdirSync(path.join(projectDir, "definitions"));
-      fs.writeFileSync(path.join(projectDir, `definitions/${filename}`), fileContents);
-    };
-
-    // Set up files with custom workflow settings
-    const setupFilesWithCustomWs = (projectDir: string, filename: string, fileContents: string, wsContent: string) => {
+    const setupFiles = (
+      projectDir: string,
+      filename: string,
+      fileContents: string,
+      wsContent: string = VALID_WORKFLOW_SETTINGS_YAML
+    ) => {
       fs.writeFileSync(
         path.join(projectDir, "workflow_settings.yaml"),
         wsContent
@@ -693,12 +688,7 @@ defaultIcebergConfigs:
       paramsToTest.forEach(params => {
         test(`${testCase.testName} in ${params.filename}`, () => {
           const projectDir = tmpDirFixture.createNewTmpDir();
-          // Use the custom setup function if wsContent is specified, otherwise default to VALID_WORKFLOW_SETTINGS_YAML
-          if (testCase.wsContent) {
-            setupFilesWithCustomWs(projectDir, params.filename, params.fileContents, testCase.wsContent);
-          } else {
-             setupFiles(projectDir, params.filename, params.fileContents);
-          }
+          setupFiles(projectDir, params.filename, params.fileContents, testCase.wsContent);
 
           const result = runMainInVm(coreExecutionRequestFromPath(projectDir));
 

--- a/core/actions/table_test.ts
+++ b/core/actions/table_test.ts
@@ -292,9 +292,10 @@ ${exampleBuiltInAssertionsAsYaml.inputActionConfigBlock}
 defaultProject: "defaultProject"
 defaultDataset: "defaultDataset"
 defaultLocation: "us-central1"
-defaultBucketName: "ws-default-bucket"
-defaultTableFolderRoot: "ws-default-root"
-defaultTableFolderSubpath: "ws-default-sub"
+defaultIcebergConfigs:
+  defaultBucketName: "ws-default-bucket"
+  defaultTableFolderRoot: "ws-default-root"
+  defaultTableFolderSubpath: "ws-default-sub"
 `;
 
     const testCases = [

--- a/core/utils.ts
+++ b/core/utils.ts
@@ -332,21 +332,83 @@ export function getConnectionForIcebergTable(connection?: string): string {
  */
 export function getStorageUriForIcebergTable(
   bucketName: string,
+  tableFolderRoot: string,
   tableFolderSubpath: string,
-  tableFolderRoot: string = "_dataform",
 ): string {
   return `gs://${bucketName}/${tableFolderRoot}/${tableFolderSubpath}`;
 }
 
 /**
- * Handles defaulting logic for the tableFolderSubpath variable used to construct
- * storage URI for Iceberg tables.
- * @param datasetName Might be used to construct the tableFolderSubpath if no alternative value is provided.
- * @param tableName Might be used to construct the tableFolderSubpath if no alternative value is provided.
- * @param tableFolderSubpath User-provided tableFolderSubpath, if it exists.
+ * Returns the bucketName which will be used to construct storageUri for an
+ * Iceberg table. If the bucketName is provided in the config block, that value
+ * will be used. Otherwise, defaultBucketName defined in workspace_settings.yaml
+ * will be used. If none of those two values are defined, we throw an error.
+ * @param defaultBucketName defined in workspace_settings.yaml
+ * @param configBucketName defined in the config block
+ * @returns bucketName used to construct storageUri for Iceberg tables
  */
-export function getEffectiveTableFolderSubpath(datasetName: string, tableName: string, tableFolderSubpath?: string): string {
-  return tableFolderSubpath ? tableFolderSubpath : `${datasetName}/${tableName}`;
+export function getEffectiveBucketName(
+  defaultBucketName?: string,
+  configBucketName?: string,
+): string {
+  if(configBucketName) {
+    return configBucketName;
+  } else if(defaultBucketName) {
+    return defaultBucketName;
+  } else {
+    throw new Error(
+      "When defining an Iceberg table, bucket name must be defined in workspace_settings.yaml or the config block."
+    );
+  }
+}
+
+/**
+ * Returns the tableFolderRoot which will be used to construct storageUri for an
+ * Iceberg table. If the tableFolderRoot is provided in the config block, that
+ * value will be used. Otherwise, defaultTableFolderRoot defined in
+ * workspace_settings.yaml will be used. If none of those two values are
+ * defined, "_dataform" will be used.
+ * @param defaultTableFolderRoot defined in workspace_settings.yaml
+ * @param configTableFolderRoot defined in the config block
+ * @returns tableFolderRoot used to construct storageUri for Iceberg tables
+ */
+export function getEffectiveTableFolderRoot(
+  defaultTableFolderRoot?: string,
+  configTableFolderRoot?: string,
+): string {
+  if(configTableFolderRoot) {
+    return configTableFolderRoot;
+  } else if(defaultTableFolderRoot) {
+    return defaultTableFolderRoot;
+  } else {
+    return "_dataform";
+  }
+}
+
+/**
+ * Returns the tableFolderSubpath which will be used to construct storageUri for
+ * an Iceberg table. If the tableFolderSubpath is provided in the config block,
+ * that value will be used. Otherwise, defaultTableFolderSubpath defined in
+ * workspace_settings.yaml will be used. If none of those two values are
+ * defined, "{dataset_name}/{table_name}"" will be used.
+ * @param datasetName Might be used to construct the tableFolderSubpath if no alternative value is available.
+ * @param tableName Might be used to construct the tableFolderSubpath if no alternative value is available.
+ * @param defaultTableFolderSubpath defined in workspace_settings.yaml
+ * @param configTableFolderSubpath defined in the config block
+ */
+export function getEffectiveTableFolderSubpath(
+  datasetName: string,
+  tableName: string,
+  defaultTableFolderSubpath?: string,
+  configTableFolderSubpath?: string,
+): string {
+  if(configTableFolderSubpath) {
+    return configTableFolderSubpath;
+  } else if(defaultTableFolderSubpath) {
+    return defaultTableFolderSubpath;
+  } else {
+    return `${datasetName}/${tableName}`;
+  }
 }
 
 export function tableTypeStringToEnum(type: string, throwIfUnknown: boolean) {

--- a/core/utils_test.ts
+++ b/core/utils_test.ts
@@ -1,6 +1,8 @@
 import {expect} from "chai";
 import {
   getConnectionForIcebergTable,
+  getEffectiveBucketName,
+  getEffectiveTableFolderRoot,
   getEffectiveTableFolderSubpath,
   getFileFormatValueForIcebergTable,
   getStorageUriForIcebergTable,
@@ -126,6 +128,81 @@ suite('Dataform Utility Validations', () => {
     });
   });
 
+  suite('getEffectiveBucketName', () => {
+    test('returns configBucketName if provided', () => {
+      expect(getEffectiveBucketName('ws-default', 'config-bucket')).to.equal('config-bucket');
+    });
+
+    test('returns defaultBucketName when configBucketName is undefined', () => {
+      expect(getEffectiveBucketName('ws-default', undefined)).to.equal('ws-default');
+    });
+
+    test('returns defaultBucketName when configBucketName is an empty string', () => {
+      expect(getEffectiveBucketName('ws-default', '')).to.equal('ws-default');
+    });
+
+    test('throws error if both configBucketName and defaultBucketName are undefined', () => {
+      assertThrowsWithMessage(
+        () => getEffectiveBucketName(undefined, undefined),
+        'When defining an Iceberg table, bucket name must be defined in workspace_settings.yaml or the config block.'
+      );
+    });
+
+    test('throws error if both configBucketName and defaultBucketName are empty strings', () => {
+      assertThrowsWithMessage(
+        () => getEffectiveBucketName('', ''),
+        'When defining an Iceberg table, bucket name must be defined in workspace_settings.yaml or the config block.'
+      );
+    });
+  });
+
+  suite('getEffectiveTableFolderRoot', () => {
+    test('returns configTableFolderRoot if provided', () => {
+      expect(getEffectiveTableFolderRoot('ws-root', 'config-root')).to.equal('config-root');
+    });
+
+    test('returns defaultTableFolderRoot when configTableFolderRoot is undefined', () => {
+      expect(getEffectiveTableFolderRoot('ws-root', undefined)).to.equal('ws-root');
+    });
+
+    test('returns defaultTableFolderRoot when configTableFolderRoot is an empty string', () => {
+      expect(getEffectiveTableFolderRoot('ws-root', '')).to.equal('ws-root');
+    });
+
+    test('returns "_dataform" when both config and default are undefined', () => {
+      expect(getEffectiveTableFolderRoot(undefined, undefined)).to.equal('_dataform');
+    });
+
+     test('returns "_dataform" when both config and default are empty strings', () => {
+      expect(getEffectiveTableFolderRoot('', '')).to.equal('_dataform');
+    });
+  });
+
+  suite('getEffectiveTableFolderSubpath', () => {
+    const testDataset = 'my_dataset';
+    const testTable = 'my_table';
+
+    test('returns configTableFolderSubpath when provided', () => {
+      expect(getEffectiveTableFolderSubpath(testDataset, testTable, 'ws/sub', 'config/sub')).to.equal('config/sub');
+    });
+
+    test('returns defaultTableFolderSubpath when configTableFolderSubpath is undefined', () => {
+      expect(getEffectiveTableFolderSubpath(testDataset, testTable, 'ws/sub', undefined)).to.equal('ws/sub');
+    });
+
+    test('returns defaultTableFolderSubpath when configTableFolderSubpath is an empty string', () => {
+      expect(getEffectiveTableFolderSubpath(testDataset, testTable, 'ws/sub', '')).to.equal('ws/sub');
+    });
+
+    test('constructs from dataset/table when both config and default are undefined', () => {
+      expect(getEffectiveTableFolderSubpath(testDataset, testTable, undefined, undefined)).to.equal('my_dataset/my_table');
+    });
+
+    test('constructs from dataset/table when both config and default are empty strings', () => {
+      expect(getEffectiveTableFolderSubpath(testDataset, testTable, '', '')).to.equal('my_dataset/my_table');
+    });
+  });
+
   suite('getConnectionForIcebergTable', () => {
     test('returns the provided connection string if it exists', () => {
       expect(getConnectionForIcebergTable('my-custom-conn')).to.equal('my-custom-conn');
@@ -137,23 +214,6 @@ suite('Dataform Utility Validations', () => {
 
     test('returns "DEFAULT" when the connection is an empty string', () => {
       expect(getConnectionForIcebergTable('')).to.equal('DEFAULT');
-    });
-  });
-
-  suite('getEffectiveTableFolderSubpath', () => {
-    const testDataset = 'my_dataset';
-    const testTable = 'my_table';
-
-    test('returns the provided tableFolderSubpath when it exists', () => {
-      expect(getEffectiveTableFolderSubpath(testDataset, testTable, 'custom/sub/path')).to.equal('custom/sub/path');
-    });
-
-    test('constructs a path from dataset and table when tableFolderSubpath is undefined', () => {
-      expect(getEffectiveTableFolderSubpath(testDataset, testTable, undefined)).to.equal('my_dataset/my_table');
-    });
-
-    test('constructs a path from dataset and table when tableFolderSubpath is an empty string', () => {
-      expect(getEffectiveTableFolderSubpath(testDataset, testTable, '')).to.equal('my_dataset/my_table');
     });
   });
 
@@ -176,29 +236,27 @@ suite('Dataform Utility Validations', () => {
         'File format CSV is not supported.'
       );
     });
-
-
   });
 
   suite('getStorageUriForIcebergTable', () => {
     const testBucket = 'my-iceberg-bucket';
+    const testRoot = '_dataform';
     const testSubpath = 'data/v1';
-    const customRoot = '_my_custom_root';
 
     test('constructs the URI with a provided tableFolderRoot', () => {
-      expect(getStorageUriForIcebergTable(testBucket, testSubpath, customRoot)).to.equal('gs://my-iceberg-bucket/_my_custom_root/data/v1');
-    });
-
-    test('constructs the URI with the default tableFolderRoot when omitted', () => {
-      expect(getStorageUriForIcebergTable(testBucket, testSubpath)).to.equal('gs://my-iceberg-bucket/_dataform/data/v1');
+      expect(getStorageUriForIcebergTable(testBucket, testRoot, testSubpath)).to.equal('gs://my-iceberg-bucket/_dataform/data/v1');
     });
 
     test('handles empty bucket name, resulting in an invalid but formed URI', () => {
-      expect(getStorageUriForIcebergTable('', testSubpath)).to.equal('gs:///_dataform/data/v1');
+      expect(getStorageUriForIcebergTable('', testRoot, testSubpath)).to.equal('gs:///_dataform/data/v1');
+    });
+
+    test('handles empty tableFolderRoot, resulting in an invalid but formed URI', () => {
+      expect(getStorageUriForIcebergTable(testBucket, '', testSubpath)).to.equal('gs://my-iceberg-bucket//data/v1');
     });
 
     test('handles empty tableFolderSubpath', () => {
-      expect(getStorageUriForIcebergTable(testBucket, '')).to.equal('gs://my-iceberg-bucket/_dataform/');
+      expect(getStorageUriForIcebergTable(testBucket, testRoot, '')).to.equal('gs://my-iceberg-bucket/_dataform/');
     });
   });
 });

--- a/core/workflow_settings.ts
+++ b/core/workflow_settings.ts
@@ -133,15 +133,19 @@ export function workflowSettingsAsProjectConfig(
         workflowSettings.defaultNotebookRuntimeOptions.runtimeTemplateName;
     }
   }
-  if(workflowSettings.defaultBucketName) {
-    projectConfig.defaultBucketName = workflowSettings.defaultBucketName;
+  if(workflowSettings.defaultIcebergConfigs) {
+    projectConfig.defaultIcebergConfigs = {};
+    if(workflowSettings.defaultIcebergConfigs.defaultBucketName) {
+      projectConfig.defaultIcebergConfigs.defaultBucketName = workflowSettings.defaultIcebergConfigs.defaultBucketName;
+    }
+    if(workflowSettings.defaultIcebergConfigs.defaultTableFolderRoot) {
+      projectConfig.defaultIcebergConfigs.defaultTableFolderRoot = workflowSettings.defaultIcebergConfigs.defaultTableFolderRoot;
+    }
+    if(workflowSettings.defaultIcebergConfigs.defaultTableFolderSubpath) {
+      projectConfig.defaultIcebergConfigs.defaultTableFolderSubpath = workflowSettings.defaultIcebergConfigs.defaultTableFolderSubpath;
+    }
   }
-  if(workflowSettings.defaultTableFolderRoot) {
-    projectConfig.defaultTableFolderRoot = workflowSettings.defaultTableFolderRoot;
-  }
-  if(workflowSettings.defaultTableFolderSubpath) {
-    projectConfig.defaultTableFolderSubpath = workflowSettings.defaultTableFolderSubpath;
-  }
+
   projectConfig.warehouse = "bigquery";
   return projectConfig;
 }

--- a/core/workflow_settings.ts
+++ b/core/workflow_settings.ts
@@ -133,6 +133,15 @@ export function workflowSettingsAsProjectConfig(
         workflowSettings.defaultNotebookRuntimeOptions.runtimeTemplateName;
     }
   }
+  if(workflowSettings.defaultBucketName) {
+    projectConfig.defaultBucketName = workflowSettings.defaultBucketName;
+  }
+  if(workflowSettings.defaultTableFolderRoot) {
+    projectConfig.defaultTableFolderRoot = workflowSettings.defaultTableFolderRoot;
+  }
+  if(workflowSettings.defaultTableFolderSubpath) {
+    projectConfig.defaultTableFolderSubpath = workflowSettings.defaultTableFolderSubpath;
+  }
   projectConfig.warehouse = "bigquery";
   return projectConfig;
 }

--- a/core/workflow_settings.ts
+++ b/core/workflow_settings.ts
@@ -133,16 +133,16 @@ export function workflowSettingsAsProjectConfig(
         workflowSettings.defaultNotebookRuntimeOptions.runtimeTemplateName;
     }
   }
-  if(workflowSettings.defaultIcebergConfigs) {
-    projectConfig.defaultIcebergConfigs = {};
-    if(workflowSettings.defaultIcebergConfigs.defaultBucketName) {
-      projectConfig.defaultIcebergConfigs.defaultBucketName = workflowSettings.defaultIcebergConfigs.defaultBucketName;
+  if(workflowSettings.defaultIcebergConfig) {
+    projectConfig.defaultIcebergConfig = {};
+    if(workflowSettings.defaultIcebergConfig.defaultBucketName) {
+      projectConfig.defaultIcebergConfig.defaultBucketName = workflowSettings.defaultIcebergConfig.defaultBucketName;
     }
-    if(workflowSettings.defaultIcebergConfigs.defaultTableFolderRoot) {
-      projectConfig.defaultIcebergConfigs.defaultTableFolderRoot = workflowSettings.defaultIcebergConfigs.defaultTableFolderRoot;
+    if(workflowSettings.defaultIcebergConfig.defaultTableFolderRoot) {
+      projectConfig.defaultIcebergConfig.defaultTableFolderRoot = workflowSettings.defaultIcebergConfig.defaultTableFolderRoot;
     }
-    if(workflowSettings.defaultIcebergConfigs.defaultTableFolderSubpath) {
-      projectConfig.defaultIcebergConfigs.defaultTableFolderSubpath = workflowSettings.defaultIcebergConfigs.defaultTableFolderSubpath;
+    if(workflowSettings.defaultIcebergConfig.defaultTableFolderSubpath) {
+      projectConfig.defaultIcebergConfig.defaultTableFolderSubpath = workflowSettings.defaultIcebergConfig.defaultTableFolderSubpath;
     }
   }
 

--- a/protos/configs.proto
+++ b/protos/configs.proto
@@ -47,10 +47,10 @@ message WorkflowSettings {
   string builtin_assertion_name_prefix = 11;
 
   // Optional. Default config options for Iceberg tables.
-  DefaultIcebergConfigs default_iceberg_configs = 12;
+  DefaultIcebergConfig default_iceberg_config = 12;
 }
 
-message DefaultIcebergConfigs {
+message DefaultIcebergConfig {
   // Optional. Bucket name used to construct a storage URI when creating an
   // Iceberg table.
   string default_bucket_name = 1;

--- a/protos/configs.proto
+++ b/protos/configs.proto
@@ -46,11 +46,16 @@ message WorkflowSettings {
   // Optional. The prefix to append to built-in assertion names.
   string builtin_assertion_name_prefix = 11;
 
-  // Optional.
+  // Optional. Bucket name used to construct a storage URI when creating an
+  // Iceberg table.
   string default_bucket_name = 12;
 
+  // Optional. Table folder root used to construct a storage URI when creating
+  // an Iceberg table.
   string default_table_folder_root = 13;
 
+  // Optional. Table folder subpath used to construct a storage URI when
+  // creating an Iceberg table.
   string default_table_folder_subpath = 14;
 }
 

--- a/protos/configs.proto
+++ b/protos/configs.proto
@@ -46,17 +46,22 @@ message WorkflowSettings {
   // Optional. The prefix to append to built-in assertion names.
   string builtin_assertion_name_prefix = 11;
 
+  // Optional. Default config options for Iceberg tables.
+  DefaultIcebergConfigs default_iceberg_configs = 12;
+}
+
+message DefaultIcebergConfigs {
   // Optional. Bucket name used to construct a storage URI when creating an
   // Iceberg table.
-  string default_bucket_name = 12;
+  string default_bucket_name = 1;
 
   // Optional. Table folder root used to construct a storage URI when creating
   // an Iceberg table.
-  string default_table_folder_root = 13;
+  string default_table_folder_root = 2;
 
   // Optional. Table folder subpath used to construct a storage URI when
   // creating an Iceberg table.
-  string default_table_folder_subpath = 14;
+  string default_table_folder_subpath = 3;
 }
 
 // Action configs defines the contents of `actions.yaml` configuration files.

--- a/protos/configs.proto
+++ b/protos/configs.proto
@@ -45,6 +45,13 @@ message WorkflowSettings {
 
   // Optional. The prefix to append to built-in assertion names.
   string builtin_assertion_name_prefix = 11;
+
+  // Optional.
+  string default_bucket_name = 12;
+
+  string default_table_folder_root = 13;
+
+  string default_table_folder_subpath = 14;
 }
 
 // Action configs defines the contents of `actions.yaml` configuration files.

--- a/protos/core.proto
+++ b/protos/core.proto
@@ -26,7 +26,7 @@ message ProjectConfig {
 
   NotebookRuntimeOptions default_notebook_runtime_options = 17;
 
-  DefaultIcebergConfigs default_iceberg_configs = 19;
+  DefaultIcebergConfig default_iceberg_config = 19;
 
   reserved 3, 4, 6, 8, 10, 12, 13;
 }

--- a/protos/core.proto
+++ b/protos/core.proto
@@ -26,6 +26,10 @@ message ProjectConfig {
 
   NotebookRuntimeOptions default_notebook_runtime_options = 17;
 
+  string default_bucket_name = 19;
+  string default_table_folder_root = 20;
+  string default_table_folder_subpath = 21;
+
   reserved 3, 4, 6, 8, 10, 12, 13;
 }
 

--- a/protos/core.proto
+++ b/protos/core.proto
@@ -26,9 +26,7 @@ message ProjectConfig {
 
   NotebookRuntimeOptions default_notebook_runtime_options = 17;
 
-  string default_bucket_name = 19;
-  string default_table_folder_root = 20;
-  string default_table_folder_subpath = 21;
+  DefaultIcebergConfigs default_iceberg_configs = 19;
 
   reserved 3, 4, 6, 8, 10, 12, 13;
 }


### PR DESCRIPTION
This change allows users to set defaultBucketName, defaultTableFolderRoot and defaultTableFolderSubpath in workflow_settings.yaml. These fields are parsed and stored as part of projectConfig. If no alternative values are provided inside the user's config block, we use the defaults defined inside workflow_settings.yaml. If the default values inside workflow_settings.yaml are also not provided, we fall back to preexisting defaults.