### PR TITLE
Dataform Protos - Fix //protos:dataform_proto build

### DIFF
--- a/protos/core.proto
+++ b/protos/core.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package dataform;
 
+import "protos/configs.proto";
+
 option java_package = "com.dataform.protos";
 option java_outer_classname = "CoreMeta";
 option java_multiple_files = true;


### PR DESCRIPTION
`//protos:dataform_proto` target has been broken for quite a while with:

```
dataform/protos/BUILD:7:14: Generating Descriptor Set proto_library //protos:dataform_proto failed: (Exit 1): protoc failed: error executing command bazel-out/k8-py2-opt-exec-2B5CBBC6/bin/external/com_google_protobuf/protoc '--descriptor_
set_out=bazel-out/k8-py2-fastbuild/bin/protos/dataform_proto-descriptor-set.proto.bin' ... (remaining 13 arguments skipped)                                                                                                                                                               
                                                                                                                                                                                                                                                                                          
Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging                                                                                                                                                                              
protos/core.proto:29:3: "dataform.DefaultIcebergConfig" seems to be defined in "protos/configs.proto", which is not imported by "protos/core.proto".  To use it here, please add the necessary import. 
```

This was breaking only this target and not TS/JS code, but we had to fix it manually on the internal imports as well. Adding a missing import, so that the target is passing again and we no longer need to fix it by-hand on internal import.
