### PR TITLE
Allow filename overrides in declaration, tests and other assets

### DIFF
--- a/core/BUILD
+++ b/core/BUILD
@@ -68,6 +68,7 @@ ts_test_suite(
         "actions/assertion_test.ts",
         "actions/data_preparation_test.ts",
         "actions/declaration_test.ts",
+        "actions/filename_override_test.ts",
         "actions/incremental_table_test.ts",
         "actions/index_test.ts",
         "actions/notebook_test.ts",

--- a/core/actions/declaration.ts
+++ b/core/actions/declaration.ts
@@ -84,7 +84,11 @@ export class Declaration extends ActionBuilder<dataform.Declaration> {
     }
 
     const target = actionConfigToCompiledGraphTarget(config);
-    this.proto.target = this.applySessionToTarget(target, session.projectConfig);
+    this.proto.target = this.applySessionToTarget(
+      target,
+      session.projectConfig,
+      config.filename || filename
+    );
     this.proto.canonicalTarget = this.applySessionToTarget(target, session.canonicalProjectConfig);
 
     if (config.description) {
@@ -97,7 +101,7 @@ export class Declaration extends ActionBuilder<dataform.Declaration> {
         )
       );
     }
-    this.proto.fileName = filename;
+    this.proto.fileName = config.filename || filename;
     return this;
   }
 

