### PR TITLE
fix: error messages when compiling tests for incremental tables

### DIFF
--- a/core/actions/test.ts
+++ b/core/actions/test.ts
@@ -166,6 +166,7 @@ export class Test extends ActionBuilder<dataform.Test> {
         new Error("Tests must operate upon a specified dataset."),
         this.proto.fileName
       );
+      return this.proto;
     } else {
       const allResolved = this.session.indexedActions.find(resolvableAsTarget(this.datasetToTest));
       if (allResolved.length > 1) {
@@ -173,18 +174,21 @@ export class Test extends ActionBuilder<dataform.Test> {
           new Error(ambiguousActionNameMsg(this.datasetToTest, allResolved)),
           this.proto.fileName
         );
+        return this.proto;
       }
       const dataset = allResolved.length > 0 ? allResolved[0] : undefined;
-      if (!(dataset && (dataset instanceof Table || dataset instanceof View))) {
+      if (!(dataset && (dataset instanceof Table || dataset instanceof View || dataset instanceof IncrementalTable))) {
         this.session.compileError(
           new Error(`Dataset ${stringifyResolvable(this.datasetToTest)} could not be found.`),
           this.proto.fileName
         );
+        return this.proto;
       } else if (dataset instanceof IncrementalTable) {
         this.session.compileError(
           new Error("Running tests on incremental datasets is not yet supported."),
           this.proto.fileName
         );
+        return this.proto;
       } else {
         const refReplacingContext = new RefReplacingContext(testContext);
         this.proto.testQuery = refReplacingContext.apply(dataset.contextableQuery);

--- a/core/actions/test_test.ts
+++ b/core/actions/test_test.ts
@@ -268,4 +268,35 @@ SELECT 1 AS a, 2 AS b`);
         `Expected query is empty.`
       );
     });
+
+    test(`test with incremental table`, () => { 
+      const projectDir = tmpDirFixture.createNewTmpDir();
+      const workflowSettingsPath = path.join(projectDir, "workflow_settings.yaml");
+      const definitionsDir = path.join(projectDir, "definitions");
+      const actionSqlxPath = path.join(definitionsDir, "action.sqlx");
+      const actionTestSqlxPath = path.join(definitionsDir, "action_test.sqlx");
+
+      fs.writeFileSync(workflowSettingsPath, VALID_WORKFLOW_SETTINGS_YAML);
+      fs.mkdirSync(definitionsDir);
+
+      fs.writeFileSync(actionSqlxPath, `
+config {
+  type: "incremental",
+}
+SELECT 1 AS a
+    `);
+      fs.writeFileSync(actionTestSqlxPath, `
+config {
+  type: "test",
+  dataset: "action"
+}
+SELECT 1 AS a`);
+
+      const result = runMainInVm(coreExecutionRequestFromPath(projectDir));
+
+      expect(result.compile.compiledGraph.graphErrors.compilationErrors.length).equals(1);
+      expect(result.compile.compiledGraph.graphErrors.compilationErrors[0].message).contains(
+        `Running tests on incremental datasets is not yet supported.`
+      );
+    });
 });


### PR DESCRIPTION
 This PR:
 
 1. Solves: https://github.com/dataform-co/dataform/issues/2117
 2. Avoid "Test query is empty." error for the same file by avoiding this check and returning `this.proto` early.
 
     https://github.com/dataform-co/dataform/blob/412d523108dbe411461c7d3c2e1b51484ede7e72/core/actions/test.ts#L196
   3. Added unit test for expected behavior 
   
Tests

- [x] bazel test //core:actions/test_test passes
- [x] bazel test //core/... passes 
- [x] Manually tested by building the core package and using it in a local repository. See screenshot below

<img width="800" height="400" alt="CleanShot 2026-03-19 at 15 44 47@2x" src="https://github.com/user-attachments/assets/20fe9c05-e3cf-4d31-a7d2-ad43f456343b" />



