### PR TITLE
Bump DF_VERSION from 3.0.57 to 3.0.58

### DIFF
--- a/version.bzl
+++ b/version.bzl
@@ -1,1 +1,1 @@
-DF_VERSION = "3.0.57"
+DF_VERSION = "3.0.58"


### PR DESCRIPTION
## Summary
- Bump `DF_VERSION` from `3.0.57` to `3.0.58` in `version.bzl`.

## Test plan
- [ ] CI passes (no functional changes; version-only bump).