### PR TITLE
Rename field with default iceberg configs

### DIFF
--- a/core/actions/incremental_table.ts
+++ b/core/actions/incremental_table.ts
@@ -199,9 +199,9 @@ export class IncrementalTable extends ActionBuilder<dataform.Table> {
         fileFormat: getFileFormatValueForIcebergTable(config.iceberg.fileFormat?.toString()),
         tableFormat: dataform.TableFormat.ICEBERG,
         storageUri: getStorageUriForIcebergTable(
-          getEffectiveBucketName(session.projectConfig.defaultIcebergConfig?.defaultBucketName, config.iceberg.bucketName),
-          getEffectiveTableFolderRoot(session.projectConfig.defaultIcebergConfig?.defaultTableFolderRoot, config.iceberg.tableFolderRoot),
-          getEffectiveTableFolderSubpath(this.proto.target.schema, this.proto.target.name, session.projectConfig.defaultIcebergConfig?.defaultTableFolderSubpath, config.iceberg.tableFolderSubpath),
+          getEffectiveBucketName(session.projectConfig.icebergConfig?.defaultBucketName, config.iceberg.bucketName),
+          getEffectiveTableFolderRoot(session.projectConfig.icebergConfig?.defaultTableFolderRoot, config.iceberg.tableFolderRoot),
+          getEffectiveTableFolderSubpath(this.proto.target.schema, this.proto.target.name, session.projectConfig.icebergConfig?.defaultTableFolderSubpath, config.iceberg.tableFolderSubpath),
         ),
       } : {}),
     });

--- a/core/actions/incremental_table_test.ts
+++ b/core/actions/incremental_table_test.ts
@@ -356,7 +356,7 @@ actions:
 defaultProject: "defaultProject"
 defaultDataset: "defaultDataset"
 defaultLocation: "us-central1"
-defaultIcebergConfig:
+icebergConfig:
   defaultBucketName: "ws-default-bucket"
   defaultTableFolderRoot: "ws-default-root"
   defaultTableFolderSubpath: "ws-default-sub"

--- a/core/actions/table.ts
+++ b/core/actions/table.ts
@@ -192,9 +192,9 @@ export class Table extends ActionBuilder<dataform.Table> {
         fileFormat: getFileFormatValueForIcebergTable(config.iceberg.fileFormat?.toString()),
         tableFormat: dataform.TableFormat.ICEBERG,
         storageUri: getStorageUriForIcebergTable(
-          getEffectiveBucketName(session.projectConfig.defaultIcebergConfig?.defaultBucketName, config.iceberg.bucketName),
-          getEffectiveTableFolderRoot(session.projectConfig.defaultIcebergConfig?.defaultTableFolderRoot, config.iceberg.tableFolderRoot),
-          getEffectiveTableFolderSubpath(this.proto.target.schema, this.proto.target.name, session.projectConfig.defaultIcebergConfig?.defaultTableFolderSubpath, config.iceberg.tableFolderSubpath),
+          getEffectiveBucketName(session.projectConfig.icebergConfig?.defaultBucketName, config.iceberg.bucketName),
+          getEffectiveTableFolderRoot(session.projectConfig.icebergConfig?.defaultTableFolderRoot, config.iceberg.tableFolderRoot),
+          getEffectiveTableFolderSubpath(this.proto.target.schema, this.proto.target.name, session.projectConfig.icebergConfig?.defaultTableFolderSubpath, config.iceberg.tableFolderSubpath),
         ),
       } : {}),
     });

--- a/core/actions/table_test.ts
+++ b/core/actions/table_test.ts
@@ -287,7 +287,7 @@ ${exampleBuiltInAssertionsAsYaml.inputActionConfigBlock}
 defaultProject: "defaultProject"
 defaultDataset: "defaultDataset"
 defaultLocation: "us-central1"
-defaultIcebergConfig:
+icebergConfig:
   defaultBucketName: "ws-default-bucket"
   defaultTableFolderRoot: "ws-default-root"
   defaultTableFolderSubpath: "ws-default-sub"

--- a/core/workflow_settings.ts
+++ b/core/workflow_settings.ts
@@ -133,16 +133,16 @@ export function workflowSettingsAsProjectConfig(
         workflowSettings.defaultNotebookRuntimeOptions.runtimeTemplateName;
     }
   }
-  if(workflowSettings.defaultIcebergConfig) {
-    projectConfig.defaultIcebergConfig = {};
-    if(workflowSettings.defaultIcebergConfig.defaultBucketName) {
-      projectConfig.defaultIcebergConfig.defaultBucketName = workflowSettings.defaultIcebergConfig.defaultBucketName;
+  if(workflowSettings.icebergConfig) {
+    projectConfig.icebergConfig = {};
+    if(workflowSettings.icebergConfig.defaultBucketName) {
+      projectConfig.icebergConfig.defaultBucketName = workflowSettings.icebergConfig.defaultBucketName;
     }
-    if(workflowSettings.defaultIcebergConfig.defaultTableFolderRoot) {
-      projectConfig.defaultIcebergConfig.defaultTableFolderRoot = workflowSettings.defaultIcebergConfig.defaultTableFolderRoot;
+    if(workflowSettings.icebergConfig.defaultTableFolderRoot) {
+      projectConfig.icebergConfig.defaultTableFolderRoot = workflowSettings.icebergConfig.defaultTableFolderRoot;
     }
-    if(workflowSettings.defaultIcebergConfig.defaultTableFolderSubpath) {
-      projectConfig.defaultIcebergConfig.defaultTableFolderSubpath = workflowSettings.defaultIcebergConfig.defaultTableFolderSubpath;
+    if(workflowSettings.icebergConfig.defaultTableFolderSubpath) {
+      projectConfig.icebergConfig.defaultTableFolderSubpath = workflowSettings.icebergConfig.defaultTableFolderSubpath;
     }
   }
 

--- a/protos/configs.proto
+++ b/protos/configs.proto
@@ -46,11 +46,11 @@ message WorkflowSettings {
   // Optional. The prefix to append to built-in assertion names.
   string builtin_assertion_name_prefix = 11;
 
-  // Optional. Default config options for Iceberg tables.
-  DefaultIcebergConfig default_iceberg_config = 12;
+  // Optional. Config options for Iceberg tables.
+  IcebergConfig iceberg_config = 12;
 }
 
-message DefaultIcebergConfig {
+message IcebergConfig {
   // Optional. Bucket name used to construct a storage URI when creating an
   // Iceberg table.
   string default_bucket_name = 1;

--- a/protos/core.proto
+++ b/protos/core.proto
@@ -26,7 +26,7 @@ message ProjectConfig {
 
   NotebookRuntimeOptions default_notebook_runtime_options = 17;
 
-  DefaultIcebergConfig default_iceberg_config = 19;
+  IcebergConfig iceberg_config = 19;
 
   reserved 3, 4, 6, 8, 10, 12, 13;
 }


### PR DESCRIPTION
This change renames defaultIcebergConfig to icebergConfig. 'Default' in the name is redundant since all the subfields have 'default_' as a prefix.