### PR TITLE
fix: update internal import linter rule and reorganize imports

### DIFF
--- a/cli/api/commands/compile.ts
+++ b/cli/api/commands/compile.ts
@@ -1,9 +1,9 @@
+import { ChildProcess, exec, fork } from "child_process";
 import * as fs from "fs-extra";
 import * as path from "path";
 import * as tmp from "tmp";
 import { promisify } from "util";
 
-import { ChildProcess, exec, fork } from "child_process";
 import { MISSING_CORE_VERSION_ERROR } from "df/cli/api/commands/install";
 import { readDataformCoreVersionFromWorkflowSettings } from "df/cli/api/utils";
 import { coerceAsError } from "df/common/errors/errors";

--- a/cli/api/commands/install.ts
+++ b/cli/api/commands/install.ts
@@ -1,8 +1,8 @@
+import * as childProcess from "child_process";
 import * as fs from "fs";
 import * as path from "path";
 import { promisify } from "util";
 
-import * as childProcess from "child_process";
 import { readDataformCoreVersionFromWorkflowSettings } from "df/cli/api/utils";
 
 export const MISSING_CORE_VERSION_ERROR =

--- a/cli/api/dbadapters/bigquery.ts
+++ b/cli/api/dbadapters/bigquery.ts
@@ -1,7 +1,7 @@
+import { BigQuery, GetTablesResponse, TableField, TableMetadata } from "@google-cloud/bigquery";
 import Long from "long";
 import { PromisePoolExecutor } from "promise-pool-executor";
 
-import { BigQuery, GetTablesResponse, TableField, TableMetadata } from "@google-cloud/bigquery";
 import { collectEvaluationQueries, QueryOrAction } from "df/cli/api/dbadapters/execution_sql";
 import { IBigQueryError, IDbAdapter, IDbClient, IExecutionResult, OnCancel } from "df/cli/api/dbadapters/index";
 import { parseBigqueryEvalError } from "df/cli/api/utils/error_parsing";

--- a/cli/console.ts
+++ b/cli/console.ts
@@ -1,9 +1,10 @@
+import * as readlineSync from "readline-sync";
+
 import { IInitResult } from "df/cli/api/commands/init";
 import { prettyJsonStringify } from "df/cli/api/utils";
 import { formatBytesInHumanReadableFormat, formatExecutionSuffix } from "df/cli/util";
 import { setOrValidateTableEnumType, tableTypeEnumToString } from "df/core/utils";
 import { dataform } from "df/protos/ts";
-import * as readlineSync from "readline-sync";
 
 // Support disabling colors in CLI output by using informal standard from https://no-color.org/
 // NO_COLOR=1, NO_COLOR=true, NO_COLOR=yes

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -1,9 +1,10 @@
+import * as chokidar from "chokidar";
 import * as fs from "fs";
 import * as glob from "glob";
+import parseDuration from "parse-duration";
 import * as path from "path";
 import yargs from "yargs";
 
-import * as chokidar from "chokidar";
 import { build, compile, credentials, init, install, run, test } from "df/cli/api";
 import { CREDENTIALS_FILENAME } from "df/cli/api/commands/credentials";
 import { BigQueryDbAdapter } from "df/cli/api/dbadapters/bigquery";
@@ -32,7 +33,6 @@ import { createYargsCli, INamedOption } from "df/cli/yargswrapper";
 import { targetAsReadableString } from "df/core/targets";
 import { dataform } from "df/protos/ts";
 import { formatFile } from "df/sqlx/format";
-import parseDuration from "parse-duration";
 
 const RECOMPILE_DELAY = 500;
 

--- a/cli/index_compile_test.ts
+++ b/cli/index_compile_test.ts
@@ -1,9 +1,9 @@
 import { expect } from "chai";
+import { execFile } from "child_process";
 import * as fs from "fs-extra";
 import { dump as dumpYaml, load as loadYaml } from "js-yaml";
 import * as path from "path";
 
-import { execFile } from "child_process";
 import { cliEntryPointPath, DEFAULT_DATABASE, DEFAULT_LOCATION } from "df/cli/index_test_base";
 import { version } from "df/core/version";
 import { dataform } from "df/protos/ts";

--- a/cli/index_help_test.ts
+++ b/cli/index_help_test.ts
@@ -1,6 +1,6 @@
 import { expect } from "chai";
-
 import { execFile } from "child_process";
+
 import { cliEntryPointPath } from "df/cli/index_test_base";
 import { getProcessResult, nodePath, suite, test } from "df/testing";
 

--- a/cli/index_init_test.ts
+++ b/cli/index_init_test.ts
@@ -1,9 +1,9 @@
 import { assert, expect } from "chai";
+import { execFile } from "child_process";
 import * as fs from "fs-extra";
 import { load as loadYaml } from "js-yaml";
 import * as path from "path";
 
