### PR TITLE
Refactor CompileChildProcess to use BaseWorker

### DIFF
--- a/cli/api/commands/base_worker.ts
+++ b/cli/api/commands/base_worker.ts
@@ -15,6 +15,7 @@ export abstract class BaseWorker<TResponse, TMessage = any> {
 
     return new Promise((resolve, reject) => {
       let completed = false;
+      let booted = false;
 
       const terminate = (fn: () => void) => {
         if (completed) {
@@ -22,7 +23,7 @@ export abstract class BaseWorker<TResponse, TMessage = any> {
         }
         completed = true;
         clearTimeout(timeout);
-        child.kill();
+        child.kill("SIGKILL");
         fn();
       };
 
@@ -34,7 +35,10 @@ export abstract class BaseWorker<TResponse, TMessage = any> {
 
       child.on("message", (message: any) => {
         if (message.type === "worker_booted") {
-          onBoot(child);
+          if (!booted) {
+            booted = true;
+            onBoot(child);
+          }
           return;
         }
         onMessage(message, child, (res) => terminate(() => resolve(res)), (err) => terminate(() => reject(err)));
@@ -57,7 +61,7 @@ export abstract class BaseWorker<TResponse, TMessage = any> {
   }
 
   private resolveScript() {
-    const pathsToTry = [this.loaderPath, "./worker_bundle.js"];
+    const pathsToTry = ["./worker_bundle.js", this.loaderPath];
     for (const p of pathsToTry) {
       try {
         return require.resolve(p);

--- a/cli/api/commands/compile.ts
+++ b/cli/api/commands/compile.ts
@@ -1,11 +1,13 @@
-import { ChildProcess, exec, fork } from "child_process";
+import { exec } from "child_process";
 import * as fs from "fs-extra";
 import * as path from "path";
 import * as tmp from "tmp";
 import { promisify } from "util";
 
+import { BaseWorker } from "df/cli/api/commands/base_worker";
 import { MISSING_CORE_VERSION_ERROR } from "df/cli/api/commands/install";
 import { readConfigFromWorkflowSettings } from "df/cli/api/utils";
+import { DEFAULT_COMPILATION_TIMEOUT_MILLIS } from "df/cli/api/utils/constants";
 import { coerceAsError } from "df/common/errors/errors";
 import { decode64 } from "df/common/protos";
 import { dataform } from "df/protos/ts";
@@ -77,7 +79,7 @@ export async function compile(
     const { stdout, stderr } = await promisify(exec)(npmCommand, {
       cwd: temporaryProjectPath
     });
-    
+
     if (compileConfig.verbose) {
       print(`NPM HTTP Logs:\n${stderr}\n`);
       print(`NPM install completed in ${performance.now() - npmStartTime}ms\n`);
@@ -86,7 +88,7 @@ export async function compile(
     compileConfig.projectDir = temporaryProjectPath;
   }
 
-  const result = await CompileChildProcess.forkProcess().compile(compileConfig);
+  const result = await new CompileChildProcess().compile(compileConfig);
 
   const decodedResult = decode64(dataform.CoreExecutionResponse, result);
   compiledGraph = dataform.CompiledGraph.create(decodedResult.compile.compiledGraph);
@@ -98,68 +100,24 @@ export async function compile(
   return compiledGraph;
 }
 
-export class CompileChildProcess {
-  public static forkProcess() {
-    // Runs the worker_bundle script we generate for the package (see packages/@dataform/cli/BUILD)
-    // if it exists, otherwise run the bazel compile loader target.
-    const findForkScript = () => {
-      try {
-        const workerBundlePath = require.resolve("./worker_bundle.js");
-        return workerBundlePath;
-      } catch (e) {
-        return require.resolve("../../vm/compile_loader");
-      }
-    };
-    const forkScript = findForkScript();
-    return new CompileChildProcess(
-      fork(require.resolve(forkScript), [], { stdio: [0, 1, 2, "ipc", "pipe"] })
-    );
-  }
-  private readonly childProcess: ChildProcess;
-
-  constructor(childProcess: ChildProcess) {
-    this.childProcess = childProcess;
+export class CompileChildProcess extends BaseWorker<string, string | Error> {
+  constructor() {
+    super(path.resolve(__dirname, "../../vm/compile_loader"));
   }
 
   public async compile(compileConfig: dataform.ICompileConfig) {
-    const compileInChildProcess = new Promise<string>(async (resolve, reject) => {
-      this.childProcess.on("error", (e: Error) => reject(coerceAsError(e)));
+    const timeoutValue = compileConfig.timeoutMillis || DEFAULT_COMPILATION_TIMEOUT_MILLIS;
 
-      this.childProcess.on("message", (messageOrError: string | Error) => {
-        if (typeof messageOrError === "string") {
-          resolve(messageOrError);
-          return;
+    return await this.runWorker(
+      timeoutValue,
+      child => child.send(compileConfig),
+      (message, child, resolve, reject) => {
+        if (typeof message === "string") {
+          resolve(message);
+        } else {
+          reject(coerceAsError(message));
         }
-        reject(coerceAsError(messageOrError));
-      });
-
-      this.childProcess.on("close", exitCode => {
-        if (exitCode !== 0) {
-          reject(new Error(`Compilation child process exited with exit code ${exitCode}.`));
-        }
-      });
-
-      // Trigger the child process to start compiling.
-      this.childProcess.send(compileConfig);
-    });
-    let timer;
-    const timeout = new Promise(
-      (resolve, reject) =>
-        (timer = setTimeout(
-          () => reject(new CompilationTimeoutError("Compilation timed out")),
-          compileConfig.timeoutMillis || 5000
-        ))
+      }
     );
-    try {
-      await Promise.race([timeout, compileInChildProcess]);
-      return await compileInChildProcess;
-    } finally {
-      if (!this.childProcess.killed) {
-        this.childProcess.kill("SIGKILL");
-      }
-      if (timer) {
-        clearTimeout(timer);
-      }
-    }
   }
 }

--- a/cli/vm/compile.ts
+++ b/cli/vm/compile.ts
@@ -99,7 +99,11 @@ export function compile(compileConfig: dataform.ICompileConfig) {
 }
 
 export function listenForCompileRequest() {
-  process.on("message", (compileConfig: dataform.ICompileConfig) => {
+  process.on("message", (compileConfig: dataform.ICompileConfig & { type?: string }) => {
+    // JiT messages are handled by handleJitRequest in worker.ts; skip them here.
+    if ((compileConfig as { type?: string })?.type === "jit_compile") {
+      return;
+    }
     try {
       const compiledResult = compile(compileConfig);
       process.send(compiledResult);
@@ -114,6 +118,9 @@ export function listenForCompileRequest() {
 }
 
 if (require.main === module) {
+  if (process.send) {
+    process.send({ type: "worker_booted" });
+  }
   listenForCompileRequest();
 }
 

--- a/tests/api/projects.spec.ts
+++ b/tests/api/projects.spec.ts
@@ -694,10 +694,13 @@ suite("examples", () => {
 
   test("times out after timeout period during compilation", async () => {
     try {
-      await compile({ projectDir: "tests/api/projects/never_finishes_compiling" });
+      await compile({
+        projectDir: "tests/api/projects/never_finishes_compiling",
+        timeoutMillis: 1000
+      });
       fail("Compilation timeout Error expected.");
     } catch (e) {
-      expect(e.message).to.equal("Compilation timed out");
+      expect(e.message).to.equal("Worker timed out after 1 seconds");
     }
   });
 


### PR DESCRIPTION
Part of https://github.com/dataform-co/dataform/pull/2110 - [Integrate JiT compilation into CLI]