### PR TITLE
Remove obsolete check on declaration config.

### DIFF
--- a/core/session.ts
+++ b/core/session.ts
@@ -125,9 +125,6 @@ export class Session {
         "Actions may only include incremental_where if they are of type 'incremental'."
       );
     }
-    if (!sqlxConfig.hasOwnProperty("schema") && actionType === "declaration") {
-      this.compileError("Actions of type 'declaration' must specify a value for 'schema'.");
-    }
     if (actionOptions.inputContextables.length > 0 && actionType !== "test") {
       this.compileError("Actions may only include input blocks if they are of type 'test'.");
     }


### PR DESCRIPTION
Remove obsolete check on declaration config which led to the compilation error like:

```
Actions of type 'declaration' must specify a value for 'schema'.
```

The config parsing logic currently already support the correct conversion both legacy and the current format of defining schema.