### PR TITLE
Bump DF_VERSION from 3.0.58 to 3.0.59

### DIFF
--- a/version.bzl
+++ b/version.bzl
@@ -1,1 +1,1 @@
-DF_VERSION = "3.0.58"
+DF_VERSION = "3.0.59"


### PR DESCRIPTION
## Summary
- Bump `DF_VERSION` from `3.0.58` to `3.0.59` in `version.bzl`.

## Test plan
- [ ] CI passes (no functional changes; version-only bump).