### PR TITLE
Extend list of supported BQ types

### DIFF
--- a/cli/api/dbadapters/bigquery.ts
+++ b/cli/api/dbadapters/bigquery.ts
@@ -483,6 +483,12 @@ function convertFieldType(type: string) {
       return dataform.Field.Primitive.BYTES;
     case "GEOGRAPHY":
       return dataform.Field.Primitive.GEOGRAPHY;
+    case "BIGNUMERIC":
+      return dataform.Field.Primitive.BIGNUMERIC;
+    case "JSON":
+      return dataform.Field.Primitive.JSON;
+    case "INTERVAL":
+      return dataform.Field.Primitive.INTERVAL;
     default:
       return dataform.Field.Primitive.UNKNOWN;
   }

--- a/protos/db_adapter.proto
+++ b/protos/db_adapter.proto
@@ -21,6 +21,9 @@ message Field {
     BYTES = 10;
     ANY = 11;
     GEOGRAPHY = 12;
+    BIGNUMERIC = 13;
+    JSON = 14;
+    INTERVAL = 15;
   }
 
   enum Flag {


### PR DESCRIPTION
Adding more types supported by BigQuery Data types: https://docs.cloud.google.com/bigquery/docs/reference/standard-sql/data-types.