### PR TITLE
Fix cloud build npm package paths

### DIFF
--- a/cloudbuild-publish.yaml
+++ b/cloudbuild-publish.yaml
@@ -26,9 +26,9 @@ availableSecrets:
 artifacts:
   npmPackages:
   - repository: 'https://us-central1-npm.pkg.dev/dataform-open-source/dataform-open-source'
-    packagePath: './bazel-bin/packages/@dataform/cli'
+    packagePath: './bazel-bin/packages/@dataform/cli/package'
   - repository: 'https://us-central1-npm.pkg.dev/dataform-open-source/dataform-open-source'
-    packagePath: './bazel-bin/packages/@dataform/core'
+    packagePath: './bazel-bin/packages/@dataform/core/package'
 options:
   machineType: E2_HIGHCPU_8
   requestedVerifyOption: VERIFIED


### PR DESCRIPTION
Currently it's packed one level higher than it should, below is the content of the `package` directory from the downloaded tarball, it contains another `package` directory with the correct content

<img width="1215" height="1403" alt="image" src="https://github.com/user-attachments/assets/0be243ad-31a7-4909-a94d-9ef9473de88a" />
