### PR TITLE
Rename worker timeout error to "Compilation timed out"

### DIFF
--- a/cli/api/commands/base_worker.ts
+++ b/cli/api/commands/base_worker.ts
@@ -29,7 +29,7 @@ export abstract class BaseWorker<TResponse, TMessage = any> {
 
       const timeout = setTimeout(() => {
         terminate(() =>
-          reject(new Error(`Worker timed out after ${timeoutMillis / 1000} seconds`))
+          reject(new Error(`Compilation timed out after ${timeoutMillis / 1000} seconds`))
         );
       }, timeoutMillis);
 

--- a/cli/api/commands/compile.ts
+++ b/cli/api/commands/compile.ts
@@ -114,9 +114,9 @@ export class CompileChildProcess extends BaseWorker<string, string | Error> {
       (message, child, resolve, reject) => {
         if (typeof message === "string") {
           resolve(message);
-        } else {
-          reject(coerceAsError(message));
+          return;
         }
+        reject(coerceAsError(message));
       }
     );
   }

--- a/tests/api/projects.spec.ts
+++ b/tests/api/projects.spec.ts
@@ -700,7 +700,7 @@ suite("examples", () => {
       });
       fail("Compilation timeout Error expected.");
     } catch (e) {
-      expect(e.message).to.equal("Worker timed out after 1 seconds");
+      expect(e.message).to.equal("Compilation timed out after 1 seconds");
     }
   });
 


### PR DESCRIPTION
Addresses review comments on #2179 (now merged)