### PR TITLE
Fix caller-file error (#2177) and enforce Core/CLI version match

### DIFF
--- a/cli/index_compile_test.ts
+++ b/cli/index_compile_test.ts
@@ -65,6 +65,71 @@ suite("compile command", ({ afterEach }) => {
     );
   });
 
+  test("compile rejects @dataform/core with incompatible version", async () => {
+    const projectDir = tmpDirFixture.createNewTmpDir();
+    // dataformCoreVersion in workflow_settings.yaml triggers the stateless
+    // install path (compile.ts copies to a tmp dir and runs `npm i`), so the
+    // test exercises the same flow real users hit. 2.9.0 is the latest 2.x on
+    // the registry; its major (2) is incompatible with the current CLI (3.x).
+    fs.writeFileSync(
+      path.join(projectDir, "workflow_settings.yaml"),
+      dumpYaml(
+        dataform.WorkflowSettings.create({
+          defaultProject: "dataform",
+          dataformCoreVersion: "2.9.0"
+        })
+      )
+    );
+
+    // npm needs a writable cache; ~/.npm is read-only in the bazel sandbox.
+    const npmCacheDir = tmpDirFixture.createNewTmpDir();
+    const stderr = (
+      await getProcessResult(
+        execFile(nodePath, [cliEntryPointPath, "compile", projectDir], {
+          env: { ...process.env, NPM_CONFIG_CACHE: npmCacheDir }
+        })
+      )
+    ).stderr;
+    expect(stderr).contains("@dataform/core 2.9.0 is not compatible with @dataform/cli");
+    expect(stderr).contains("matching major.minor");
+    expect(stderr).contains("Set `dataformCoreVersion:");
+  });
+
+  test("compile succeeds with @dataform/core <= 3.0.56 via caller-file shim", async () => {
+    const projectDir = tmpDirFixture.createNewTmpDir();
+    // 3.0.50 predates 3.0.57, which is when @dataform/core started reading
+    // global.__dataform_current_file as a fallback in getCallerFile(). The
+    // compile path text-patches the bundle to add that fallback; this test
+    // proves the patch + host-side file stack drive a real action's
+    // fileName from inside vm2 3.11.3's path-stripped sandbox.
+    fs.writeFileSync(
+      path.join(projectDir, "workflow_settings.yaml"),
+      dumpYaml({
+        defaultProject: DEFAULT_DATABASE,
+        defaultLocation: DEFAULT_LOCATION,
+        defaultDataset: "dataform",
+        dataformCoreVersion: "3.0.50"
+      })
+    );
+    fs.ensureFileSync(path.join(projectDir, "definitions", "example.sqlx"));
+    fs.writeFileSync(
+      path.join(projectDir, "definitions", "example.sqlx"),
+      `config { type: "table" }\nSELECT 1 AS id`
+    );
+
+    const npmCacheDir = tmpDirFixture.createNewTmpDir();
+    const result = await getProcessResult(
+      execFile(nodePath, [cliEntryPointPath, "compile", projectDir, "--json"], {
+        env: { ...process.env, NPM_CONFIG_CACHE: npmCacheDir }
+      })
+    );
+
+    expect(result.exitCode, `compile failed: ${result.stderr}`).equals(0);
+    const compiled = JSON.parse(result.stdout);
+    expect(compiled.tables).to.have.lengthOf(1);
+    expect(compiled.tables[0].fileName).equals("definitions/example.sqlx");
+  });
+
   ["package.json", "package-lock.json", "node_modules"].forEach(npmFile => {
     test(`compile throws an error when dataformCoreVersion in workflow_settings.yaml and ${npmFile} is present`, async () => {
       const projectDir = tmpDirFixture.createNewTmpDir();

--- a/cli/vm/compile.ts
+++ b/cli/vm/compile.ts
@@ -9,11 +9,10 @@ import { dataform } from "df/protos/ts";
 
 export function compile(compileConfig: dataform.ICompileConfig) {
   compileConfig.projectDir = fs.realpathSync(path.resolve(compileConfig.projectDir));
-  if (
-    !fs.existsSync(
-      path.join(compileConfig.projectDir, "node_modules", "@dataform", "core", "bundle.js")
-    )
-  ) {
+  const coreBundlePath = path.join(
+    compileConfig.projectDir, "node_modules", "@dataform", "core", "bundle.js"
+  );
+  if (!fs.existsSync(coreBundlePath)) {
     throw new Error(
       "Could not find a recent installed version of @dataform/core in the project. Check that " +
         "either `dataformCoreVersion` is specified in `workflow_settings.yaml`, or " +
@@ -21,9 +20,13 @@ export function compile(compileConfig: dataform.ICompileConfig) {
         "`dataform install`."
     );
   }
+
   const vmIndexFileName = path.resolve(path.join(compileConfig.projectDir, "index.js"));
 
-  // First retrieve a compiler function for vm2 to process files.
+  // Retrieve compiler and version from the resolved @dataform/core. Going
+  // through Node's resolver inside the vm covers every install layout
+  // (package.json, workflow_settings.yaml, JiT) and matches what the user's
+  // code will see. require() caches the bundle so the second call is free.
   const indexGeneratorVm = new NodeVM({
     wrapper: "none",
     require: {
@@ -37,10 +40,47 @@ export function compile(compileConfig: dataform.ICompileConfig) {
     'return require("@dataform/core").compiler',
     vmIndexFileName
   );
+  const dataformCoreVersion: string = indexGeneratorVm.run(
+    'return require("@dataform/core").version || "0.0.0"',
+    vmIndexFileName
+  );
+
+  const cliVersion = readCliVersion();
+  const cliParsed = semver.parse(cliVersion);
+  // cliParsed is null for unparseable strings, and "0.0.0" is the sentinel
+  // returned when package.json can't be read (unbundled local dev). In both
+  // cases skip the check rather than reject every real Core install.
+  if (cliParsed && cliVersion !== "0.0.0") {
+    const minCoreVersion = `${cliParsed.major}.${cliParsed.minor}.0`;
+    if (
+      semver.major(dataformCoreVersion) !== cliParsed.major ||
+      semver.lt(dataformCoreVersion, minCoreVersion)
+    ) {
+      throw new Error(
+        `@dataform/core ${dataformCoreVersion} is not compatible with @dataform/cli ` +
+          `${cliVersion}. The CLI requires @dataform/core >= ${minCoreVersion} ` +
+          `(matching major.minor). Set \`dataformCoreVersion: ${cliVersion}\` in ` +
+          `workflow_settings.yaml (or pin @dataform/core in package.json), then run ` +
+          `\`dataform install\`.`
+      );
+    }
+  }
+  const needsCallerFileShim = semver.lt(dataformCoreVersion, "3.0.57");
+
+  // vm2 strips file paths from V8 CallSite objects inside the sandbox, so
+  // getCallerFile() in @dataform/core needs a fallback. Track the currently
+  // executing file via a host-side stack exposed through sandbox helpers, and
+  // expose it as a getter on `global.__dataform_current_file`.
+  const fileStack: string[] = [];
 
   // Then use vm2's native compiler integration to apply the compiler to files.
   const userCodeVm = new NodeVM({
     wrapper: "none",
+    sandbox: {
+      __df_enter: (p: string) => { fileStack.push(p); },
+      __df_exit: () => { fileStack.pop(); },
+      __df_current: () => fileStack.length > 0 ? fileStack[fileStack.length - 1] : null
+    },
     require: {
       builtin: ["path"],
       context: "sandbox",
@@ -50,32 +90,22 @@ export function compile(compileConfig: dataform.ICompileConfig) {
         path.join(parentDirName, path.relative(parentDirName, compileConfig.projectDir), moduleName)
     },
     sourceExtensions: ["js", "sql", "sqlx", "yaml", "yml"],
-    // vm2 3.11.3 strips file paths from V8 CallSite objects inside the sandbox,
-    // which breaks getCallerFile() in @dataform/core. Wrap each compiled module so
-    // the current file path is exposed via a global, used as a fallback when the
-    // stack-trace path is unavailable. The try/finally restores the previous value
-    // to keep nested requires (macros) consistent.
     compiler: (code, filePath) => {
-      const compiledCode = compiler(code, filePath);
+      let source = code;
+      if (needsCallerFileShim && filePath === coreBundlePath) {
+        source = patchOldCoreCallerFile(source);
+      }
+      const compiledCode = compiler(source, filePath);
       return `
-        var __old_file = global.__dataform_current_file;
-        global.__dataform_current_file = ${JSON.stringify(filePath)};
+        __df_enter(${JSON.stringify(filePath)});
         try {
           ${compiledCode}
         } finally {
-          global.__dataform_current_file = __old_file;
+          __df_exit();
         }
       `;
     }
   });
-
-  const dataformCoreVersion: string = userCodeVm.run(
-    'return require("@dataform/core").version || "0.0.0"',
-    vmIndexFileName
-  );
-  if (semver.lt(dataformCoreVersion, "3.0.0-alpha.0")) {
-    throw new Error("@dataform/core ^3.0.0 required.");
-  }
 
   const hasWorkflowSettingsYaml = fs.existsSync(
     path.join(compileConfig.projectDir, "workflow_settings.yaml")
@@ -86,6 +116,10 @@ export function compile(compileConfig: dataform.ICompileConfig) {
 
   return userCodeVm.run(
     `
+      Object.defineProperty(global, '__dataform_current_file', {
+        configurable: true,
+        get: function() { return __df_current(); }
+      });
       ${hasWorkflowSettingsYaml
         ? 'global.workflowSettingsYaml = require("./workflow_settings.yaml");'
         : ''}
@@ -122,6 +156,34 @@ if (require.main === module) {
     process.send({ type: "worker_booted" });
   }
   listenForCompileRequest();
+}
+
+// Reads the CLI's own version from the package.json baked next to the bundle
+// by pkg_json(version = DF_VERSION). Returns "0.0.0" when unreadable.
+function readCliVersion(): string {
+  try {
+    const pkg = JSON.parse(
+      fs.readFileSync(path.join(__dirname, "package.json"), "utf8")
+    );
+    return pkg.version || "0.0.0";
+  } catch {
+    return "0.0.0";
+  }
+}
+
+// @dataform/core <= 3.0.56 has no `global.__dataform_current_file` fallback in
+// getCallerFile(), so paired with CLI >= 3.0.57 (which uses vm2 with path
+// stripping) every action fails with "Unable to find valid caller file".
+// Backport the fallback by rewriting the bundle text at load time. Gated on
+// version so we never touch newer core bundles whose layout differs.
+const OLD_CORE_THROW =
+  'if(!t)throw new Error("Unable to find valid caller file; please report this issue.")';
+const OLD_CORE_WITH_FALLBACK =
+  'if(!t){if(global.__dataform_current_file){t=global.__dataform_current_file}' +
+  'else{throw new Error("Unable to find valid caller file; please report this issue.")}}';
+
+function patchOldCoreCallerFile(source: string): string {
+  return source.replace(OLD_CORE_THROW, OLD_CORE_WITH_FALLBACK);
 }
 
 /**

--- a/testing/run_core.ts
+++ b/testing/run_core.ts
@@ -76,12 +76,21 @@ export function runMainInVm(
   fs.copySync(`${process.cwd()}/core/node_modules`, `${projectDir}/node_modules`);
 
   const compiler = compile as CompilerFunction;
+  // See cli/vm/compile.ts for why we use a host-side stack + enter/exit helpers
+  // instead of writing to `global.__dataform_current_file` inside every module.
+  const fileStack: string[] = [];
+
   // Then use vm2's native compiler integration to apply the compiler to files.
   const nodeVm = new NodeVM({
     // Inheriting the console makes console.logs show when tests are running, which is useful for
     // debugging.
     console: "inherit",
     wrapper: "none",
+    sandbox: {
+      __df_enter: (p: string) => { fileStack.push(p); },
+      __df_exit: () => { fileStack.pop(); },
+      __df_current: () => fileStack.length > 0 ? fileStack[fileStack.length - 1] : null
+    },
     require: {
       builtin: ["path"],
       context: "sandbox",
@@ -94,12 +103,11 @@ export function runMainInVm(
     compiler: (code, filePath) => {
       const compiledCode = compiler(code, filePath);
       return `
-        var __old_file = global.__dataform_current_file;
-        global.__dataform_current_file = ${JSON.stringify(filePath)};
+        __df_enter(${JSON.stringify(filePath)});
         try {
           ${compiledCode}
         } finally {
-          global.__dataform_current_file = __old_file;
+          __df_exit();
         }
       `;
     }
@@ -109,6 +117,10 @@ export function runMainInVm(
   const vmIndexFileName = path.resolve(path.join(projectDir, "index.js"));
   const encodedCoreExecutionResponse = nodeVm.run(
     `
+      Object.defineProperty(global, '__dataform_current_file', {
+        configurable: true,
+        get: function() { return __df_current(); }
+      });
       global.workflowSettingsYaml = (function() { try { return require("./workflow_settings.yaml"); } catch(e) { console.error("YAML require failed run_core:", e); } })();
       global.dataformJson = (function() { try { return require("./dataform.json"); } catch(e) {} })();
       return require("@dataform/core").main("${encodedCoreExecutionRequest}")


### PR DESCRIPTION
vm2 3.11.3 strips file paths from V8 CallSite objects inside the sandbox, so `getCallerFile()` in @dataform/core can no longer resolve the current file from the stack. Track it via a host-side stack exposed through `__df_enter`/`__df_exit`/`__df_current` sandbox helpers and read it through a getter on `global.__dataform_current_file`.

For @dataform/core <= 3.0.56 (no global fallback in getCallerFile), patch the bundle text at load time to consult the global. Gated on the installed Core version so newer bundles are never touched.

Add a CLI/Core compatibility check: reject installed Core whose major differs from the CLI's, or whose minor is below the CLI's minor. The error tells the user the exact `dataformCoreVersion:` line to set in `workflow_settings.yaml`. Skipped when the CLI version can't be determined (unbundled local dev).

Mirror the same wrapper pattern in `testing/run_core.ts`.

Add `compile rejects @dataform/core with incompatible version` test in `cli/index_compile_test.ts`.