--- a/core/actions/filename_override_test.ts
+++ b/core/actions/filename_override_test.ts
@@ -1,0 +1,358 @@
+// tslint:disable tsr-detect-non-literal-fs-filename
+import { expect } from "chai";
+import * as fs from "fs-extra";
+import * as path from "path";
+
+import { asPlainObject, suite, test } from "df/testing";
+import { TmpDirFixture } from "df/testing/fixtures";
+import {
+  coreExecutionRequestFromPath,
+  runMainInVm,
+  VALID_WORKFLOW_SETTINGS_YAML
+} from "df/testing/run_core";
+
+suite("filename_override", ({ afterEach }) => {
+  const tmpDirFixture = new TmpDirFixture(afterEach);
+
+  test("publish with filename override", () => {
+    const projectDir = tmpDirFixture.createNewTmpDir();
+    fs.writeFileSync(
+      path.join(projectDir, "workflow_settings.yaml"),
+      VALID_WORKFLOW_SETTINGS_YAML
+    );
+    fs.mkdirSync(path.join(projectDir, "definitions"));
+    fs.writeFileSync(
+      path.join(projectDir, "definitions/file.js"),
+      `
+      publish("override_table", {
+        type: "table",
+        filename: "custom/path/to/file.sql"
+      }).query("SELECT 1");
+      `
+    );
+
+    const result = runMainInVm(coreExecutionRequestFromPath(projectDir));
+
+    expect(result.compile.compiledGraph.graphErrors.compilationErrors).deep.equals([]);
+    const table = result.compile.compiledGraph.tables.find(
+      t => t.target.name === "override_table"
+    );
+    expect(table.fileName).equals("custom/path/to/file.sql");
+  });
+
+  test("publish with omitted filename dynamically determined", () => {
+    const projectDir = tmpDirFixture.createNewTmpDir();
+    fs.writeFileSync(
+      path.join(projectDir, "workflow_settings.yaml"),
+      VALID_WORKFLOW_SETTINGS_YAML
+    );
+    fs.mkdirSync(path.join(projectDir, "definitions"));
+    fs.writeFileSync(
+      path.join(projectDir, "definitions/file.js"),
+      `
+      publish("dynamic_table", {
+        type: "table"
+      }).query("SELECT 1");
+      `
+    );
+
+    const result = runMainInVm(coreExecutionRequestFromPath(projectDir));
+
+    expect(result.compile.compiledGraph.graphErrors.compilationErrors).deep.equals([]);
+    const table = result.compile.compiledGraph.tables.find(t => t.target.name === "dynamic_table");
+    expect(table.fileName).equals("definitions/file.js");
+  });
+
+
+  test("incremental with filename override", () => {
+    const projectDir = tmpDirFixture.createNewTmpDir();
+    fs.writeFileSync(
+      path.join(projectDir, "workflow_settings.yaml"),
+      VALID_WORKFLOW_SETTINGS_YAML
+    );
+    fs.mkdirSync(path.join(projectDir, "definitions"));
+    fs.writeFileSync(
+      path.join(projectDir, "definitions/file.js"),
+      `
+      publish("override_incremental", {
+        type: "incremental",
+        filename: "custom/path/to/incremental.sql"
+      }).query("SELECT 1");
+      `
+    );
+
+    const result = runMainInVm(coreExecutionRequestFromPath(projectDir));
+
+    expect(result.compile.compiledGraph.graphErrors.compilationErrors).deep.equals([]);
+    const table = result.compile.compiledGraph.tables.find(
+      t => t.target.name === "override_incremental"
+    );
+    expect(table.fileName).equals("custom/path/to/incremental.sql");
+  });
+
+  test("incremental with omitted filename dynamically determined", () => {
+    const projectDir = tmpDirFixture.createNewTmpDir();
+    fs.writeFileSync(
+      path.join(projectDir, "workflow_settings.yaml"),
+      VALID_WORKFLOW_SETTINGS_YAML
+    );
+    fs.mkdirSync(path.join(projectDir, "definitions"));
+    fs.writeFileSync(
+      path.join(projectDir, "definitions/file.js"),
+      `
+      publish("dynamic_incremental", {
+        type: "incremental"
+      }).query("SELECT 1");
+      `
+    );
+
+    const result = runMainInVm(coreExecutionRequestFromPath(projectDir));
+
+    expect(result.compile.compiledGraph.graphErrors.compilationErrors).deep.equals([]);
+    const table = result.compile.compiledGraph.tables.find(
+      t => t.target.name === "dynamic_incremental"
+    );
+    expect(table.fileName).equals("definitions/file.js");
+  });
+
+  test("operate with filename override", () => {
+    const projectDir = tmpDirFixture.createNewTmpDir();
+    fs.writeFileSync(
+      path.join(projectDir, "workflow_settings.yaml"),
+      VALID_WORKFLOW_SETTINGS_YAML
+    );
+    fs.mkdirSync(path.join(projectDir, "definitions"));
+    fs.writeFileSync(
+      path.join(projectDir, "definitions/file.js"),
+      `
+      operate("override_op", {
+        filename: "custom/path/to/op.sql"
+      }).queries("SELECT 1");
+      `
+    );
+
+    const result = runMainInVm(coreExecutionRequestFromPath(projectDir));
+
+    expect(result.compile.compiledGraph.graphErrors.compilationErrors).deep.equals([]);
+    const op = result.compile.compiledGraph.operations.find(
+      o => o.target.name === "override_op"
+    );
+    expect(op.fileName).equals("custom/path/to/op.sql");
+  });
+
+  test("operate with omitted filename dynamically determined", () => {
+    const projectDir = tmpDirFixture.createNewTmpDir();
+    fs.writeFileSync(
+      path.join(projectDir, "workflow_settings.yaml"),
+      VALID_WORKFLOW_SETTINGS_YAML
+    );
+    fs.mkdirSync(path.join(projectDir, "definitions"));
+    fs.writeFileSync(
+      path.join(projectDir, "definitions/file.js"),
+      `
+      operate("dynamic_op").queries("SELECT 1");
+      `
+    );
+
+    const result = runMainInVm(coreExecutionRequestFromPath(projectDir));
+
+    expect(result.compile.compiledGraph.graphErrors.compilationErrors).deep.equals([]);
+    const op = result.compile.compiledGraph.operations.find(o => o.target.name === "dynamic_op");
+    expect(op.fileName).equals("definitions/file.js");
+  });
+
+
+  test("assert with filename override", () => {
+    const projectDir = tmpDirFixture.createNewTmpDir();
+    fs.writeFileSync(
+      path.join(projectDir, "workflow_settings.yaml"),
+      VALID_WORKFLOW_SETTINGS_YAML
+    );
+    fs.mkdirSync(path.join(projectDir, "definitions"));
+    fs.writeFileSync(
+      path.join(projectDir, "definitions/file.js"),
+      `
+      assert("override_assert", {
+        filename: "custom/path/to/assert.sql"
+      }).query("SELECT 1");
+      `
+    );
+
+    const result = runMainInVm(coreExecutionRequestFromPath(projectDir));
+
+    expect(result.compile.compiledGraph.graphErrors.compilationErrors).deep.equals([]);
+    const assertion = result.compile.compiledGraph.assertions.find(
+      a => a.target.name === "override_assert"
+    );
+    expect(assertion.fileName).equals("custom/path/to/assert.sql");
+  });
+
+  test("assert with omitted filename dynamically determined", () => {
+    const projectDir = tmpDirFixture.createNewTmpDir();
+    fs.writeFileSync(
+      path.join(projectDir, "workflow_settings.yaml"),
+      VALID_WORKFLOW_SETTINGS_YAML
+    );
+    fs.mkdirSync(path.join(projectDir, "definitions"));
+    fs.writeFileSync(
+      path.join(projectDir, "definitions/file.js"),
+      `
+      assert("dynamic_assert").query("SELECT 1");
+      `
+    );
+
+    const result = runMainInVm(coreExecutionRequestFromPath(projectDir));
+
+    expect(result.compile.compiledGraph.graphErrors.compilationErrors).deep.equals([]);
+    const assertion = result.compile.compiledGraph.assertions.find(
+      a => a.target.name === "dynamic_assert"
+    );
+    expect(assertion.fileName).equals("definitions/file.js");
+  });
+
+  test("declare with filename override", () => {
+    const projectDir = tmpDirFixture.createNewTmpDir();
+    fs.writeFileSync(
+      path.join(projectDir, "workflow_settings.yaml"),
+      VALID_WORKFLOW_SETTINGS_YAML
+    );
+    fs.mkdirSync(path.join(projectDir, "definitions"));
+    fs.writeFileSync(
+      path.join(projectDir, "definitions/file.js"),
+      `
+      declare({
+        database: "db",
+        schema: "schema",
+        name: "override_decl",
+        filename: "custom/path/to/decl.sql"
+      });
+      `
+    );
+
+    const result = runMainInVm(coreExecutionRequestFromPath(projectDir));
+
+    expect(result.compile.compiledGraph.graphErrors.compilationErrors).deep.equals([]);
+    const decl = result.compile.compiledGraph.declarations.find(
+      d => d.target.name === "override_decl"
+    );
+    expect(decl.fileName).equals("custom/path/to/decl.sql");
+  });
+
+  test("declare with omitted filename dynamically determined", () => {
+    const projectDir = tmpDirFixture.createNewTmpDir();
+    fs.writeFileSync(
+      path.join(projectDir, "workflow_settings.yaml"),
+      VALID_WORKFLOW_SETTINGS_YAML
+    );
+    fs.mkdirSync(path.join(projectDir, "definitions"));
+    fs.writeFileSync(
+      path.join(projectDir, "definitions/file.js"),
+      `
+      declare({
+        database: "db",
+        schema: "schema",
+        name: "dynamic_decl"
+      });
+      `
+    );
+
+    const result = runMainInVm(coreExecutionRequestFromPath(projectDir));
+
+    expect(result.compile.compiledGraph.graphErrors.compilationErrors).deep.equals([]);
+    const decl = result.compile.compiledGraph.declarations.find(
+      d => d.target.name === "dynamic_decl"
+    );
+    expect(decl.fileName).equals("definitions/file.js");
+  });
+
+  test("test with filename override", () => {
+    const projectDir = tmpDirFixture.createNewTmpDir();
+    fs.writeFileSync(
+      path.join(projectDir, "workflow_settings.yaml"),
+      VALID_WORKFLOW_SETTINGS_YAML
+    );
+    fs.mkdirSync(path.join(projectDir, "definitions"));
+    fs.writeFileSync(
+      path.join(projectDir, "definitions/file.js"),
+      `
+      test("override_test")
+        .config({
+          filename: "custom/path/to/test.sql",
+          dataset: "override_table"
+        })
+        .input("override_table", "SELECT 1")
+        .expect("SELECT 1");
+      
+      publish("override_table").query("SELECT 1");
+      `
+    );
+
+    const result = runMainInVm(coreExecutionRequestFromPath(projectDir));
+
+    expect(result.compile.compiledGraph.graphErrors.compilationErrors).deep.equals([]);
+    const t = result.compile.compiledGraph.tests.find(
+      testProto => testProto.name === "override_test"
+    );
+    expect(t.fileName).equals("custom/path/to/test.sql");
+  });
+
+  test("test with omitted filename dynamically determined", () => {
+    const projectDir = tmpDirFixture.createNewTmpDir();
+    fs.writeFileSync(
+      path.join(projectDir, "workflow_settings.yaml"),
+      VALID_WORKFLOW_SETTINGS_YAML
+    );
+    fs.mkdirSync(path.join(projectDir, "definitions"));
+    fs.writeFileSync(
+      path.join(projectDir, "definitions/file.js"),
+      `
+      test("dynamic_test")
+        .config({
+          dataset: "override_table"
+        })
+        .input("override_table", "SELECT 1")
+        .expect("SELECT 1");
+      
+      publish("override_table").query("SELECT 1");
+      `
+    );
+
+    const result = runMainInVm(coreExecutionRequestFromPath(projectDir));
+
+    expect(result.compile.compiledGraph.graphErrors.compilationErrors).deep.equals([]);
+    const t = result.compile.compiledGraph.tests.find(
+      testProto => testProto.name === "dynamic_test"
+    );
+    expect(t.fileName).equals("definitions/file.js");
+  });
+
+  test("notebook with filename explicitly set", () => {
+    const projectDir = tmpDirFixture.createNewTmpDir();
+    fs.writeFileSync(
+      path.join(projectDir, "workflow_settings.yaml"),
+      VALID_WORKFLOW_SETTINGS_YAML
+    );
+    fs.mkdirSync(path.join(projectDir, "definitions"));
+    fs.writeFileSync(path.join(projectDir, "definitions/notebook.ipynb"), '{"cells":[]}');
+    
+    fs.writeFileSync(
+      path.join(projectDir, "definitions/file.js"),
+      `
+      notebook({
+        name: "override_notebook",
+        location: "US",
+        filename: "notebook.ipynb" // This is used to load content, it MUST point to valid notebook.
+      });
+      `
+    );
+    
+    const result = runMainInVm(coreExecutionRequestFromPath(projectDir));
+
+    expect(result.compile.compiledGraph.graphErrors.compilationErrors).deep.equals([]);
+    const nb = result.compile.compiledGraph.notebooks.find(
+      n => n.target.name === "override_notebook"
+    );
+    // It should use the explicitly provided filename
+    expect(nb.fileName).to.contain("definitions/notebook.ipynb");
+  });
+});

