### PR TITLE
Include notebooks and data preparations in tag/action selection

### DIFF
--- a/cli/api/commands/prune.ts
+++ b/cli/api/commands/prune.ts
@@ -2,7 +2,12 @@ import { targetAsReadableString } from "df/core/targets";
 import * as utils from "df/core/utils";
 import { dataform } from "df/protos/ts";
 
-type CompileAction = dataform.ITable | dataform.IOperation | dataform.IAssertion;
+type CompileAction =
+  | dataform.ITable
+  | dataform.IOperation
+  | dataform.IAssertion
+  | dataform.INotebook
+  | dataform.IDataPreparation;
 
 export function prune(
   compiledGraph: dataform.ICompiledGraph,
@@ -20,6 +25,12 @@ export function prune(
     ),
     operations: compiledGraph.operations.filter(action =>
       includedActionNames.has(targetAsReadableString(action.target))
+    ),
+    notebooks: compiledGraph.notebooks.filter(action =>
+      includedActionNames.has(targetAsReadableString(action.target))
+    ),
+    dataPreparations: compiledGraph.dataPreparations.filter(action =>
+      includedActionNames.has(targetAsReadableString(action.target))
     )
   };
 }
@@ -28,11 +39,13 @@ function computeIncludedActionNames(
   compiledGraph: dataform.ICompiledGraph,
   runConfig: dataform.IRunConfig
 ): Set<string> {
-  // Union all tables, operations, assertions.
+  // Union all tables, operations, assertions, notebooks and data preparations.
   const allActions: CompileAction[] = [].concat(
     compiledGraph.tables,
     compiledGraph.operations,
-    compiledGraph.assertions
+    compiledGraph.assertions,
+    compiledGraph.notebooks,
+    compiledGraph.dataPreparations
   );
 
   const allActionNames = new Set<string>(

--- a/tests/api/api.spec.ts
+++ b/tests/api/api.spec.ts
@@ -377,6 +377,98 @@ suite("@dataform/api", () => {
       expect(actionNames).not.includes("schema.b");
       expect(actionNames).not.includes("schema.d");
     });
+
+    // Mirrors a project that registers a notebook and a data preparation with a tag via the
+    // JS API, e.g. notebook({ name: "nb_a", filename: "...", tags: ["tag1"] }), alongside
+    // operations/tables that share the same tag. "tag1" actions depend on an untagged
+    // operation (op_dep) to exercise dependency traversal; "tag2" actions are unrelated.
+    const TEST_GRAPH_WITH_NOTEBOOK_TAGS: dataform.ICompiledGraph = dataform.CompiledGraph.create({
+      projectConfig: { warehouse: "bigquery", defaultLocation: "US" },
+      operations: [
+        {
+          target: { schema: "schema", name: "op_a" },
+          tags: ["tag1"],
+          queries: ["create or replace view schema.someview as select 1 as test"]
+        },
+        {
+          target: { schema: "schema", name: "op_b" },
+          tags: ["tag2"],
+          queries: ["create or replace view schema.someview as select 1 as test"]
+        },
+        {
+          target: { schema: "schema", name: "op_dep" },
+          tags: [],
+          queries: ["create or replace view schema.someview as select 1 as test"]
+        }
+      ],
+      notebooks: [
+        {
+          target: { schema: "schema", name: "nb_a" },
+          tags: ["tag1"],
+          dependencyTargets: [{ schema: "schema", name: "op_dep" }]
+        },
+        {
+          target: { schema: "schema", name: "nb_b" },
+          tags: ["tag2"]
+        }
+      ],
+      dataPreparations: [
+        {
+          target: { schema: "schema", name: "dp_a" },
+          tags: ["tag1"]
+        },
+        {
+          target: { schema: "schema", name: "dp_b" },
+          tags: ["tag2"]
+        }
+      ]
+    });
+
+    const prunedActionNames = (prunedGraph: dataform.ICompiledGraph) => [
+      ...prunedGraph.tables.map(action => targetAsReadableString(action.target)),
+      ...prunedGraph.operations.map(action => targetAsReadableString(action.target)),
+      ...prunedGraph.assertions.map(action => targetAsReadableString(action.target)),
+      ...prunedGraph.notebooks.map(action => targetAsReadableString(action.target)),
+      ...prunedGraph.dataPreparations.map(action => targetAsReadableString(action.target))
+    ];
+
+    test("prune notebooks and data preparations with --tags", () => {
+      const prunedGraph = prune(TEST_GRAPH_WITH_NOTEBOOK_TAGS, {
+        tags: ["tag1"],
+        includeDependencies: false,
+        includeDependents: false
+      });
+      const actionNames = prunedActionNames(prunedGraph);
+
+      // Operations are filtered by tag correctly: the "tag1" operation is kept and the
+      // "tag2" operation is dropped.
+      expect(actionNames).includes("schema.op_a");
+      expect(actionNames).not.includes("schema.op_b");
+
+      // Notebooks behave identically: a notebook tagged "tag1" is selected, and a notebook
+      // tagged "tag2" is dropped.
+      expect(actionNames).includes("schema.nb_a");
+      expect(actionNames).not.includes("schema.nb_b");
+
+      // Data preparations behave identically.
+      expect(actionNames).includes("schema.dp_a");
+      expect(actionNames).not.includes("schema.dp_b");
+    });
+
+    test("prune notebooks with --tags pulls in dependencies", () => {
+      const prunedGraph = prune(TEST_GRAPH_WITH_NOTEBOOK_TAGS, {
+        tags: ["tag1"],
+        includeDependencies: true,
+        includeDependents: false
+      });
+      const actionNames = prunedActionNames(prunedGraph);
+
+      // The tag-selected notebook is included, along with its (untagged) dependency.
+      expect(actionNames).includes("schema.nb_a");
+      expect(actionNames).includes("schema.op_dep");
+      // Unrelated "tag2" actions remain excluded.
+      expect(actionNames).not.includes("schema.nb_b");
+    });
   });
 
   suite("sql_generating", () => {


### PR DESCRIPTION
## Summary

`prune()` (`cli/api/commands/prune.ts`) — the function that turns a compiled graph plus a run config (selected tags/actions) into the set of actions to execute — only considered **tables, operations and assertions**. Notebooks and data preparations were:

- **Excluded from the selection union**, so a `--tags` (or `--actions`) selector could never match them, and dependency/dependent traversal never reached them.
- **Never filtered** in the returned graph — they were carried through the `...compiledGraph` spread unchanged, so they neither got correctly included by tag nor correctly excluded.

Net effect: a notebook registered with a tag via the JS API, e.g.

```js
notebook({
  name: "run_notebook",
  filename: "notebooks/release_reconciliation_diffs.ipynb",
  tags: ["reconciliation"],
  dependencyTargets: [{ name: "release_reconciliation_diffs" }]
})
```

would **not** appear when you "execute by tag" in the CLI or the UI — the tagged notebook was silently dropped from the selected-actions list (e.g. 5 actions shown instead of 6).

The notebook proto itself is fine — `core/actions/notebook.ts` correctly sets `proto.tags`, and `notebook_test.ts` already asserts the tags survive compilation. The defect was purely in the downstream selection step.

This isn't a niche path — tagging notebooks via the JS API is a documented, commonly-used pattern (e.g. this walkthrough: https://gtm-gear.com/posts/dataform-notebooks/).

### Changes

- Add `notebooks` and `dataPreparations` to the `allActions` union in `computeIncludedActionNames`, so tag/action selectors match them and dependency/dependent traversal includes them.
- Filter `notebooks` and `dataPreparations` in the returned graph instead of leaking them through the spread.
- Widen the `CompileAction` type to include `INotebook | IDataPreparation`.

Data preparations had the identical defect (same `tags` + `dependencyTargets` shape, same exclusion), so they're fixed symmetrically.

## Test plan

- [x] Added `prune notebooks and data preparations with --tags` — a `tag1` notebook/dp is selected, a `tag2` one is dropped (matching the operation behavior alongside it).
- [x] Added `prune notebooks with --tags pulls in dependencies` — selecting by a notebook's tag with `includeDependencies` pulls in its untagged dependency.
- [x] `bazel test //tests/api:api.spec` passes (all 6 pre-existing prune tests + 2 new).
- [x] `bazel test //core:actions/notebook_test //core:actions/data_preparation_test` passes.

> **Note (out of scope):** the OSS `Builder` (`cli/api/commands/build.ts`) only turns tables/operations/assertions into executable tasks; notebooks are executed by the managed service, not the OSS CLI runner. This PR fixes **selection** (the pruned graph the UI reads to show "N actions selected for execute"), which is the reported bug.

🤖 Generated with [Claude Code](https://claude.ai/code)
