### PR TITLE
Enable setting default connection for Iceberg table

### DIFF
--- a/core/actions/incremental_table.ts
+++ b/core/actions/incremental_table.ts
@@ -195,7 +195,10 @@ export class IncrementalTable extends ActionBuilder<dataform.Table> {
       requirePartitionFilter: config.requirePartitionFilter,
       additionalOptions: config.additionalOptions,
       ...(config.iceberg ? {
-        connection: getConnectionForIcebergTable(config.iceberg.connection),
+        connection: getConnectionForIcebergTable(
+          session.projectConfig.defaultIcebergConfig?.connection,
+          config.iceberg.connection
+        ),
         fileFormat: getFileFormatValueForIcebergTable(config.iceberg.fileFormat?.toString()),
         tableFormat: dataform.TableFormat.ICEBERG,
         storageUri: getStorageUriForIcebergTable(

--- a/core/actions/incremental_table.ts
+++ b/core/actions/incremental_table.ts
@@ -196,8 +196,8 @@ export class IncrementalTable extends ActionBuilder<dataform.Table> {
       additionalOptions: config.additionalOptions,
       ...(config.iceberg ? {
         connection: getConnectionForIcebergTable(
-          session.projectConfig.defaultIcebergConfig?.connection,
-          config.iceberg.connection
+          config.iceberg.connection,
+          session.projectConfig.defaultIcebergConfig?.connection
         ),
         fileFormat: getFileFormatValueForIcebergTable(config.iceberg.fileFormat?.toString()),
         tableFormat: dataform.TableFormat.ICEBERG,

--- a/core/actions/incremental_table_test.ts
+++ b/core/actions/incremental_table_test.ts
@@ -360,6 +360,7 @@ defaultIcebergConfig:
   bucketName: "ws-default-bucket"
   tableFolderRoot: "ws-default-root"
   tableFolderSubpath: "ws-default-sub"
+  connection: "ws.default.connection"
 `;
 
     const testCases = [
@@ -737,6 +738,32 @@ defaultIcebergConfig:
         expectError: false,
       },
       {
+        testName: "uses default connection from workflow_settings.yaml",
+        wsContent: CUSTOM_WORKFLOW_SETTINGS_WITH_ICEBERG_DEFAULTS,
+        configBlock: `
+        type: "incremental",
+        name: "incremental_ws_sub",
+        dataset: "dataset_ws",
+        bigquery: {
+          iceberg: {
+            fileFormat: "PARQUET",
+            bucketName: "my-bucket",
+            tableFolderRoot: "my-root",
+            tableFolderSubpath: "my-subpath"
+          }
+        }`,
+        expected: {
+          target: { name: "incremental_ws_sub", schema: "dataset_ws", database: "defaultProject" },
+          bigquery: {
+            tableFormat: "ICEBERG",
+            fileFormat: "PARQUET",
+            connection: "ws.default.connection",
+            storageUri: "gs://my-bucket/my-root/my-subpath",
+          },
+        },
+        expectError: false,
+      },
+      {
         testName: "uses all Iceberg defaults from workspace_settings.yaml",
         wsContent: CUSTOM_WORKFLOW_SETTINGS_WITH_ICEBERG_DEFAULTS,
         configBlock: `
@@ -746,8 +773,6 @@ defaultIcebergConfig:
         bigquery: {
           iceberg: {
             fileFormat: "PARQUET",
-            connection: "gcp.us.conn-id",
-            // All path components omitted
           }
         }`,
         expected: {
@@ -755,7 +780,7 @@ defaultIcebergConfig:
           bigquery: {
             tableFormat: "ICEBERG",
             fileFormat: "PARQUET",
-            connection: "gcp.us.conn-id",
+            connection: "ws.default.connection",
             storageUri: "gs://ws-default-bucket/ws-default-root/ws-default-sub",
           },
         },

--- a/core/actions/table.ts
+++ b/core/actions/table.ts
@@ -189,8 +189,8 @@ export class Table extends ActionBuilder<dataform.Table> {
       additionalOptions: config.additionalOptions,
       ...(config.iceberg ? {
         connection: getConnectionForIcebergTable(
-          session.projectConfig.defaultIcebergConfig?.connection,
-          config.iceberg.connection
+          config.iceberg.connection,
+          session.projectConfig.defaultIcebergConfig?.connection
         ),
         fileFormat: getFileFormatValueForIcebergTable(config.iceberg.fileFormat?.toString()),
         tableFormat: dataform.TableFormat.ICEBERG,

--- a/core/actions/table.ts
+++ b/core/actions/table.ts
@@ -188,7 +188,10 @@ export class Table extends ActionBuilder<dataform.Table> {
       requirePartitionFilter: config.requirePartitionFilter,
       additionalOptions: config.additionalOptions,
       ...(config.iceberg ? {
-        connection: getConnectionForIcebergTable(config.iceberg.connection),
+        connection: getConnectionForIcebergTable(
+          session.projectConfig.defaultIcebergConfig?.connection,
+          config.iceberg.connection
+        ),
         fileFormat: getFileFormatValueForIcebergTable(config.iceberg.fileFormat?.toString()),
         tableFormat: dataform.TableFormat.ICEBERG,
         storageUri: getStorageUriForIcebergTable(

--- a/core/actions/table_test.ts
+++ b/core/actions/table_test.ts
@@ -291,6 +291,7 @@ defaultIcebergConfig:
   bucketName: "ws-default-bucket"
   tableFolderRoot: "ws-default-root"
   tableFolderSubpath: "ws-default-sub"
+  connection: "ws.default.connection"
 `;
 
     const testCases = [
@@ -648,6 +649,31 @@ defaultIcebergConfig:
         expectError: false,
       },
       {
+        testName: "uses default connection from workflow_settings.yaml",
+        wsContent: CUSTOM_WORKFLOW_SETTINGS_WITH_ICEBERG_DEFAULTS,
+        configBlock: `
+        name: "table_ws_sub",
+        dataset: "dataset_ws",
+        bigquery: {
+          iceberg: {
+            fileFormat: "PARQUET",
+            bucketName: "my-bucket",
+            tableFolderRoot: "my-root",
+            tableFolderSubpath: "my-subpath",
+          }
+        }`,
+        expected: {
+          target: { name: "table_ws_sub", schema: "dataset_ws", database: "project" },
+          bigquery: {
+            tableFormat: "ICEBERG",
+            fileFormat: "PARQUET",
+            connection: "ws.default.connection",
+            storageUri: "gs://my-bucket/my-root/my-subpath",
+          },
+        },
+        expectError: false,
+      },
+      {
         testName: "uses all Iceberg defaults from workspace_settings.yaml",
         wsContent: CUSTOM_WORKFLOW_SETTINGS_WITH_ICEBERG_DEFAULTS,
         configBlock: `
@@ -656,7 +682,6 @@ defaultIcebergConfig:
         bigquery: {
           iceberg: {
             fileFormat: "PARQUET",
-            connection: "gcp.us.conn-id",
           }
         }`,
         expected: {
@@ -664,7 +689,7 @@ defaultIcebergConfig:
           bigquery: {
             tableFormat: "ICEBERG",
             fileFormat: "PARQUET",
-            connection: "gcp.us.conn-id",
+            connection: "ws.default.connection",
             storageUri: "gs://ws-default-bucket/ws-default-root/ws-default-sub",
           },
         },

--- a/core/utils.ts
+++ b/core/utils.ts
@@ -317,13 +317,13 @@ export function getFileFormatValueForIcebergTable(
 /**
  * Returns the connection for an Iceberg table, as specified in the user's config file.
  * Defaults to "DEFAULT" if no connection is provided.
- * @param defaultConnection defined in workflow_settings.yaml.
  * @param configConnection defined in the config block
+ * @param defaultConnection defined in workflow_settings.yaml.
  * @returns Connection used when creating an Iceberg table.
  */
 export function getConnectionForIcebergTable(
+  configConnection?: string,
   defaultConnection?: string,
-  configConnection?: string
 ): string {
   if(configConnection) {
     return configConnection;

--- a/core/utils.ts
+++ b/core/utils.ts
@@ -317,11 +317,21 @@ export function getFileFormatValueForIcebergTable(
 /**
  * Returns the connection for an Iceberg table, as specified in the user's config file.
  * Defaults to "DEFAULT" if no connection is provided.
- * @param connection User-provided connection, if it exists.
+ * @param defaultConnection defined in workflow_settings.yaml.
+ * @param configConnection defined in the config block
  * @returns Connection used when creating an Iceberg table.
  */
-export function getConnectionForIcebergTable(connection?: string): string {
-  return connection || "DEFAULT";
+export function getConnectionForIcebergTable(
+  defaultConnection?: string,
+  configConnection?: string
+): string {
+  if(configConnection) {
+    return configConnection;
+  } else if(defaultConnection) {
+    return defaultConnection;
+  } else {
+    return "DEFAULT";
+  }
 }
 
 /**

--- a/core/utils_test.ts
+++ b/core/utils_test.ts
@@ -204,16 +204,24 @@ suite('Dataform Utility Validations', () => {
   });
 
   suite('getConnectionForIcebergTable', () => {
-    test('returns the provided connection string if it exists', () => {
-      expect(getConnectionForIcebergTable('my-custom-conn')).to.equal('my-custom-conn');
+    test('returns the config connection string if it exists', () => {
+      expect(getConnectionForIcebergTable('default-connection', 'config-connection')).to.equal('config-connection');
     });
 
-    test('returns "DEFAULT" when the connection is undefined', () => {
-      expect(getConnectionForIcebergTable(undefined)).to.equal('DEFAULT');
+    test('returns the default connection string if the config connection is undefined', () => {
+      expect(getConnectionForIcebergTable('default-connection', undefined)).to.equal('default-connection');
     });
 
-    test('returns "DEFAULT" when the connection is an empty string', () => {
-      expect(getConnectionForIcebergTable('')).to.equal('DEFAULT');
+    test('returns the default connection string if the config connection is an empty string', () => {
+      expect(getConnectionForIcebergTable('default-connection', '')).to.equal('default-connection');
+    });
+
+    test('returns "DEFAULT" when the connections are undefined', () => {
+      expect(getConnectionForIcebergTable(undefined, undefined)).to.equal('DEFAULT');
+    });
+
+    test('returns "DEFAULT" when the connections are empty strings', () => {
+      expect(getConnectionForIcebergTable('', '')).to.equal('DEFAULT');
     });
   });
 

--- a/core/utils_test.ts
+++ b/core/utils_test.ts
@@ -205,15 +205,15 @@ suite('Dataform Utility Validations', () => {
 
   suite('getConnectionForIcebergTable', () => {
     test('returns the config connection string if it exists', () => {
-      expect(getConnectionForIcebergTable('default-connection', 'config-connection')).to.equal('config-connection');
+      expect(getConnectionForIcebergTable('config-connection', 'default-connection')).to.equal('config-connection');
     });
 
     test('returns the default connection string if the config connection is undefined', () => {
-      expect(getConnectionForIcebergTable('default-connection', undefined)).to.equal('default-connection');
+      expect(getConnectionForIcebergTable(undefined, 'default-connection')).to.equal('default-connection');
     });
 
     test('returns the default connection string if the config connection is an empty string', () => {
-      expect(getConnectionForIcebergTable('default-connection', '')).to.equal('default-connection');
+      expect(getConnectionForIcebergTable('', 'default-connection')).to.equal('default-connection');
     });
 
     test('returns "DEFAULT" when the connections are undefined', () => {

--- a/core/workflow_settings.ts
+++ b/core/workflow_settings.ts
@@ -144,6 +144,9 @@ export function workflowSettingsAsProjectConfig(
     if(workflowSettings.defaultIcebergConfig.tableFolderSubpath) {
       projectConfig.defaultIcebergConfig.tableFolderSubpath = workflowSettings.defaultIcebergConfig.tableFolderSubpath;
     }
+    if(workflowSettings.defaultIcebergConfig.connection) {
+      projectConfig.defaultIcebergConfig.connection = workflowSettings.defaultIcebergConfig.connection;
+    }
   }
 
   projectConfig.warehouse = "bigquery";

--- a/protos/configs.proto
+++ b/protos/configs.proto
@@ -62,6 +62,10 @@ message DefaultIcebergConfig {
   // Optional. Table folder subpath used to construct a storage URI when
   // creating an Iceberg table.
   string table_folder_subpath = 3;
+
+  // Optional. The connection specifying the credentials to be used to read and
+  // write to external storage, such as Cloud Storage.
+  string connection = 4;
 }
 
 // Action configs defines the contents of `actions.yaml` configuration files.


### PR DESCRIPTION
This change enables a workflow-level default connection to be set inside workflow_settings.yaml.