### PR TITLE
JiT contexts implementation

### DIFF
--- a/core/BUILD
+++ b/core/BUILD
@@ -33,6 +33,7 @@ ts_library(
         "contextables.ts",
         "extension.ts",
         "index.ts",
+        "jit_context.ts",
         "main.ts",
         "path.ts",
         "session.ts",
@@ -76,6 +77,7 @@ ts_test_suite(
         "actions/table_test.ts",
         "actions/test_test.ts",
         "actions/view_test.ts",
+        "jit_context_test.ts",
     ],
     data = [
         ":node_modules",

--- a/core/jit_context.ts
+++ b/core/jit_context.ts
@@ -1,0 +1,108 @@
+import { IActionContext, ITableContext, JitContext, Resolvable } from "df/core/contextables";
+import { ambiguousActionNameMsg, resolvableAsTarget, ResolvableMap, stringifyResolvable, toResolvable } from "df/core/utils";
+import { dataform } from "df/protos/ts";
+
+function canonicalTargetValue(target: dataform.ITarget): string {
+    return `${target.database}.${target.schema}.${target.name}`;
+}
+
+function schemaTargetValue(target: dataform.ITarget): string {
+    return `${target.schema}.${target.name}`;
+}
+
+/** Generate SQL action JiT context. */
+export class SqlActionJitContext implements JitContext<IActionContext> {
+    private readonly resolvableMap: ResolvableMap<string>;
+
+    constructor(
+        public readonly adapter: dataform.DbAdapter,
+        public readonly data: { [k: string]: any } | undefined,
+        private readonly target: dataform.ITarget,
+        dependencies: dataform.ITarget[],
+    ) {
+        const resolvables = [target, ...dependencies];
+        this.resolvableMap = new ResolvableMap(resolvables.map(dep => ({
+            actionTarget: dep,
+            value: canonicalTargetValue(dep)
+        })));
+    }
+
+    public self(): string {
+        return this.resolve(this.name());
+    }
+
+    public name(): string {
+        return this.target.name;
+    }
+
+    public ref(ref: Resolvable | string[], ...rest: string[]): string {
+        return this.resolve(ref, ...rest);
+    }
+
+    public resolve(ref: Resolvable | string[], ...rest: string[]): string {
+        ref = toResolvable(ref, rest);
+        const refTarget = resolvableAsTarget(ref);
+        const candidates = this.resolvableMap.find(refTarget);
+
+        if (candidates.length > 1) {
+            throw new Error(ambiguousActionNameMsg(ref, candidates));
+        }
+
+        return this.resolveReference(
+            stringifyResolvable(ref),
+            candidates.length > 0 ? candidates[0] : undefined);
+    }
+
+    public schema(): string {
+        return this.target.schema;
+    }
+
+    public database(): string {
+        return this.target.database;
+    }
+
+
+    private resolveReference(name: string, resolvedName?: string): string {
+        if (!!resolvedName) {
+            return `\`${resolvedName}\``;
+        }
+        throw new Error(`Undeclared dependency referenced: ${name}.\n` +
+            "JiT action must have its dependencies declared explicitly.");
+    }
+}
+
+/** JiT context for table and view actions. */
+export class TableJitContext extends SqlActionJitContext implements JitContext<ITableContext> {
+    constructor(
+        adapter: dataform.DbAdapter,
+        data: { [k: string]: any } | undefined,
+        target: dataform.ITarget,
+        dependencies: dataform.ITarget[],
+    ) {
+        super(adapter, data, target, dependencies);
+    }
+
+    public when(cond: boolean, trueCase: string, falseCase?: string) {
+        return cond ? trueCase : falseCase || "";
+    }
+
+    public incremental(): boolean {
+        return false;
+    }
+}
+
+/** JiT context for incremental table actions. */
+export class IncrementalTableJitContext extends TableJitContext {
+    constructor(adapter: dataform.DbAdapter,
+        data: { [k: string]: any } | undefined,
+        target: dataform.ITarget,
+        dependencies: dataform.ITarget[],
+        private readonly isIncrementalContext: boolean,
+    ) {
+        super(adapter, data, target, dependencies);
+    }
+
+    public incremental(): boolean {
+        return this.isIncrementalContext;
+    }
+}

--- a/core/jit_context_test.ts
+++ b/core/jit_context_test.ts
@@ -1,0 +1,104 @@
+import { expect } from "chai";
+
+import { IncrementalTableJitContext, SqlActionJitContext, TableJitContext } from "df/core/jit_context";
+import { dataform } from "df/protos/ts";
+import { suite, test } from "df/testing";
+
+suite("jit_context", () => {
+  suite("SqlActionJitContext", () => {
+    const adapter = {} as dataform.DbAdapter;
+    const target = dataform.Target.create({
+      database: "db",
+      schema: "schema",
+      name: "name"
+    });
+    const dependency = dataform.Target.create({
+      database: "db",
+      schema: "schema",
+      name: "dep"
+    });
+
+    test("resolve by name only", () => {
+      const context = new SqlActionJitContext(adapter, {}, target, [dependency]);
+      expect(context.resolve("dep")).to.equal("`db.schema.dep`");
+    });
+
+    test("resolve by schema and name", () => {
+      const context = new SqlActionJitContext(adapter, {}, target, [dependency]);
+      expect(context.resolve(["schema", "dep"])).to.equal("`db.schema.dep`");
+    });
+
+    test("resolve by database, schema and name", () => {
+      const context = new SqlActionJitContext(adapter, {}, target, [dependency]);
+      expect(context.resolve(["db", "schema", "dep"])).to.equal("`db.schema.dep`");
+    });
+
+    test("resolve throws for undeclared dependency", () => {
+      const context = new SqlActionJitContext(adapter, {}, target, []);
+      expect(() => context.resolve("dep")).to.throw("Undeclared dependency referenced: dep");
+    });
+
+    test("ref", () => {
+      const context = new SqlActionJitContext(adapter, {}, target, [dependency]);
+      expect(context.ref("dep")).to.equal("`db.schema.dep`");
+    });
+
+    test("self", () => {
+      const context = new SqlActionJitContext(adapter, {}, target, []);
+      expect(context.self()).to.equal("`db.schema.name`");
+    });
+
+    test("name", () => {
+      const context = new SqlActionJitContext(adapter, {}, target, []);
+      expect(context.name()).to.equal("name");
+    });
+
+    test("schema", () => {
+      const context = new SqlActionJitContext(adapter, {}, target, []);
+      expect(context.schema()).to.equal("schema");
+    });
+
+    test("database", () => {
+      const context = new SqlActionJitContext(adapter, {}, target, []);
+      expect(context.database()).to.equal("db");
+    });
+  });
+
+  suite("TableJitContext", () => {
+    const adapter = {} as dataform.DbAdapter;
+    const target = dataform.Target.create({
+      database: "db",
+      schema: "schema",
+      name: "name"
+    });
+
+    test("when", () => {
+      const context = new TableJitContext(adapter, {}, target, []);
+      expect(context.when(true, "true", "false")).to.equal("true");
+      expect(context.when(false, "true", "false")).to.equal("false");
+      expect(context.when(false, "true")).to.equal("");
+    });
+
+    test("incremental", () => {
+      const context = new TableJitContext(adapter, {}, target, []);
+      expect(context.incremental()).to.equal(false);
+    });
+  });
+
+  suite("IncrementalTableJitContext", () => {
+    const adapter = {} as dataform.DbAdapter;
+    const target = dataform.Target.create({
+      database: "db",
+      schema: "schema",
+      name: "name"
+    });
+
+    test("incremental", () => {
+      let context = new IncrementalTableJitContext(adapter, {}, target, [], true);
+      expect(context.incremental()).to.equal(true);
+
+      context = new IncrementalTableJitContext(adapter, {}, target, [], false);
+      expect(context.incremental()).to.equal(false);
+    });
+  });
+});


### PR DESCRIPTION
Implementation of context objects accessible at JiT compilation stage for supported action types.

They expose access to adapter/data and context methods, equivalent to AoT context, but with a more restrictive selection of resolvable targets.
