### PR TITLE
feat: add getContents() for reading external markdown files into table descriptions

### DIFF
--- a/cli/vm/compile.ts
+++ b/cli/vm/compile.ts
@@ -48,7 +48,7 @@ export function compile(compileConfig: dataform.ICompileConfig) {
       resolve: (moduleName, parentDirName) =>
         path.join(parentDirName, path.relative(parentDirName, compileConfig.projectDir), moduleName)
     },
-    sourceExtensions: ["js", "sql", "sqlx", "yaml", "yml"],
+    sourceExtensions: ["js", "sql", "sqlx", "yaml", "yml","md"],
     compiler
   });
 

--- a/core/compilers.ts
+++ b/core/compilers.ts
@@ -56,6 +56,13 @@ export function compile(code: string, path: string): string {
       .replace(/\${/g, "\\${");
     return `exports.query = \`${escapedCode}\`;`;
   }
+  if (Path.fileExtension(path) === "md") {
+    const contents = code
+      .replace(/\\/g, "\\\\")
+      .replace(/`/g, "\\`")
+      .replace(/\${/g, "\\${");
+    return `exports.contents = \`${contents}\`;`;
+  }
   return code;
 }
 

--- a/core/compilers.ts
+++ b/core/compilers.ts
@@ -58,6 +58,7 @@ export function compile(code: string, path: string): string {
   }
   if (Path.fileExtension(path) === "md") {
     const contents = code
+      .replace(/\r\n/g, "\n")
       .replace(/\\/g, "\\\\")
       .replace(/`/g, "\\`")
       .replace(/\${/g, "\\${");

--- a/core/compilers_test.ts
+++ b/core/compilers_test.ts
@@ -92,5 +92,28 @@ suite("core/compilers", () => {
             const result = compile(code, path);
             expect(result).to.equal(code);
         });
+
+        test("compiles md to js contents export",() => {
+            const code = '# this table defines';
+            const path = "definitions/foo.md"
+            const result = compile(code, path);
+            expect(result).to.equal("export.contents = `# this table defines`;");
+
+        })
+
+        test("escapes backslashes in md", () => {
+            const code = "select ''";
+            const path = "definitions/foo.sql";
+            const result = compile(code, path);
+            expect(result).to.equal("exports.contents = `select ''`;");
+        });
+
+        test("escapes backticks in md", () => {
+            const code = "select `a` from `b`";
+            const path = "definitions/foo.sql";
+            const result = compile(code, path);
+            expect(result).to.equal("exports.contents = `select \\`a\\` from \\`b\\``;");
+        });
+
     });
 });

--- a/core/compilers_test.ts
+++ b/core/compilers_test.ts
@@ -95,22 +95,41 @@ suite("core/compilers", () => {
 
         test("compiles md to js contents export",() => {
             const code = '# this table defines';
-            const path = "definitions/foo.md"
+            const path = "definitions/foo.md";
             const result = compile(code, path);
-            expect(result).to.equal("export.contents = `# this table defines`;");
+            expect(result).to.equal("exports.contents = `# this table defines`;");
 
         })
 
         test("escapes backslashes in md", () => {
             const code = "select ''";
-            const path = "definitions/foo.sql";
+            const path = "definitions/foo.md";
             const result = compile(code, path);
             expect(result).to.equal("exports.contents = `select ''`;");
         });
-
+        test("escapes newlines in md", () => {
+            const code = `
+- item1
+- item2`;
+            const path = "definitions/foo.md";
+            const result = compile(code, path);
+            expect(result).to.equal("exports.contents = `\n- item1\n- item2`;");
+        });
+        test ("escapes template literals in md", () => {
+            const code = "select ${foo}";
+            const path = "definitions/foo.md";
+            const result = compile(code, path);
+            expect(result).to.equal("exports.contents = `select \\${foo}`;");
+        });
+        test("escapes backslashes and backticks in md", () => {
+            const code = "c = '\\'";
+            const path = "definitions/foo.md";
+            const result = compile(code, path);
+            expect(result).to.equal("exports.contents = `c = '\\\\'`;");
+        });
         test("escapes backticks in md", () => {
             const code = "select `a` from `b`";
-            const path = "definitions/foo.sql";
+            const path = "definitions/foo.md";
             const result = compile(code, path);
             expect(result).to.equal("exports.contents = `select \\`a\\` from \\`b\\``;");
         });

--- a/core/main.ts
+++ b/core/main.ts
@@ -232,7 +232,8 @@ function dataformCompile(compileRequest: dataform.ICompileExecutionRequest, sess
   globalAny.notebook = session.notebook.bind(session);
   globalAny.test = session.test.bind(session);
   globalAny.jitData = session.jitData.bind(session);
-
+  globalAny.getContents = session.getContents.bind(session);
+  
   loadActionConfigs(session, compileRequest.compileConfig.filePaths);
 
   // Require all "definitions" files (attaching them to the session).

--- a/core/main_test.ts
+++ b/core/main_test.ts
@@ -1757,6 +1757,30 @@ dataform.jitData("key", {test: () => {}});
           ).to.include("nonexistent.md");
 
       });
+
+      test("throws error for file outisde of rootDir", () => {
+          const projectDir = tmpDirFixture.createNewTmpDir();
+          fs.writeFileSync(
+            path.join(projectDir, "workflow_settings.yaml"),
+            VALID_WORKFLOW_SETTINGS_YAML
+          );
+          fs.mkdirSync(path.join(projectDir, "definitions"));
+          fs.writeFileSync(
+            path.join(projectDir, "definitions/table.sqlx"),
+            `config {
+            type: "table",
+            description: getContents('../../description.md'),
+          }
+            SELECT 1 AS test`
+          );
+
+          const result = runMainInVm(coreExecutionRequestFromPath(projectDir));
+
+          expect(
+            result.compile.compiledGraph.graphErrors.compilationErrors[0].message
+          ).to.include("outside the project directory");
+
+      });
     });
     suite("invalid options", () => {
       [

--- a/core/main_test.ts
+++ b/core/main_test.ts
@@ -1705,63 +1705,59 @@ dataform.jitData("key", {test: () => {}});
         ).to.deep.equal(["Unsupported context object: () => {}"]);
       });
     });
