### PR TITLE
Make Iceberg fileFormat compilation case insensitive

### DIFF
--- a/core/utils.ts
+++ b/core/utils.ts
@@ -303,7 +303,7 @@ export function getFileFormatValueForIcebergTable(
     return dataform.FileFormat.PARQUET;
   }
 
-  switch (configFileFormat) {
+  switch (configFileFormat.toUpperCase()) {
     case "PARQUET":
       return dataform.FileFormat.PARQUET;
 

--- a/core/utils_test.ts
+++ b/core/utils_test.ts
@@ -230,6 +230,11 @@ suite('Dataform Utility Validations', () => {
       expect(getFileFormatValueForIcebergTable('')).to.equal(dataform.FileFormat.PARQUET);
     });
 
+    test('is case insensitive ', () => {
+      expect(getFileFormatValueForIcebergTable('parquet')).to.equal(dataform.FileFormat.PARQUET);
+      expect(getFileFormatValueForIcebergTable('pArQuEt')).to.equal(dataform.FileFormat.PARQUET);
+    });
+
     test('throws an error for an unsupported file format string', () => {
       assertThrowsWithMessage(
         () => getFileFormatValueForIcebergTable('CSV'),


### PR DESCRIPTION
This change ensures users can provide the fileFormat string in any case.