-import { execFile } from "child_process";
 import { cliEntryPointPath } from "df/cli/index_test_base";
 import {
   ICEBERG_BUCKET_NAME_HINT,

--- a/cli/index_project_test.ts
+++ b/cli/index_project_test.ts
@@ -1,9 +1,9 @@
 import { expect } from "chai";
+import { execFile } from "child_process";
 import * as fs from "fs-extra";
 import { dump as dumpYaml, load as loadYaml } from "js-yaml";
 import * as path from "path";
 
-import { execFile } from "child_process";
 import { cliEntryPointPath, DEFAULT_DATABASE, DEFAULT_LOCATION } from "df/cli/index_test_base";
 import { version } from "df/core/version";
 import { dataform } from "df/protos/ts";

--- a/cli/index_run_e2e_test.ts
+++ b/cli/index_run_e2e_test.ts
@@ -1,9 +1,9 @@
 import { expect } from "chai";
+import { execFile } from "child_process";
 import * as fs from "fs-extra";
 import { dump as dumpYaml, load as loadYaml } from "js-yaml";
 import * as path from "path";
 
-import { execFile } from "child_process";
 import {
   cliEntryPointPath,
   CREDENTIALS_PATH,

--- a/cli/util.ts
+++ b/cli/util.ts
@@ -1,5 +1,6 @@
 import * as fs from "fs";
 import * as path from "path";
+import untildify from "untildify";
 
 import {
   interactiveQuestion,
@@ -9,7 +10,6 @@ import {
 } from "df/cli/console";
 import {validateConnectionFormat} from "df/core/utils"
 import { dataform } from "df/protos/ts";
-import untildify from "untildify";
 
 export function actuallyResolve(...filePaths: string[]) {
   return path.resolve(...filePaths.map(filePath => untildify(filePath)));

--- a/examples/examples_test.ts
+++ b/examples/examples_test.ts
@@ -1,7 +1,7 @@
 import { expect } from "chai";
+import { execFile } from "child_process";
 import * as fs from "fs-extra";
 
-import { execFile } from "child_process";
 import { verifyObjectMatchesProto } from "df/common/protos";
 import { dataform } from "df/protos/ts";
 import { getProcessResult, nodePath, suite, test } from "df/testing";

--- a/sqlx/format.ts
+++ b/sqlx/format.ts
@@ -1,11 +1,11 @@
 import * as fs from "fs";
 import { GoogleSqlDefinition, QueryFormatter } from "google-sql-syntax-ts";
 import * as jsBeautify from "js-beautify";
+import { typeid } from "typeid-js";
 import { promisify } from "util";
 
 import { ErrorWithCause } from "df/common/errors/errors";
 import { SyntaxTreeNode, SyntaxTreeNodeType } from "df/sqlx/lexer";
-import { typeid } from "typeid-js";
 
 const JS_BEAUTIFY_OPTIONS = {
   indent_size: 2,

--- a/testing/child_process.ts
+++ b/testing/child_process.ts
@@ -1,7 +1,7 @@
+import { ChildProcess, spawn } from "child_process";
 import * as fs from "fs";
 import * as path from "path";
 
-import { ChildProcess, spawn } from "child_process";
 import { IHookHandler } from "df/testing";
 
 export class ChildProcessForBazelTestEnvironment {

--- a/testing/index.ts
+++ b/testing/index.ts
@@ -1,6 +1,5 @@
-import * as os from "os";
-
 import { ChildProcess } from "child_process";
+import * as os from "os";
 
 export * from "df/testing/hook";
 export * from "df/testing/suite";

--- a/testing/runner.ts
+++ b/testing/runner.ts
@@ -1,9 +1,9 @@
 import chalk from "chalk";
+import * as Diff from "diff";
 import DeterministicStringify from "json-stable-stringify";
 import { promisify } from "util";
 
 import { Hook, Suite } from "df/testing";
-import * as Diff from "diff";
 
 export interface IRunResult {
   path: string[];

--- a/tslint.json
+++ b/tslint.json
@@ -20,7 +20,7 @@
         "groups": [
           {
             "name": "internal",
-            "match": "df*/*",
+            "match": "^df/*",
             "order": 2
           },
           {

--- a/vscode/server.ts
+++ b/vscode/server.ts
@@ -1,5 +1,4 @@
 import { ChildProcess, spawn } from "child_process";
-import { dataform } from "df/protos/ts";
 import {
   createConnection,
   DidChangeConfigurationNotification,
@@ -10,6 +9,8 @@ import {
   TextDocumentSyncKind
 } from "vscode-languageserver";
 import { TextDocument } from "vscode-languageserver-textdocument";
+
+import { dataform } from "df/protos/ts";
 
 const connection = createConnection(ProposedFeatures.all);
 const documents: TextDocuments<TextDocument> = new TextDocuments(TextDocument);


### PR DESCRIPTION
This PR addresses a misclassification issue in the ordered-imports linter rule. The previous regex df*/* was too shallow, causing deeply nested internal imports (starting with df/) to be treated as external modules.