### PR TITLE
feat: add .preOps() and .postOps() support to Assertion action

### DIFF
--- a/core/actions/assertion.ts
+++ b/core/actions/assertion.ts
@@ -89,6 +89,8 @@ export class Assertion extends ActionBuilder<dataform.Assertion> {
 
   /** @hidden We delay contextification until the final compile step, so hold these here for now. */
   private contextableQuery: AContextable<string>;
+  private contextablePreOps: Array<AContextable<string | string[]>> = [];
+  private contextablePostOps: Array<AContextable<string | string[]>> = [];
 
   /** @hidden */
   constructor(session?: Session, unverifiedConfig?: any, configPath?: string) {
@@ -155,6 +157,12 @@ export class Assertion extends ActionBuilder<dataform.Assertion> {
       }
       this.proto.actionDescriptor.reservation = config.reservation;
     }
+    if (config.preOperations) {
+      this.preOps(config.preOperations);
+    }
+    if (config.postOperations) {
+      this.postOps(config.postOperations);
+    }
     return this;
   }
 
@@ -163,6 +171,16 @@ export class Assertion extends ActionBuilder<dataform.Assertion> {
    */
   public query(query: AContextable<string>) {
     this.contextableQuery = query;
+    return this;
+  }
+
+  public preOps(pres: AContextable<string | string[]>) {
+    this.contextablePreOps.push(pres);
+    return this;
+  }
+
+  public postOps(posts: AContextable<string | string[]>) {
+    this.contextablePostOps.push(posts);
     return this;
   }
 
@@ -296,6 +314,18 @@ export class Assertion extends ActionBuilder<dataform.Assertion> {
     this.proto.query = context.apply(this.contextableQuery);
     validateQueryString(this.session, this.proto.query, this.proto.fileName);
 
+    this.contextablePreOps.forEach(contextablePreOp => {
+      const appliedPreOp = context.apply(contextablePreOp);
+      const preOps = typeof appliedPreOp === "string" ? [appliedPreOp] : appliedPreOp;
+      preOps.forEach(preOp => this.proto.preOps.push(preOp));
+    });
+
+    this.contextablePostOps.forEach(contextablePostOp => {
+      const appliedPostOp = context.apply(contextablePostOp);
+      const postOps = typeof appliedPostOp === "string" ? [appliedPostOp] : appliedPostOp;
+      postOps.forEach(postOp => this.proto.postOps.push(postOp));
+    });
+
     return verifyObjectMatchesProto(
       dataform.Assertion,
       this.proto,
@@ -396,6 +426,16 @@ export class AssertionContext implements IActionContext {
 
   public tags(name: string | string[]) {
     this.assertion.tags(name);
+    return "";
+  }
+
+  public preOps(statement: string | string[]) {
+    this.assertion.preOps(statement);
+    return "";
+  }
+
+  public postOps(statement: string | string[]) {
+    this.assertion.postOps(statement);
     return "";
   }
 

--- a/core/main_test.ts
+++ b/core/main_test.ts
@@ -442,6 +442,44 @@ SELECT 1`);
 `);
     });
 
+    test("extract assertion blocks", () => {
+      const projectDir = tmpDirFixture.createNewTmpDir();
+      fs.writeFileSync(
+        path.join(projectDir, "workflow_settings.yaml"),
+        dumpYaml(dataform.WorkflowSettings.create(WorkflowSettingsTemplates.bigquery))
+      );
+      fs.mkdirSync(path.join(projectDir, "definitions"));
+      fs.writeFileSync(
+        path.join(projectDir, "definitions/file.sqlx"),
+        `
+config {
+  type: "assertion"
+}
+pre_operations {
+  SELECT 2;
+}
+post_operations {
+  SELECT 3;
+}
+SELECT 1`
+      );
+
+      const result = runMainInVm(coreExecutionRequestFromPath(projectDir));
+
+      expect(result.compile.compiledGraph.graphErrors.compilationErrors).deep.equals([]);
+      expect(result.compile.compiledGraph.assertions[0].query).equals(`
+
+
+
+SELECT 1`);
+      expect(result.compile.compiledGraph.assertions[0].preOps[0]).equals(`
+  SELECT 2;
+`);
+      expect(result.compile.compiledGraph.assertions[0].postOps[0]).equals(`
+  SELECT 3;
+`);
+    });
+
     test("backticks appear to users as written", () => {
       const projectDir = tmpDirFixture.createNewTmpDir();
       fs.writeFileSync(
@@ -1132,6 +1170,34 @@ actions:
 
       expect(result.compile.compiledGraph.graphErrors.compilationErrors).deep.equals([]);
     });
+
+    test(`extract assertion blocks`, () => {
+      const projectDir = tmpDirFixture.createNewTmpDir();
+      fs.writeFileSync(
+        path.join(projectDir, "workflow_settings.yaml"),
+        VALID_WORKFLOW_SETTINGS_YAML
+      );
+      fs.mkdirSync(path.join(projectDir, "definitions"));
+      fs.writeFileSync(
+        path.join(projectDir, "definitions/actions.yaml"),
+        `
+actions:
+- assertion:
+    filename: file.sql
+    preOperations:
+    - SELECT 2
+    postOperations:
+    - SELECT 3`
+      );
+      fs.writeFileSync(path.join(projectDir, "definitions/file.sql"), "SELECT 1");
+
+      const result = runMainInVm(coreExecutionRequestFromPath(projectDir));
+
+      expect(result.compile.compiledGraph.graphErrors.compilationErrors).deep.equals([]);
+      expect(result.compile.compiledGraph.assertions[0].query).equals("SELECT 1");
+      expect(result.compile.compiledGraph.assertions[0].preOps[0]).equals("SELECT 2");
+      expect(result.compile.compiledGraph.assertions[0].postOps[0]).equals("SELECT 3");
+    });
   });
 
   suite("javascript API", () => {
@@ -1457,6 +1523,8 @@ operate("name", {
 assert("name", {
   type: "operations",
 }).query(_ => "SELECT 1")
+  .preOps(_ => ["pre_op"])
+  .postOps(_ => ["post_op"])
   .database("otherProject")
   .schema("otherDataset")`
             );
@@ -1482,7 +1550,9 @@ assert("name", {
                     name: "name"
                   },
                   fileName: "definitions/assert.js",
-                  query: "SELECT 1"
+                  query: "SELECT 1",
+                  postOps: ["post_op"],
+                  preOps: ["pre_op"]
                 }
               ])
             );

--- a/core/session.ts
+++ b/core/session.ts
@@ -134,11 +134,11 @@ export class Session {
     if (actionOptions.inputContextables.length > 0 && actionType !== "test") {
       this.compileError("Actions may only include input blocks if they are of type 'test'.");
     }
-    if (actionOptions.preOperationsContextable && !definesDataset(actionType)) {
-      this.compileError("Actions may only include pre_operations if they create a dataset.");
+    if (actionOptions.preOperationsContextable && !definesDataset(actionType) && actionType !== "assertion") {
+      this.compileError("Actions may only include pre_operations if they create a dataset or are assertions.");
     }
-    if (actionOptions.postOperationsContextable && !definesDataset(actionType)) {
-      this.compileError("Actions may only include post_operations if they create a dataset.");
+    if (actionOptions.postOperationsContextable && !definesDataset(actionType) && actionType !== "assertion") {
+      this.compileError("Actions may only include post_operations if they create a dataset or are assertions.");
     }
 
     if (!sqlxConfig.filename) {
@@ -190,9 +190,16 @@ export class Session {
         this.actions.push(table);
         break;
       case "assertion":
-        this.actions.push(
-          new Assertion(this, sqlxConfig).query(ctx => actionOptions.sqlContextable(ctx)[0])
+        const assertion = new Assertion(this, sqlxConfig).query(
+          ctx => actionOptions.sqlContextable(ctx)[0]
         );
+        if (actionOptions.preOperationsContextable) {
+          assertion.preOps(actionOptions.preOperationsContextable as any);
+        }
+        if (actionOptions.postOperationsContextable) {
+          assertion.postOps(actionOptions.postOperationsContextable as any);
+        }
+        this.actions.push(assertion);
         break;
       case "dataPreparation":
         const dataPreparation = new DataPreparation(this, sqlxConfig).query(

--- a/protos/configs.proto
+++ b/protos/configs.proto
@@ -528,6 +528,12 @@ message ActionConfig {
     // If unset, the value from workflow_settings.yaml is used. If neither is set, default BigQuery behavior applies.
     // Dataform CLI only (GCP Dataform support pending).
     string reservation = 11;
+
+    // Queries to run before `query`.
+    repeated string pre_operations = 12;
+
+    // Queries to run after `query`.
+    repeated string post_operations = 13;
   }
 
   message OperationConfig {

--- a/protos/core.proto
+++ b/protos/core.proto
@@ -260,6 +260,9 @@ message Assertion {
   // Only present for auto assertions.
   Target parent_action = 15;
 
+  repeated string pre_ops = 16;
+  repeated string post_ops = 17;
+
   // Generated.
   string file_name = 7;
 

--- a/tests/api/projects.spec.ts
+++ b/tests/api/projects.spec.ts
@@ -47,14 +47,6 @@ suite("examples", () => {
                 'Unexpected property "hasOutput", or property value type of "boolean" is incorrect. See https://dataform-co.github.io/dataform/docs/configs-reference#dataform-ActionConfig-AssertionConfig for allowed properties.'
             },
             {
-              fileName: "definitions/has_compile_errors/assertion_with_postops.sqlx",
-              message: "Actions may only include post_operations if they create a dataset."
-            },
-            {
-              fileName: "definitions/has_compile_errors/assertion_with_preops.sqlx",
-              message: "Actions may only include pre_operations if they create a dataset."
-            },
-            {
               fileName: "definitions/has_compile_errors/protected_assertion.sqlx",
               message:
                 "Actions may only specify 'protected: true' if they are of type 'incremental'."

--- a/tests/api/projects/common_v2/definitions/has_compile_errors/assertion_with_postops.sqlx
+++ b/tests/api/projects/common_v2/definitions/has_compile_errors/assertion_with_postops.sqlx
@@ -1,3 +1,0 @@
-config { type: "assertion", hermetic: false }
-SELECT 1 as test
-post_operations { select 2 as other }

--- a/tests/api/projects/common_v2/definitions/has_compile_errors/assertion_with_preops.sqlx
+++ b/tests/api/projects/common_v2/definitions/has_compile_errors/assertion_with_preops.sqlx
@@ -1,3 +1,0 @@
-config { type: "assertion", hermetic: false }
-SELECT 1 as test
-pre_operations { select 2 as other }


### PR DESCRIPTION
This update brings the Assertion action on par with Table and View by introducing support for pre-operations and post-operations.

- Updated `dataform.proto` (via `core.proto` and `configs.proto`) to include `pre_ops`/`post_ops` for `Assertion` and `pre_operations`/ `post_operations` for `AssertionConfig`.
- Enhanced `core/actions/assertion.ts` with `contextablePreOps` and `contextablePostOps` arrays.
- Exposed `.preOps()` and `.postOps()` methods on both `Assertion` builder and `AssertionContext`.
- Added test coverage in `core/main_test.ts` to ensure operations are compiled correctly for assertions.