### PR TITLE
JiT context - decode data

### DIFF
--- a/core/jit_context.ts
+++ b/core/jit_context.ts
@@ -1,6 +1,6 @@
 import { IActionContext, ITableContext, JitContext, Resolvable } from "df/core/contextables";
 import { ambiguousActionNameMsg, resolvableAsTarget, ResolvableMap, stringifyResolvable, toResolvable } from "df/core/utils";
-import { dataform } from "df/protos/ts";
+import { dataform, google } from "df/protos/ts";
 
 function canonicalTargetValue(target: dataform.ITarget): string {
     return `${target.database}.${target.schema}.${target.name}`;
@@ -24,7 +24,7 @@ export class SqlActionJitContext implements JitContext<IActionContext> {
             actionTarget: dep,
             value: canonicalTargetValue(dep)
         })));
-        this.data = request.jitData;
+        this.data = jitDataToJsValue(request.jitData);
     }
 
     public self(): string {
@@ -101,4 +101,48 @@ export class IncrementalTableJitContext extends TableJitContext {
     public incremental(): boolean {
         return this.isIncrementalContext;
     }
+}
+
+function jitDataToJsValue(value?: google.protobuf.IStruct): { [key: string]: {} } | undefined {
+    if (value === undefined || value === null) {
+        return
+    }
+    function protobufValueToJs(val: google.protobuf.IValue): {} {
+        if (val.nullValue != null) {
+            return null;
+        }
+        if (val.stringValue != null) {
+            return val.stringValue;
+        }
+        if (val.numberValue != null) {
+            return val.numberValue;
+        }
+        if (val.boolValue != null) {
+            return val.boolValue;
+        }
+        if (val.listValue != null) {
+            return (val.listValue.values || []).map(protobufValueToJs);
+        }
+        if (val.structValue != null) {
+            return Object.fromEntries(
+                Object.entries(val.structValue.fields || {}).map(
+                    ([fieldKey, fieldValue]) => ([
+                        fieldKey,
+                        protobufValueToJs(fieldValue)
+                    ])
+                )
+            );
+        }
+
+        throw new Error(`Unsupported protobuf value: ${JSON.stringify(val)}`);
+    }
+
+    return Object.fromEntries(
+        Object.entries(value.fields || {}).map(
+            ([fieldKey, fieldValue]) => [
+                fieldKey,
+                protobufValueToJs(fieldValue)
+            ]
+        )
+    );
 }

--- a/core/jit_context_test.ts
+++ b/core/jit_context_test.ts
@@ -1,12 +1,47 @@
 import { expect } from "chai";
 
 import { IncrementalTableJitContext, SqlActionJitContext, TableJitContext } from "df/core/jit_context";
-import { dataform } from "df/protos/ts";
+import { dataform, google } from "df/protos/ts";
 import { suite, test } from "df/testing";
 
 suite("jit_context", () => {
   suite("SqlActionJitContext", () => {
     const adapter = {} as dataform.DbAdapter;
+    const jitData = google.protobuf.Struct.create({
+      fields: {
+        key: google.protobuf.Value.create({
+          structValue: google.protobuf.Struct.create({
+            fields: {
+              number: google.protobuf.Value.create({ numberValue: 123 }),
+              string: google.protobuf.Value.create({ stringValue: "value" }),
+              boolean: google.protobuf.Value.create({ boolValue: true }),
+              struct: google.protobuf.Value.create({
+                structValue: google.protobuf.Struct.create({
+                  fields: {
+                    nestedKey: google.protobuf.Value.create({ stringValue: "nestedValue" })
+                  }
+                })
+              }),
+              list: google.protobuf.Value.create({
+                listValue: google.protobuf.ListValue.create({
+                  values: [
+                    google.protobuf.Value.create({ stringValue: "a" }),
+                    google.protobuf.Value.create({ stringValue: "b" }),
+                    google.protobuf.Value.create({ stringValue: "c" })
+                  ]
+                })
+              }),
+              null: google.protobuf.Value.create({
+                nullValue: google.protobuf.NullValue.NULL_VALUE
+              }),
+              undef: google.protobuf.Value.create({
+                nullValue: google.protobuf.NullValue.NULL_VALUE
+              }),
+            }
+          })
+        })
+      }
+    });
     const request = dataform.JitCompilationRequest.create({
       target: dataform.Target.create({
         database: "db",
@@ -21,6 +56,7 @@ suite("jit_context", () => {
         })
       ],
       filePaths: [],
+      jitData,
     });
     const withoutDependenciesRequest = dataform.JitCompilationRequest.create({
       target: dataform.Target.create({
@@ -75,6 +111,27 @@ suite("jit_context", () => {
     test("database", () => {
       const context = new SqlActionJitContext(adapter, withoutDependenciesRequest);
       expect(context.database()).to.equal("db");
+    });
+
+    test("data", () => {
+      const context = new SqlActionJitContext(adapter, request);
+      expect(context.data).to.deep.equal({
+        "key": {
+          "number": 123,
+          "string": "value",
+          "boolean": true,
+          "struct": {
+            "nestedKey": "nestedValue"
+          },
+          "list": [
+            "a",
+            "b",
+            "c"
+          ],
+          "null": null,
+          "undef": null,
+        }
+      });
     });
   });
 


### PR DESCRIPTION
Instead of exposing a proto struct, returning (mostly) the same object that got passed in the original key at definition.