### PR TITLE
adding dot option to compile command

### DIFF
--- a/cli/console.ts
+++ b/cli/console.ts
@@ -187,13 +187,13 @@ export enum compiledGraphOutputType {
   Summary = "summary"
 }
 
-export function printCompiledGraph(graph: dataform.ICompiledGraph, output: compiledGraphOutputType, quietCompilation: boolean) {
+export function printCompiledGraph(graph: dataform.ICompiledGraph, outputType: compiledGraphOutputType, quietCompilation: boolean) {
   
   const interactive = isInteractive();
   
-  if (output === compiledGraphOutputType.Json) {
+  if (outputType === compiledGraphOutputType.Json) {
     writeStdOut(prettyJsonStringify(graph));
-  } else if (output === compiledGraphOutputType.Dot) {
+  } else if (outputType === compiledGraphOutputType.Dot) {
     writeStdOut(dotRepresentation(graph, interactive));
   } else {
     const actionCount =

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -10,6 +10,7 @@ import { CREDENTIALS_FILENAME } from "df/cli/api/commands/credentials";
 import { BigQueryDbAdapter } from "df/cli/api/dbadapters/bigquery";
 import { prettyJsonStringify } from "df/cli/api/utils";
 import {
+  compiledGraphOutputType,
   print,
   printCompiledGraph,
   printCompiledGraphErrors,
@@ -20,8 +21,7 @@ import {
   printInitCredsResult,
   printInitResult,
   printSuccess,
-  printTestResult,
-  compiledGraphOutputType
+  printTestResult
 } from "df/cli/console";
 import { getBigQueryCredentials } from "df/cli/credentials";
 import {
@@ -420,7 +420,7 @@ export function runCli() {
               outputType = compiledGraphOutputType.Dot;
             } 
             
-            if (outputType == compiledGraphOutputType.Summary) {
+            if (outputType === compiledGraphOutputType.Summary) {
               print("Compiling...\n");
             }
             const compiledGraph = await compile({
@@ -429,7 +429,7 @@ export function runCli() {
               timeoutMillis: argv[timeoutOption.name] || undefined,
               verbose: argv[verboseOptionName] || false
             });
-            printCompiledGraph(compiledGraph, outputType, argv[quietCompileOption.name], );
+            printCompiledGraph(compiledGraph, outputType, argv[quietCompileOption.name]);
             if (compiledGraphHasErrors(compiledGraph)) {
               print("");
               printCompiledGraphErrors(compiledGraph.graphErrors, argv[quietCompileOption.name]);


### PR DESCRIPTION
This update adds a dot option to the compile command. It formats the json as a dot string and writes it out. table types are added to the label as name [tableType]. fixes #1232 