### PR TITLE
Allow extensions to populate project config without workflow_settings.

### DIFF
--- a/core/main.ts
+++ b/core/main.ts
@@ -38,8 +38,10 @@ export function main(coreExecutionRequest: Uint8Array | string): Uint8Array | st
   }
   const compileRequest = request.compile;
 
+  // Allow extensions to populate settings by themselves.
+  const failIfMissing = !compileRequest?.compileConfig?.extension?.compilationMode;
   // Read the workflow settings from the root of the project.
-  let projectConfig = readWorkflowSettings();
+  let projectConfig = readWorkflowSettings(failIfMissing);
 
   // Merge in project config overrides.
   const projectConfigOverride = compileRequest.compileConfig.projectConfigOverride ?? {};

--- a/core/main_test.ts
+++ b/core/main_test.ts
@@ -1963,6 +1963,44 @@ publish("name", {type: "${fromType}", schema: "schemaOverride"}).type("${toType}
       expect(result.compile.compiledGraph.targets?.map(t => t.name)).deep.equals(["sample-action"]);
     });
 
+    test("works in application mode without workflow settings", () => {
+      const projectDir = tmpDirFixture.createNewTmpDir();
+      fs.mkdirSync(path.join(projectDir, "definitions"));
+      fs.writeFileSync(path.join(projectDir, "definitions/e.sqlx"), `config {type: "view"}`);
+      fs.writeFileSync(path.join(projectDir, "definitions/file.sqlx"), "${resolve('e')}");
+
+      const request = coreExecutionRequestFromPath(projectDir);
+      request.compile.compileConfig.extension = {
+        name: "@dataform/sample-extension",
+        compilationMode: dataform.ExtensionCompilationMode.APPLICATION_CODE
+      };
+
+      const result = runMainInVm(request);
+
+      expect(result.compile.compiledGraph.graphErrors.compilationErrors).deep.equals([]);
+      expect(result.compile.compiledGraph.targets?.map(t => t.name)).deep.equals([
+        "sample-action"
+      ]);
+    });
+
+    test("works in prologue mode without workflow settings", () => {
+      const projectDir = tmpDirFixture.createNewTmpDir();
+      fs.mkdirSync(path.join(projectDir, "definitions"));
+      fs.writeFileSync(path.join(projectDir, "definitions/e.sqlx"), `config {type: "view"}`);
+      fs.writeFileSync(path.join(projectDir, "definitions/file.sqlx"), "${resolve('e')}");
+
+      const request = coreExecutionRequestFromPath(projectDir);
+      request.compile.compileConfig.extension = {
+        name: "@dataform/sample-extension",
+        compilationMode: dataform.ExtensionCompilationMode.PROLOGUE,
+      };
+
+      const result = runMainInVm(request);
+
+      expect(result.compile.compiledGraph.graphErrors.compilationErrors).deep.equals([]);
+      expect(result.compile.compiledGraph.targets?.map(t => t.name)).deep.equals(["sample-action", "e", "file"]);
+    });
+
     test("catches extension import exceptions", () => {
       const projectDir = setUpProjectWithExtension();
       const request = coreExecutionRequestFromPath(projectDir);

--- a/core/workflow_settings.ts
+++ b/core/workflow_settings.ts
@@ -9,7 +9,7 @@ declare var __webpack_require__: any;
 declare var __non_webpack_require__: any;
 const nativeRequire = typeof __webpack_require__ === "function" ? __non_webpack_require__ : require;
 
-export function readWorkflowSettings(): dataform.ProjectConfig {
+export function readWorkflowSettings(failIfMissing: boolean = true): dataform.ProjectConfig {
   const workflowSettingsYaml = maybeRequire("workflow_settings.yaml");
   // `dataform.json` is deprecated; new versions of Dataform Core prefer `workflow_settings.yaml`.
   const dataformJson = maybeRequire("dataform.json");
@@ -42,7 +42,10 @@ export function readWorkflowSettings(): dataform.ProjectConfig {
     }
   }
 
-  throw Error("Failed to resolve workflow_settings.yaml");
+  if (failIfMissing) {
+    throw Error("Failed to resolve workflow_settings.yaml");
+  }
+  return dataform.ProjectConfig.create();
 }
 
 function verifyWorkflowSettingsAsJson(workflowSettingsAsJson: object): dataform.WorkflowSettings {


### PR DESCRIPTION
Some extensions might use different configuration files, this will allow them to proceed when workflow_settings.yaml is missing.