### PR TITLE
Guard workflow_settings.yaml and dataform.json require with existence check

### DIFF
--- a/cli/vm/compile.ts
+++ b/cli/vm/compile.ts
@@ -77,10 +77,21 @@ export function compile(compileConfig: dataform.ICompileConfig) {
     throw new Error("@dataform/core ^3.0.0 required.");
   }
 
+  const hasWorkflowSettingsYaml = fs.existsSync(
+    path.join(compileConfig.projectDir, "workflow_settings.yaml")
+  );
+  const hasDataformJson = fs.existsSync(
+    path.join(compileConfig.projectDir, "dataform.json")
+  );
+
   return userCodeVm.run(
     `
-      global.workflowSettingsYaml = (function() { try { return require("./workflow_settings.yaml"); } catch(e) { console.error("YAML require failed:", e); } })();
-      global.dataformJson = (function() { try { return require("./dataform.json"); } catch(e) {} })();
+      ${hasWorkflowSettingsYaml
+        ? 'global.workflowSettingsYaml = require("./workflow_settings.yaml");'
+        : ''}
+      ${hasDataformJson
+        ? 'global.dataformJson = require("./dataform.json");'
+        : ''}
       return require("@dataform/core").main("${createCoreExecutionRequest(compileConfig)}")
     `,
     vmIndexFileName


### PR DESCRIPTION
## Summary
- Replace `try/catch` + `console.error("YAML require failed:", e)` around `require("./workflow_settings.yaml")` with an `fs.existsSync` guard. Same treatment for `dataform.json`.
- Eliminates the `VMError: Cannot find module './workflow_settings.yaml'` stack trace that #2168 introduced on stderr when the file is legitimately absent (vm2 3.9.19 silently returned undefined for missing files; 3.11.3 throws).
- The core's existing `maybeRequire` fallback path remains unchanged — `readWorkflowSettings()` still works when neither global is injected.