### PR TITLE
Add optional original_file_path to Assertion protos

### DIFF
--- a/protos/configs.proto
+++ b/protos/configs.proto
@@ -528,6 +528,11 @@ message ActionConfig {
     // If unset, the value from workflow_settings.yaml is used. If neither is set, default BigQuery behavior applies.
     // Dataform CLI only (GCP Dataform support pending).
     string reservation = 11;
+
+    // Optional. Path to the user-visible source declaration for this action,
+    // when distinct from `filename`. If unset, consumers should treat
+    // `filename` as the source.
+    string original_file_path = 12;
   }
 
   message OperationConfig {

--- a/protos/core.proto
+++ b/protos/core.proto
@@ -265,6 +265,11 @@ message Assertion {
   // Generated.
   string file_name = 7;
 
+  // Optional. Path to the user-visible source declaration for this action,
+  // when distinct from `file_name`. If unset, consumers should treat
+  // `file_name` as the source.
+  string original_file_path = 17;
+
   reserved 1, 2, 4, 5, 6;
 }
 

--- a/protos/execution.proto
+++ b/protos/execution.proto
@@ -46,6 +46,11 @@ message ExecutionAction {
 
   string jit_code = 12;
 
+  // Optional. Path to the user-visible source declaration for this action,
+  // when distinct from `file_name`. If unset, consumers should treat
+  // `file_name` as the source.
+  string original_file_path = 13;
+
   reserved 1, 3, 7;
 }
 


### PR DESCRIPTION
Lets callers record a source declaration path distinct from the existing `file_name`/`filename`. When the new field is unset, consumers continue to use `file_name` as today.

Backwards-compatible: additive, optional.