### PR TITLE
Support generic compilation options

### DIFF
--- a/protos/core.proto
+++ b/protos/core.proto
@@ -57,6 +57,12 @@ message CompileConfig {
   // Whether to emit compilation debug logs.
   bool verbose = 11;
 
+  // Supplementary key-value options for the compilation process,
+  // distinct from `project_config_override.vars` (which holds user vars).
+  // This can be used to pass environment-specific parameters or
+  // auxiliary configuration paths to the underlying execution engine.
+  map<string, string> additional_options = 12;
+
   reserved 2, 4, 5, 7, 9;
 }
 


### PR DESCRIPTION
Introduce generic configuration options for compilation

Adds the `additional_options` field to `CompileConfig`. This generic map allows the pipeline to supply auxiliary key-value parameters and paths necessary for compilation, keeping the core schema clean while supporting various environment-specific requirements.