### PR TITLE
fix: Handle missing defaultProject in incremental table validation (#2053)

### DIFF
--- a/core/actions/index.ts
+++ b/core/actions/index.ts
@@ -157,21 +157,21 @@ export abstract class ActionBuilder<T> {
   }
 
   private validateTarget(target: dataform.Target, fileName: string) {
-    if (target.name.includes(".")) {
+    if (target.name && target.name.includes(".")) {
       this.session.compileError(
         new Error("Action target names cannot include '.'"),
         fileName,
         target
       );
     }
-    if (target.schema.includes(".")) {
+    if (target.schema && target.schema.includes(".")) {
       this.session.compileError(
         new Error("Action target datasets cannot include '.'"),
         fileName,
         target
       );
     }
-    if (target.database.includes(".")) {
+    if (target.database && target.database.includes(".")) {
       this.session.compileError(
         new Error("Action target projects cannot include '.'"),
         fileName,


### PR DESCRIPTION


- Added null checks in validateTarget method before calling .includes()
- Prevents TypeError when target properties (name, schema, database) are undefined
- Enables CLI --default-database flag to work correctly without hardcoded defaultProject
- Added test case verifying incremental() function works without workflow_settings defaultProject