+    suite("markdown in description", () => {
+      test("markdown contents added to description in sqlx", () => {
+          const projectDir = tmpDirFixture.createNewTmpDir();
+          fs.writeFileSync(
+            path.join(projectDir, "workflow_settings.yaml"),
+            VALID_WORKFLOW_SETTINGS_YAML
+          );
+          fs.mkdirSync(path.join(projectDir, "definitions"));
+          fs.writeFileSync(
+            path.join(projectDir, "definitions/descriptions.md"),
+            `# This table contains data about`
+          );
+          fs.writeFileSync(
+            path.join(projectDir, "definitions/table.sqlx"),
+            `config {
+            type: "table",
+            description: getContents('./descriptions.md'),
+          }
+            SELECT 1 AS test`
+          );
 
-    suite("markedown descriptions", () => {
-      test("markedown contents added to descrtiption in js file", () => {
-        const projectDir = tmpDirFixture.createNewTmpDir();
-        fs.writeFileSync(
-          path.join(projectDir, "workflow_settings.yaml"),
-          VALID_WORKFLOW_SETTINGS_YAML
-        );
-        fs.mkdirSync(path.join(projectDir, "definitions"));
-        fs.writeFileSync(
-          path.join(projectDir, "definitions/description.md"),
-          `# This table contains data about`
-        );
-        fs.writeFileSync(
-          path.join(projectDir, "definitions/table.js"),
-          `publish("published-table", {
-          type: "table",
-          description: getContents('./descriptions.md')"],
-        }).query(ctx => "SELECT 1 AS test");`
-        );
+          const result = runMainInVm(coreExecutionRequestFromPath(projectDir));
 
-        const result = runMainInVm(coreExecutionRequestFromPath(projectDir));
+          expect(
+            result.compile.compiledGraph.tables[0].actionDescriptor.description
+          ).to.equal(`# This table contains data about`);
 
-        expect(
-          result.compile.compiledGraph.tables[0].actionDescriptor.description
-        ).to.equal([`# This table contains data about`]);
+      });
 
+       test("throws error for invalid missing markedown", () => {
+          const projectDir = tmpDirFixture.createNewTmpDir();
+          fs.writeFileSync(
+            path.join(projectDir, "workflow_settings.yaml"),
+            VALID_WORKFLOW_SETTINGS_YAML
+          );
+          fs.mkdirSync(path.join(projectDir, "definitions"));
+          fs.writeFileSync(
+            path.join(projectDir, "definitions/table.sqlx"),
+            `config {
+            type: "table",
+            description: getContents('./nonexistent.md'),
+          }
+            SELECT 1 AS test`
+          );
+
+          const result = runMainInVm(coreExecutionRequestFromPath(projectDir));
+
+          expect(
+            result.compile.compiledGraph.graphErrors.compilationErrors[0].message
+          ).to.include("nonexistent.md");
+
+      });
     });
-
-    test("markedown contents added to descrtiption in sqlx", () => {
-        const projectDir = tmpDirFixture.createNewTmpDir();
-        fs.writeFileSync(
-          path.join(projectDir, "workflow_settings.yaml"),
-          VALID_WORKFLOW_SETTINGS_YAML
-        );
-        fs.mkdirSync(path.join(projectDir, "definitions"));
-        fs.writeFileSync(
-          path.join(projectDir, "definitions/description.md"),
-          `# This table contains data about`
-        );
-        fs.writeFileSync(
-          path.join(projectDir, "definitions/table.sqlx"),
-          `config {
-          type: "table",
-          description: getContents('./descriptions.md')"],
-        }
-          SELECT 1 AS test;`
-        );
-
-        const result = runMainInVm(coreExecutionRequestFromPath(projectDir));
-
-        expect(
-          result.compile.compiledGraph.tables[0].actionDescriptor.description
-        ).to.equal([`# This table contains data about`]);
-
-    });
-  })
     suite("invalid options", () => {
       [
         {

--- a/core/main_test.ts
+++ b/core/main_test.ts
@@ -1706,6 +1706,62 @@ dataform.jitData("key", {test: () => {}});
       });
     });
 
+    suite("markedown descriptions", () => {
+      test("markedown contents added to descrtiption in js file", () => {
+        const projectDir = tmpDirFixture.createNewTmpDir();
+        fs.writeFileSync(
+          path.join(projectDir, "workflow_settings.yaml"),
+          VALID_WORKFLOW_SETTINGS_YAML
+        );
+        fs.mkdirSync(path.join(projectDir, "definitions"));
+        fs.writeFileSync(
+          path.join(projectDir, "definitions/description.md"),
+          `# This table contains data about`
+        );
+        fs.writeFileSync(
+          path.join(projectDir, "definitions/table.js"),
+          `publish("published-table", {
+          type: "table",
+          description: getContents('./descriptions.md')"],
+        }).query(ctx => "SELECT 1 AS test");`
+        );
+
+        const result = runMainInVm(coreExecutionRequestFromPath(projectDir));
+
+        expect(
+          result.compile.compiledGraph.tables[0].actionDescriptor.description
+        ).to.equal([`# This table contains data about`]);
+
+    });
+
+    test("markedown contents added to descrtiption in sqlx", () => {
+        const projectDir = tmpDirFixture.createNewTmpDir();
+        fs.writeFileSync(
+          path.join(projectDir, "workflow_settings.yaml"),
+          VALID_WORKFLOW_SETTINGS_YAML
+        );
+        fs.mkdirSync(path.join(projectDir, "definitions"));
+        fs.writeFileSync(
+          path.join(projectDir, "definitions/description.md"),
+          `# This table contains data about`
+        );
+        fs.writeFileSync(
+          path.join(projectDir, "definitions/table.sqlx"),
+          `config {
+          type: "table",
+          description: getContents('./descriptions.md')"],
+        }
+          SELECT 1 AS test;`
+        );
+
+        const result = runMainInVm(coreExecutionRequestFromPath(projectDir));
+
+        expect(
+          result.compile.compiledGraph.tables[0].actionDescriptor.description
+        ).to.equal([`# This table contains data about`]);
+
+    });
+  })
     suite("invalid options", () => {
       [
         {

--- a/core/session.ts
+++ b/core/session.ts
@@ -22,7 +22,6 @@ import { targetAsReadableString, targetStringifier } from "df/core/targets";
 import * as utils from "df/core/utils";
 import { ResolvableMap, toResolvable } from "df/core/utils";
 import { version as dataformCoreVersion } from "df/core/version";
-import { separator } from "df/core/path";
 import { dataform, google } from "df/protos/ts";
 
 
@@ -98,8 +97,9 @@ export class Session {
     const callerDir = Path.dirName(callerFile);
     const resolvedPath = Path.normalize(Path.join(callerDir,filePath));
     const absolutePath = nodePath.join(this.rootDir, resolvedPath);
+    const root = this.rootDir.endsWith(Path.separator) ? this.rootDir : this.rootDir + Path.separator;
 
-    if (!absolutePath.startsWith(`${Path.normalize(this.rootDir) + separator}`)){
+    if (!absolutePath.startsWith(root)){
       throw new Error(`Cannot read "${filePath}": path resolves outside the project directory.`);
     }
 

--- a/core/session.ts
+++ b/core/session.ts
@@ -1,5 +1,5 @@
+import * as nodePath from "path";
 import { default as TarjanGraphConstructor, Graph as TarjanGraph } from "tarjan-graph";
-
 
 import { encode64, verifyObjectMatchesProto, VerifyProtoErrorBehaviour } from "df/common/protos";
 import { Action, ActionProto, ILegacyTableConfig, TableType } from "df/core/actions";
@@ -23,6 +23,7 @@ import * as utils from "df/core/utils";
 import { ResolvableMap, toResolvable } from "df/core/utils";
 import { version as dataformCoreVersion } from "df/core/version";
 import { dataform, google } from "df/protos/ts";
+
 
 const DEFAULT_CONFIG = {
   defaultSchema: "dataform",
@@ -96,14 +97,19 @@ export class Session {
     const callerDir = Path.dirName(callerFile);
 
     const resolvedPath = Path.normalize(Path.join(callerDir,filePath));
+    const absolutePath = nodePath.isAbsolute(resolvedPath) ? resolvedPath : nodePath.join(this.rootDir, resolvedPath);
+    try {
+      const module = utils.nativeRequire(absolutePath);
+      if (!module || typeof module.contents !== "string") {
+        throw new Error(`Could not read markdown content from "${absolutePath}".`);
+      }
+    return module.contents;
 
-    const module = utils.nativeRequire(resolvedPath);
-    if (!module || typeof module.contents !== "string") {
-      throw new Error(`Could not read markdown content from "${resolvedPath}".`);
+    } catch (error) {
+      throw new Error(`Could not read markdown content from: ${absolutePath}`);
     }
-  return module.contents;
-
   }
+
   public sqlxAction(actionOptions: {
     // sqlxConfig has type any here because any object can be passed in from the compiler - the
     // structure of it is verified at later steps.

--- a/core/session.ts
+++ b/core/session.ts
@@ -98,9 +98,19 @@ export class Session {
     const resolvedPath = Path.normalize(Path.join(callerDir,filePath));
     const absolutePath = nodePath.join(this.rootDir, resolvedPath);
 
-    const module = utils.nativeRequire(absolutePath);
+    if (!absolutePath.startsWith(this.rootDir)){
+      throw new Error(`Cannot read "${filePath}": path resolves outside the project directory.`);
+    }
+
+    let module: any;
+    try {
+      module = utils.nativeRequire(absolutePath);
+    } catch {
+      throw new Error(`Cannot read "${filePath}": file not found.`);
+    }
+
     if (!module || typeof module.contents !== "string") {
-      throw new Error(`Could not read markdown content from "${absolutePath}".`);
+      throw new Error (`Cannot read "${filePath}": only .md files are supported.`)
     }
     return module.contents;
   }

--- a/core/session.ts
+++ b/core/session.ts
@@ -95,19 +95,14 @@ export class Session {
   public getContents(filePath: string): string {
     const callerFile = utils.getCallerFile(this.rootDir);
     const callerDir = Path.dirName(callerFile);
-
     const resolvedPath = Path.normalize(Path.join(callerDir,filePath));
-    const absolutePath = nodePath.isAbsolute(resolvedPath) ? resolvedPath : nodePath.join(this.rootDir, resolvedPath);
-    try {
-      const module = utils.nativeRequire(absolutePath);
-      if (!module || typeof module.contents !== "string") {
-        throw new Error(`Could not read markdown content from "${absolutePath}".`);
-      }
-    return module.contents;
+    const absolutePath = nodePath.join(this.rootDir, resolvedPath);
 
-    } catch (error) {
-      throw new Error(`Could not read markdown content from: ${absolutePath}`);
+    const module = utils.nativeRequire(absolutePath);
+    if (!module || typeof module.contents !== "string") {
+      throw new Error(`Could not read markdown content from "${absolutePath}".`);
     }
+    return module.contents;
   }
 
   public sqlxAction(actionOptions: {

--- a/core/session.ts
+++ b/core/session.ts
@@ -1,5 +1,6 @@
 import { default as TarjanGraphConstructor, Graph as TarjanGraph } from "tarjan-graph";
 
+
 import { encode64, verifyObjectMatchesProto, VerifyProtoErrorBehaviour } from "df/common/protos";
 import { Action, ActionProto, ILegacyTableConfig, TableType } from "df/core/actions";
 import { AContextable, Assertion, AssertionContext } from "df/core/actions/assertion";
@@ -16,6 +17,7 @@ import { Test } from "df/core/actions/test";
 import { View } from "df/core/actions/view";
 import { CompilationSql } from "df/core/compilation_sql";
 import { Contextable, IActionContext, ITableContext, Resolvable } from "df/core/contextables";
+import * as Path from "df/core/path";
 import { targetAsReadableString, targetStringifier } from "df/core/targets";
 import * as utils from "df/core/utils";
 import { ResolvableMap, toResolvable } from "df/core/utils";
@@ -89,6 +91,19 @@ export class Session {
     return new CompilationSql(this.projectConfig, dataformCoreVersion);
   }
 
+  public getContents(filePath: string): string {
+    const callerFile = utils.getCallerFile(this.rootDir);
+    const callerDir = Path.dirName(callerFile);
+
+    const resolvedPath = Path.normalize(Path.join(callerDir,filePath));
+
+    const module = utils.nativeRequire(resolvedPath);
+    if (!module || typeof module.contents !== "string") {
+      throw new Error(`Could not read markdown content from "${resolvedPath}".`);
+    }
+  return module.contents;
+
+  }
   public sqlxAction(actionOptions: {
     // sqlxConfig has type any here because any object can be passed in from the compiler - the
     // structure of it is verified at later steps.

--- a/core/session.ts
+++ b/core/session.ts
@@ -22,6 +22,7 @@ import { targetAsReadableString, targetStringifier } from "df/core/targets";
 import * as utils from "df/core/utils";
 import { ResolvableMap, toResolvable } from "df/core/utils";
 import { version as dataformCoreVersion } from "df/core/version";
+import { separator } from "df/core/path";
 import { dataform, google } from "df/protos/ts";
 
 
@@ -98,7 +99,7 @@ export class Session {
     const resolvedPath = Path.normalize(Path.join(callerDir,filePath));
     const absolutePath = nodePath.join(this.rootDir, resolvedPath);
 
-    if (!absolutePath.startsWith(this.rootDir)){
+    if (!absolutePath.startsWith(`${Path.normalize(this.rootDir) + separator}`)){
       throw new Error(`Cannot read "${filePath}": path resolves outside the project directory.`);
     }
 

--- a/docs/reference/session.md
+++ b/docs/reference/session.md
@@ -87,9 +87,7 @@ ___
 
 ▸ **getContents**(`filePath`: string): *string*
 
-Reads the contents of an external file and returns it as a string. The path is resolved relative to the file that calls `getContents`.
-
-Intended for use with `.md` files to source action descriptions externally, keeping `.sqlx` files smaller and enabling reusable, renderable descriptions across the project.
+Reads the contents of an external markdown file and returns it as a string. The path is resolved relative to the file that calls `getContents`.
 
 Available only in the `/definitions` directory.
 

--- a/docs/reference/session.md
+++ b/docs/reference/session.md
@@ -19,6 +19,7 @@ folder of a Dataform project.
 
 * [assert](_core_session_.session.md#assert)
 * [declare](_core_session_.session.md#declare)
+* [getContents](_core_session_.session.md#getcontents)
 * [notebook](_core_session_.session.md#notebook)
 * [operate](_core_session_.session.md#operate)
 * [publish](_core_session_.session.md#publish)
@@ -79,6 +80,36 @@ Name | Type |
 `config` | DeclarationConfig &#124; any |
 
 **Returns:** *[Declaration](_core_actions_declaration_.declaration.md)*
+
+___
+
+###  getContents
+
+▸ **getContents**(`filePath`: string): *string*
+
+Reads the contents of an external file and returns it as a string. The path is resolved relative to the file that calls `getContents`.
+
+Intended for use with `.md` files to source action descriptions externally, keeping `.sqlx` files smaller and enabling reusable, renderable descriptions across the project.
+
+Available only in the `/definitions` directory.
+
+**Example:**
+
+```sqlx
+config {
+  type: "table",
+  description: getContents('./my_table_description.md')
+}
+SELECT ...
+```
+
+**Parameters:**
+
+Name | Type | Description |
+------ | ------ | ------ |
+`filePath` | string | Path to the file, relative to the calling file. |
+
+**Returns:** *string*
 
 ___
 

--- a/testing/run_core.ts
+++ b/testing/run_core.ts
@@ -48,7 +48,7 @@ export class WorkflowSettingsTemplates {
   });
 }
 
-const SOURCE_EXTENSIONS = ["js", "sql", "sqlx", "yaml", "ipynb"];
+const SOURCE_EXTENSIONS = ["js", "sql", "sqlx", "yaml", "ipynb","md"];
 
 export function coreExecutionRequestFromPath(
   projectDir: string,


### PR DESCRIPTION
Closes #1723

Allows users to source table descriptions from external markdown files, keeping .sqlx files smaller and enabling reusable, renderable descriptions across the project.

Usage:
```
config {
  type: "table",
  description: getContents('./my_table_description.md')
}
SELECT ...
```
Changes:

- core/compilers.ts : .md files now compile to exports.contents = \...``
- core/session.ts : new getContents(filePath) method; resolves the path relative to the calling file using the call stack, then builds an absolute path for nativeRequire
- core/main.ts :  getContents bound to the global scope
- cli/vm/compile.ts + testing/run_core.ts:  "md" added to sourceExtensions so vm2 applies the compiler to .md files
- core/main_test.ts + core/compilers_test.ts : tests for happy path and missing file error

Notes:
- The method is currently named getContents, inspired by the suggestion in the issue thread, but happy to rename before merge if the maintainers have a preference!
- When getContents references a file that doesn't exist, the error surfaces as a VMError: Cannot find module '/absolute/path/to/file.md' compilation error. A cleaner message could be produced by intercepting in dataformCompile in main.ts also happy to add this if preferred, just wanted to flag the tradeoff before doing extra work. 