### PR TITLE
Move iceberg options to bigquery config block

### DIFF
--- a/core/actions/incremental_table.ts
+++ b/core/actions/incremental_table.ts
@@ -597,16 +597,6 @@ export class IncrementalTable extends ActionBuilder<dataform.Table> {
           unverifiedConfig.columns as any
         );
       }
-      if (unverifiedConfig.iceberg) {
-        if (
-          unverifiedConfig.iceberg.fileFormat &&
-          unverifiedConfig.iceberg.fileFormat.toUpperCase() !== 'PARQUET'
-        ) {
-          throw new ReferenceError(
-            `Unexpected file format; only "PARQUET" is allowed, got "${unverifiedConfig.iceberg.fileFormat}".`
-          );
-        }
-      }
       unverifiedConfig = LegacyConfigConverter.insertLegacyInlineAssertionsToConfigProto(
         unverifiedConfig
       );
@@ -626,12 +616,23 @@ export class IncrementalTable extends ActionBuilder<dataform.Table> {
             "labels",
             "partitionExpirationDays",
             "requirePartitionFilter",
-            "additionalOptions"
+            "additionalOptions",
+            "iceberg"
           ]),
           "BigQuery table config"
         );
       }
     }
+    if (unverifiedConfig.iceberg) {
+        if (
+          unverifiedConfig.iceberg.fileFormat &&
+          unverifiedConfig.iceberg.fileFormat.toUpperCase() !== 'PARQUET'
+        ) {
+          throw new ReferenceError(
+            `Unexpected file format; only "PARQUET" is allowed, got "${unverifiedConfig.iceberg.fileFormat}".`
+          );
+        }
+      }
 
     const config = verifyObjectMatchesProto(
       dataform.ActionConfig.IncrementalTableConfig,

--- a/core/actions/incremental_table_test.ts
+++ b/core/actions/incremental_table_test.ts
@@ -369,12 +369,14 @@ defaultIcebergConfig:
         type: "incremental",
         name: "incremental_table1",
         dataset: "dataset1",
-        iceberg: {
+        bigquery: {
+          iceberg: {
             fileFormat: "PARQUET",
             connection: "projects/gcp/locations/us/connections/conn-id",
             bucketName: "my-bucket",
             tableFolderRoot: "my-root",
             tableFolderSubpath: "my-subpath",
+          }
         }`,
         expected: {
           target: {name: "incremental_table1", schema: "dataset1", database: "defaultProject"},
@@ -394,12 +396,14 @@ defaultIcebergConfig:
         type: "incremental",
         name: "incremental_table2",
         dataset: "dataset2",
-        iceberg: {
+        bigquery: {
+          iceberg: {
             fileFormat: "PARQUET",
             connection: "gcp.us.conn-id",
             bucketName: "my-bucket",
             tableFolderRoot: "my-root",
             tableFolderSubpath: "my-subpath",
+          }
         }`,
         expected: {
           target: {name: "incremental_table2", schema: "dataset2", database: "defaultProject"},
@@ -419,11 +423,13 @@ defaultIcebergConfig:
         type: "incremental",
         name: "incremental_table3",
         dataset: "dataset3",
-        iceberg: {
-          fileFormat: "PARQUET",
-          connection: "gcp.us.conn-id",
+        bigquery: {
+          iceberg: {
+            fileFormat: "PARQUET",
+            connection: "gcp.us.conn-id",
             bucketName: "my-bucket",
             tableFolderSubpath: "my-subpath",
+          }
         }`,
         expected: {
           target: {name: "incremental_table3", schema: "dataset3", database: "defaultProject"},
@@ -443,11 +449,13 @@ defaultIcebergConfig:
         type: "incremental",
         name: "my-incremental",
         dataset: "my-dataset",
-        iceberg: {
+        bigquery: {
+          iceberg: {
             fileFormat: "PARQUET",
             connection: "gcp.us.conn-id",
             bucketName: "my-bucket",
             tableFolderRoot: "my-root",
+          }
         }`,
         expected: {
           target: {name: "my-incremental", schema: "my-dataset", database: "defaultProject"},
@@ -466,11 +474,13 @@ defaultIcebergConfig:
         configBlock: `
         type: "incremental",
         name: "my-incremental",
-        iceberg: {
+        bigquery: {
+          iceberg: {
             fileFormat: "PARQUET",
             connection: "gcp.us.conn-id",
             bucketName: "my-bucket",
             tableFolderRoot: "my-root",
+          }
         }`,
         expected: {
           target: {name: "my-incremental", schema: "defaultDataset", database: "defaultProject"},
@@ -490,11 +500,13 @@ defaultIcebergConfig:
         type: "incremental",
         name: "incremental_table6",
         dataset: "dataset6",
-        iceberg: {
+        bigquery: {
+          iceberg: {
             connection: "projects/gcp/locations/us/connections/conn-id",
             bucketName: "my-bucket",
             tableFolderRoot: "my-root",
             tableFolderSubpath: "my-subpath",
+          }
         }`,
         expected: {
           target: {name: "incremental_table6", schema: "dataset6", database: "defaultProject"},
@@ -514,11 +526,13 @@ defaultIcebergConfig:
         type: "incremental",
         name: "incremental_table7",
         dataset: "dataset7",
-        iceberg: {
+        bigquery: {
+          iceberg: {
             fileFormat: "PARQUET",
             bucketName: "my-bucket",
             tableFolderRoot: "my-root",
             tableFolderSubpath: "my-subpath",
+          }
         }`,
         expected: {
           target: {name: "incremental_table7", schema: "dataset7", database: "defaultProject"},
@@ -538,12 +552,14 @@ defaultIcebergConfig:
         type: "incremental",
         name: "incremental_table8",
         dataset: "dataset8",
-        iceberg: {
+        bigquery: {
+          iceberg: {
             fileFormat: "",
             connection: "projects/gcp/locations/us/connections/conn-id",
             bucketName: "my-bucket",
             tableFolderRoot: "my-root",
             tableFolderSubpath: "my-subpath",
+          }
         }`,
         expected: {
           target: {name: "incremental_table8", schema: "dataset8", database: "defaultProject"},
@@ -563,11 +579,13 @@ defaultIcebergConfig:
         type: "incremental",
         name: "incremental_table9",
         dataset: "dataset9",
-        iceberg: {
+        bigquery: {
+          iceberg: {
             connection: "invalid",
             bucketName: "my-bucket",
             tableFolderRoot: "my-root",
             tableFolderSubpath: "my-subpath",
+          }
         }`,
         expectError: "The connection must be in the format `{project}.{location}.{connection_id}` or `projects/{project}/locations/{location}/connections/{connection_id}`, or be set to `DEFAULT`.",
         wsContent: VALID_WORKFLOW_SETTINGS_YAML,
@@ -577,9 +595,11 @@ defaultIcebergConfig:
         configBlock: `
         type: "incremental",
         name: "incremental_table10",
-        iceberg: {
+        bigquery: {
+          iceberg: {
             fileFormat: "AVRO",
             bucketName: "my-bucket",
+          }
         }`,
         expectError: "Unexpected file format; only \"PARQUET\" is allowed, got \"AVRO\".",
         wsContent: VALID_WORKFLOW_SETTINGS_YAML,
@@ -589,11 +609,13 @@ defaultIcebergConfig:
         configBlock: `
         type: "incremental",
         name: "incremental_table11",
-        iceberg: {
+        bigquery: {
+          iceberg: {
             fileFormat: "PARQUET",
             connection: "projects/gcp/locations/us/connections/conn-id",
             tableFolderRoot: "my-root",
             tableFolderSubpath: "my-subpath",
+          }
         }`,
         expectError: "When defining an Iceberg table, bucket name must be defined in workspace_settings.yaml or the config block.",
         wsContent: VALID_WORKFLOW_SETTINGS_YAML,
@@ -604,18 +626,18 @@ defaultIcebergConfig:
         type: "incremental",
         name: "iceberg_incremental_mixed",
         dataset: "mixed_dataset",
-        iceberg: {
-            fileFormat: "PARQUET",
-            connection: "gcp.us.conn-id",
-            bucketName: "my-bucket",
-            tableFolderRoot: "my-root",
-            tableFolderSubpath: "my-subpath",
-        },
         bigquery: {
             partitionBy: "partition_col",
             clusterBy: ["cluster_col1", "cluster_col2"],
             labels: {"env": "test", "type": "iceberg"},
-            additionalOptions: { "key1": "val1", "key2": "val2" }
+            additionalOptions: { "key1": "val1", "key2": "val2" },
+            iceberg: {
+              fileFormat: "PARQUET",
+              connection: "gcp.us.conn-id",
+              bucketName: "my-bucket",
+              tableFolderRoot: "my-root",
+              tableFolderSubpath: "my-subpath",
+          }
         }`,
         expected: {
           target: {name: "iceberg_incremental_mixed", schema: "mixed_dataset", database: "defaultProject"},
@@ -637,16 +659,18 @@ defaultIcebergConfig:
         testName: "uses defaultBucketName from workspace_settings.yaml",
         wsContent: CUSTOM_WORKFLOW_SETTINGS_WITH_ICEBERG_DEFAULTS,
         configBlock: `
-          type: "incremental",
-          name: "incremental_ws_bucket",
-          dataset: "dataset_ws",
+        type: "incremental",
+        name: "incremental_ws_bucket",
+        dataset: "dataset_ws",
+        bigquery: {
           iceberg: {
-              fileFormat: "PARQUET",
-              connection: "gcp.us.conn-id",
-              // bucketName omitted
-              tableFolderRoot: "my-root",
-              tableFolderSubpath: "my-subpath",
-          }`,
+            fileFormat: "PARQUET",
+            connection: "gcp.us.conn-id",
+            // bucketName omitted
+            tableFolderRoot: "my-root",
+            tableFolderSubpath: "my-subpath",
+          }
+        }`,
         expected: {
           target: { name: "incremental_ws_bucket", schema: "dataset_ws", database: "defaultProject" },
           bigquery: {
@@ -662,16 +686,18 @@ defaultIcebergConfig:
         testName: "uses defaultTableFolderRoot from workspace_settings.yaml",
         wsContent: CUSTOM_WORKFLOW_SETTINGS_WITH_ICEBERG_DEFAULTS,
         configBlock: `
-          type: "incremental",
-          name: "incremental_ws_root",
-          dataset: "dataset_ws",
+        type: "incremental",
+        name: "incremental_ws_root",
+        dataset: "dataset_ws",
+        bigquery: {
           iceberg: {
-              fileFormat: "PARQUET",
-              connection: "gcp.us.conn-id",
-              bucketName: "my-bucket",
-              // tableFolderRoot omitted
-              tableFolderSubpath: "my-subpath",
-          }`,
+            fileFormat: "PARQUET",
+            connection: "gcp.us.conn-id",
+            bucketName: "my-bucket",
+            // tableFolderRoot omitted
+            tableFolderSubpath: "my-subpath",
+          }
+        }`,
         expected: {
           target: { name: "incremental_ws_root", schema: "dataset_ws", database: "defaultProject" },
           bigquery: {
@@ -687,16 +713,18 @@ defaultIcebergConfig:
         testName: "uses defaultTableFolderSubpath from workspace_settings.yaml",
         wsContent: CUSTOM_WORKFLOW_SETTINGS_WITH_ICEBERG_DEFAULTS,
         configBlock: `
-          type: "incremental",
-          name: "incremental_ws_sub",
-          dataset: "dataset_ws",
+        type: "incremental",
+        name: "incremental_ws_sub",
+        dataset: "dataset_ws",
+        bigquery: {
           iceberg: {
-              fileFormat: "PARQUET",
-              connection: "gcp.us.conn-id",
-              bucketName: "my-bucket",
-              tableFolderRoot: "my-root",
-              // tableFolderSubpath omitted
-          }`,
+            fileFormat: "PARQUET",
+            connection: "gcp.us.conn-id",
+            bucketName: "my-bucket",
+            tableFolderRoot: "my-root",
+            // tableFolderSubpath omitted
+          }
+        }`,
         expected: {
           target: { name: "incremental_ws_sub", schema: "dataset_ws", database: "defaultProject" },
           bigquery: {
@@ -712,14 +740,16 @@ defaultIcebergConfig:
         testName: "uses all Iceberg defaults from workspace_settings.yaml",
         wsContent: CUSTOM_WORKFLOW_SETTINGS_WITH_ICEBERG_DEFAULTS,
         configBlock: `
-          type: "incremental",
-          name: "incremental_ws_all",
-          dataset: "dataset_ws",
+        type: "incremental",
+        name: "incremental_ws_all",
+        dataset: "dataset_ws",
+        bigquery: {
           iceberg: {
-              fileFormat: "PARQUET",
-              connection: "gcp.us.conn-id",
-              // All path components omitted
-          }`,
+            fileFormat: "PARQUET",
+            connection: "gcp.us.conn-id",
+            // All path components omitted
+          }
+        }`,
         expected: {
           target: { name: "incremental_ws_all", schema: "dataset_ws", database: "defaultProject" },
           bigquery: {
@@ -735,16 +765,18 @@ defaultIcebergConfig:
         testName: "config values override workspace defaults for Iceberg paths",
         wsContent: CUSTOM_WORKFLOW_SETTINGS_WITH_ICEBERG_DEFAULTS,
         configBlock: `
-          type: "incremental",
-          name: "incremental_override",
-          dataset: "dataset_ovr",
+        type: "incremental",
+        name: "incremental_override",
+        dataset: "dataset_ovr",
+        bigquery: {
           iceberg: {
-              fileFormat: "PARQUET",
-              connection: "gcp.us.conn-id",
-              bucketName: "config-bucket",
-              tableFolderRoot: "config-root",
-              tableFolderSubpath: "config-sub",
-          }`,
+            fileFormat: "PARQUET",
+            connection: "gcp.us.conn-id",
+            bucketName: "config-bucket",
+            tableFolderRoot: "config-root",
+            tableFolderSubpath: "config-sub",
+          }
+        }`,
         expected: {
           target: { name: "incremental_override", schema: "dataset_ovr", database: "defaultProject" },
           bigquery: {
@@ -761,11 +793,13 @@ defaultIcebergConfig:
         configBlock: `
         type: "incremental",
         name: "incremental_no_bucket",
-        iceberg: {
+        bigquery: {
+          iceberg: {
             fileFormat: "PARQUET",
             connection: "projects/gcp/locations/us/connections/conn-id",
             tableFolderRoot: "my-root",
             tableFolderSubpath: "my-subpath",
+          }
         }`,
         expectError: "When defining an Iceberg table, bucket name must be defined in workspace_settings.yaml or the config block.",
         wsContent: VALID_WORKFLOW_SETTINGS_YAML, // Ensure no defaults are set here

--- a/core/actions/index.ts
+++ b/core/actions/index.ts
@@ -360,6 +360,14 @@ export interface ILegacyBigQueryOptions {
   partitionExpirationDays?: number;
   requirePartitionFilter?: boolean;
   additionalOptions?: { [name: string]: string };
+  iceberg?: {
+    fileFormat?: string;
+    tableFormat?: string;
+    connection?: string;
+    bucketName?: string;
+    tableFolderRoot?: string;
+    tableFolderSubpath?: string;
+  }
 }
 
 /**
@@ -456,6 +464,10 @@ export class LegacyConfigConverter {
     if (!!legacyConfig.bigquery.additionalOptions) {
       legacyConfig.additionalOptions = legacyConfig.bigquery.additionalOptions;
       delete legacyConfig.bigquery.additionalOptions;
+    }
+    if(!!legacyConfig.bigquery.iceberg) {
+      legacyConfig.iceberg = legacyConfig.bigquery.iceberg;
+      delete legacyConfig.bigquery.iceberg;
     }
     // To prevent skipping throwing an error when there are additional, unused fields, only delete
     // the legacy bigquery object if there are no more fields left on it.

--- a/core/actions/table.ts
+++ b/core/actions/table.ts
@@ -575,16 +575,6 @@ export class Table extends ActionBuilder<dataform.Table> {
           unverifiedConfig.columns as any
         );
       }
-      if (unverifiedConfig.iceberg) {
-        if (
-          unverifiedConfig.iceberg.fileFormat &&
-          unverifiedConfig.iceberg.fileFormat.toUpperCase() !== 'PARQUET'
-        ) {
-          throw new ReferenceError(
-            `Unexpected file format; only "PARQUET" is allowed, got "${unverifiedConfig.iceberg.fileFormat}".`
-          );
-        }
-      }
 
       unverifiedConfig = LegacyConfigConverter.insertLegacyInlineAssertionsToConfigProto(
         unverifiedConfig
@@ -605,10 +595,21 @@ export class Table extends ActionBuilder<dataform.Table> {
             "labels",
             "partitionExpirationDays",
             "requirePartitionFilter",
-            "additionalOptions"
+            "additionalOptions",
+            "iceberg"
           ]),
           "BigQuery table config"
         );
+      }
+      if (unverifiedConfig.iceberg) {
+        if (
+          unverifiedConfig.iceberg.fileFormat &&
+          unverifiedConfig.iceberg.fileFormat.toUpperCase() !== 'PARQUET'
+        ) {
+          throw new ReferenceError(
+            `Unexpected file format; only "PARQUET" is allowed, got "${unverifiedConfig.iceberg.fileFormat}".`
+          );
+        }
       }
     }
 

--- a/core/actions/table_test.ts
+++ b/core/actions/table_test.ts
@@ -299,12 +299,14 @@ defaultIcebergConfig:
         configBlock: `
         name: "table1",
         dataset: "dataset1",
-        iceberg: {
+        bigquery: {
+          iceberg: {
             fileFormat: "PARQUET",
             connection: "projects/gcp/locations/us/connections/conn-id",
             bucketName: "my-bucket",
             tableFolderRoot: "my-root",
             tableFolderSubpath: "my-subpath",
+          }
         }`,
         expected: {
           target: {name: "table1", schema: "dataset1", database: "project"},
@@ -323,12 +325,14 @@ defaultIcebergConfig:
         configBlock: `
         name: "table2",
         dataset: "dataset2",
-        iceberg: {
+        bigquery: {
+          iceberg: {
             fileFormat: "PARQUET",
             connection: "gcp.us.conn-id",
             bucketName: "my-bucket",
             tableFolderRoot: "my-root",
             tableFolderSubpath: "my-subpath",
+          }
         }`,
         expected: {
           target: {name: "table2", schema: "dataset2", database: "project"},
@@ -347,11 +351,13 @@ defaultIcebergConfig:
         configBlock: `
         name: "table3",
         dataset: "dataset3",
-        iceberg: {
-          fileFormat: "PARQUET",
-          connection: "gcp.us.conn-id",
+        bigquery: {
+          iceberg: {
+            fileFormat: "PARQUET",
+            connection: "gcp.us.conn-id",
             bucketName: "my-bucket",
             tableFolderSubpath: "my-subpath",
+          }
         }`,
         expected: {
           target: {name: "table3", schema: "dataset3", database: "project"},
@@ -370,11 +376,13 @@ defaultIcebergConfig:
         configBlock: `
         name: "my-table",
         dataset: "my-dataset",
-        iceberg: {
+        bigquery: {
+          iceberg: {
             fileFormat: "PARQUET",
             connection: "gcp.us.conn-id",
             bucketName: "my-bucket",
             tableFolderRoot: "my-root",
+          }
         }`,
         expected: {
           target: {name: "my-table", schema: "my-dataset", database: "project"},
@@ -392,11 +400,13 @@ defaultIcebergConfig:
         testName: "defaults to dataset and name for tableFolderSubpath with dataset from workflow settings",
         configBlock: `
         name: "my-table",
-        iceberg: {
+        bigquery: {
+          iceberg: {
             fileFormat: "PARQUET",
             connection: "gcp.us.conn-id",
             bucketName: "my-bucket",
             tableFolderRoot: "my-root",
+          }
         }`,
         expected: {
           target: {name: "my-table", schema: "defaultDataset", database: "project"},
@@ -415,11 +425,13 @@ defaultIcebergConfig:
         configBlock: `
         name: "table6",
         dataset: "dataset6",
-        iceberg: {
+        bigquery: {
+          iceberg: {
             connection: "projects/gcp/locations/us/connections/conn-id",
             bucketName: "my-bucket",
             tableFolderRoot: "my-root",
             tableFolderSubpath: "my-subpath",
+          }
         }`,
         expected: {
           target: {name: "table6", schema: "dataset6", database: "project"},
@@ -438,11 +450,13 @@ defaultIcebergConfig:
         configBlock: `
         name: "table7",
         dataset: "dataset7",
-        iceberg: {
+        bigquery: {
+          iceberg: {
             fileFormat: "PARQUET",
             bucketName: "my-bucket",
             tableFolderRoot: "my-root",
             tableFolderSubpath: "my-subpath",
+          }
         }`,
         expected: {
           target: {name: "table7", schema: "dataset7", database: "project"},
@@ -461,12 +475,14 @@ defaultIcebergConfig:
         configBlock: `
         name: "table6",
         dataset: "dataset6",
-        iceberg: {
+        bigquery: {
+          iceberg: {
             fileFormat: "",
             connection: "projects/gcp/locations/us/connections/conn-id",
             bucketName: "my-bucket",
             tableFolderRoot: "my-root",
             tableFolderSubpath: "my-subpath",
+          }
         }`,
         expected: {
           target: {name: "table6", schema: "dataset6", database: "project"},
@@ -485,11 +501,13 @@ defaultIcebergConfig:
         configBlock: `
         name: "table8",
         dataset: "dataset8",
-        iceberg: {
+        bigquery: {
+          iceberg: {
             connection: "invalid",
             bucketName: "my-bucket",
             tableFolderRoot: "my-root",
             tableFolderSubpath: "my-subpath",
+          }
         }`,
         expectError: "The connection must be in the format `{project}.{location}.{connection_id}` or `projects/{project}/locations/{location}/connections/{connection_id}`, or be set to `DEFAULT`.",
         wsContent: VALID_WORKFLOW_SETTINGS_YAML,
@@ -497,9 +515,11 @@ defaultIcebergConfig:
       {
         testName: "invalid file format",
         configBlock: `
-        iceberg: {
+        bigquery: {
+          iceberg: {
             fileFormat: "AVRO",
             bucketName: "my-bucket",
+          }
         }`,
         expectError: "Unexpected file format; only \"PARQUET\" is allowed, got \"AVRO\".",
         wsContent: VALID_WORKFLOW_SETTINGS_YAML,
@@ -507,11 +527,13 @@ defaultIcebergConfig:
       {
         testName: "bucketName not defined",
         configBlock: `
-        iceberg: {
+        bigquery: {
+          iceberg: {
             fileFormat: "PARQUET",
             connection: "projects/gcp/locations/us/connections/conn-id",
             tableFolderRoot: "my-root",
             tableFolderSubpath: "my-subpath",
+          }
         }`,
         expectError: "When defining an Iceberg table, bucket name must be defined in workspace_settings.yaml or the config block.",
         wsContent: VALID_WORKFLOW_SETTINGS_YAML,
@@ -521,18 +543,18 @@ defaultIcebergConfig:
         configBlock: `
         name: "iceberg_mixed",
         dataset: "mixed_dataset",
-        iceberg: {
+        bigquery: {
+          partitionBy: "partition_col",
+          clusterBy: ["cluster_col1", "cluster_col2"],
+          labels: {"env": "test", "type": "iceberg"},
+          additionalOptions: { "key1": "val1", "key2": "val2" },
+          iceberg: {
             fileFormat: "PARQUET",
             connection: "gcp.us.conn-id",
             bucketName: "my-bucket",
             tableFolderRoot: "my-root",
             tableFolderSubpath: "my-subpath",
-        },
-        bigquery: {
-            partitionBy: "partition_col",
-            clusterBy: ["cluster_col1", "cluster_col2"],
-            labels: {"env": "test", "type": "iceberg"},
-            additionalOptions: { "key1": "val1", "key2": "val2" }
+          },
         }`,
         expected: {
           target: {name: "iceberg_mixed", schema: "mixed_dataset", database: "project"},
@@ -554,14 +576,16 @@ defaultIcebergConfig:
         testName: "uses defaultBucketName from workspace_settings.yaml",
         wsContent: CUSTOM_WORKFLOW_SETTINGS_WITH_ICEBERG_DEFAULTS,
         configBlock: `
-          name: "table_ws_bucket",
-          dataset: "dataset_ws",
+        name: "table_ws_bucket",
+        dataset: "dataset_ws",
+        bigquery: {
           iceberg: {
-              fileFormat: "PARQUET",
-              connection: "gcp.us.conn-id",
-              tableFolderRoot: "my-root",
-              tableFolderSubpath: "my-subpath",
-          }`,
+            fileFormat: "PARQUET",
+            connection: "gcp.us.conn-id",
+            tableFolderRoot: "my-root",
+            tableFolderSubpath: "my-subpath",
+          }
+        }`,
         expected: {
           target: { name: "table_ws_bucket", schema: "dataset_ws", database: "project" },
           bigquery: {
@@ -577,14 +601,16 @@ defaultIcebergConfig:
         testName: "uses defaultTableFolderRoot from workspace_settings.yaml",
         wsContent: CUSTOM_WORKFLOW_SETTINGS_WITH_ICEBERG_DEFAULTS,
         configBlock: `
-          name: "table_ws_root",
-          dataset: "dataset_ws",
+        name: "table_ws_root",
+        dataset: "dataset_ws",
+        bigquery: {
           iceberg: {
-              fileFormat: "PARQUET",
-              connection: "gcp.us.conn-id",
-              bucketName: "my-bucket",
-              tableFolderSubpath: "my-subpath",
-          }`,
+            fileFormat: "PARQUET",
+            connection: "gcp.us.conn-id",
+            bucketName: "my-bucket",
+            tableFolderSubpath: "my-subpath",
+          }
+        }`,
         expected: {
           target: { name: "table_ws_root", schema: "dataset_ws", database: "project" },
           bigquery: {
@@ -600,14 +626,16 @@ defaultIcebergConfig:
         testName: "uses defaultTableFolderSubpath from workspace_settings.yaml",
         wsContent: CUSTOM_WORKFLOW_SETTINGS_WITH_ICEBERG_DEFAULTS,
         configBlock: `
-          name: "table_ws_sub",
-          dataset: "dataset_ws",
+        name: "table_ws_sub",
+        dataset: "dataset_ws",
+        bigquery: {
           iceberg: {
-              fileFormat: "PARQUET",
-              connection: "gcp.us.conn-id",
-              bucketName: "my-bucket",
-              tableFolderRoot: "my-root",
-          }`,
+            fileFormat: "PARQUET",
+            connection: "gcp.us.conn-id",
+            bucketName: "my-bucket",
+            tableFolderRoot: "my-root",
+          }
+        }`,
         expected: {
           target: { name: "table_ws_sub", schema: "dataset_ws", database: "project" },
           bigquery: {
@@ -623,12 +651,14 @@ defaultIcebergConfig:
         testName: "uses all Iceberg defaults from workspace_settings.yaml",
         wsContent: CUSTOM_WORKFLOW_SETTINGS_WITH_ICEBERG_DEFAULTS,
         configBlock: `
-          name: "table_ws_all",
-          dataset: "dataset_ws",
+        name: "table_ws_all",
+        dataset: "dataset_ws",
+        bigquery: {
           iceberg: {
-              fileFormat: "PARQUET",
-              connection: "gcp.us.conn-id",
-          }`,
+            fileFormat: "PARQUET",
+            connection: "gcp.us.conn-id",
+          }
+        }`,
         expected: {
           target: { name: "table_ws_all", schema: "dataset_ws", database: "project" },
           bigquery: {
@@ -644,15 +674,17 @@ defaultIcebergConfig:
         testName: "config values override workspace defaults for Iceberg paths",
         wsContent: CUSTOM_WORKFLOW_SETTINGS_WITH_ICEBERG_DEFAULTS,
         configBlock: `
-          name: "table_override",
-          dataset: "dataset_ovr",
+        name: "table_override",
+        dataset: "dataset_ovr",
+        bigquery: {
           iceberg: {
-              fileFormat: "PARQUET",
-              connection: "gcp.us.conn-id",
-              bucketName: "config-bucket",
-              tableFolderRoot: "config-root",
-              tableFolderSubpath: "config-sub",
-          }`,
+            fileFormat: "PARQUET",
+            connection: "gcp.us.conn-id",
+            bucketName: "config-bucket",
+            tableFolderRoot: "config-root",
+            tableFolderSubpath: "config-sub",
+          }
+        }`,
         expected: {
           target: { name: "table_override", schema: "dataset_ovr", database: "project" },
           bigquery: {


### PR DESCRIPTION
Compilation logic will now support iceberg options declared inside the bigquery block in the user's config file.