--- a/core/actions/test.ts
+++ b/core/actions/test.ts
@@ -29,10 +29,13 @@ export interface ITestConfig extends INamedConfig {
 
   /** Name of this action. */
   name?: string;
+
+  /** Path to the source file that the contents of the action is loaded from. */
+  filename?: string;
 }
 
 /** @hidden */
-const ITestConfigProperties = strictKeysOf<ITestConfig>()(["type", "dataset", "name"]);
+const ITestConfigProperties = strictKeysOf<ITestConfig>()(["type", "dataset", "name", "filename"]);
 
 /**
  * Dataform test actions can be used to write unit tests for your generated SQL
@@ -105,6 +108,9 @@ export class Test extends ActionBuilder<dataform.Test> {
     }
     if (config.dataset) {
       this.dataset(config.dataset);
+    }
+    if (config.filename) {
+      this.proto.fileName = config.filename;
     }
     return this;
   }

--- a/core/session.ts
+++ b/core/session.ts
@@ -135,9 +135,12 @@ export class Session {
       this.compileError("Actions may only include post_operations if they create a dataset.");
     }
 
+    if (!sqlxConfig.filename) {
+      sqlxConfig.filename = utils.getCallerFile(this.rootDir);
+    }
+
     switch (actionType) {
       case "view":
-        sqlxConfig.filename = utils.getCallerFile(this.rootDir);
         const view = new View(this, sqlxConfig).query(ctx => actionOptions.sqlContextable(ctx)[0]);
         if (actionOptions.incrementalWhereContextable) {
           view.where(actionOptions.incrementalWhereContextable);
@@ -151,7 +154,6 @@ export class Session {
         this.actions.push(view);
         break;
       case "incremental":
-        sqlxConfig.filename = utils.getCallerFile(this.rootDir);
         const incrementalTable = new IncrementalTable(this, sqlxConfig).query(
           ctx => actionOptions.sqlContextable(ctx)[0]
         );
@@ -167,7 +169,6 @@ export class Session {
         this.actions.push(incrementalTable);
         break;
       case "table":
-        sqlxConfig.filename = utils.getCallerFile(this.rootDir);
         const table = new Table(this, sqlxConfig).query(
           ctx => actionOptions.sqlContextable(ctx)[0]
         );
@@ -183,24 +184,21 @@ export class Session {
         this.actions.push(table);
         break;
       case "assertion":
-        sqlxConfig.filename = utils.getCallerFile(this.rootDir);
         this.actions.push(
           new Assertion(this, sqlxConfig).query(ctx => actionOptions.sqlContextable(ctx)[0])
         );
         break;
       case "dataPreparation":
-        sqlxConfig.filename = utils.getCallerFile(this.rootDir);
         const dataPreparation = new DataPreparation(this, sqlxConfig).query(
           ctx => actionOptions.sqlContextable(ctx)[0]
         );
         this.actions.push(dataPreparation);
         break;
       case "operations":
-        sqlxConfig.filename = utils.getCallerFile(this.rootDir);
         this.actions.push(new Operation(this, sqlxConfig).queries(actionOptions.sqlContextable));
         break;
       case "declaration":
-        const declaration = new Declaration(this, sqlxConfig, utils.getCallerFile(this.rootDir));
+        const declaration = new Declaration(this, sqlxConfig, sqlxConfig.filename);
         this.actions.push(declaration);
         break;
       case "test":
@@ -312,8 +310,8 @@ export class Session {
           newTable = new IncrementalTable(this, {
             type: "incremental",
             name,
-            ...queryOrConfig,
-            filename
+            filename,
+            ...queryOrConfig
           });
         } else if (queryOrConfig?.type === "table") {
           newTable = new Table(this, { type: "table", name, filename, ...queryOrConfig });

--- a/protos/configs.proto
+++ b/protos/configs.proto
@@ -556,6 +556,9 @@ message ActionConfig {
 
     // Descriptions of columns within the declaration.
     repeated ColumnDescriptor columns = 5;
+
+    // Path to the source file that the contents of the action is loaded from.
+    string filename = 6;
   }
 
   message NotebookConfig {


### PR DESCRIPTION
Making filename configuration supported in all graph nodes - right now this works only partially, for ex. for views and tables, but it is not supported for declarations and breaks for incremental tables.

Explicitly adding a support for that and adding a test to prevent furture regressions.