### PR TITLE
Upgrade gcloud to 572.0.0

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -95,7 +95,7 @@
   "moduleExtensions": {
     "//tools/gcloud:extensions.bzl%gcloud_sdk_extension": {
       "general": {
-        "bzlTransitiveDigest": "VrQN9AjKy3YKE3oOI90UXljo6ZU+VuyVKhDJ/6fJnk0=",
+        "bzlTransitiveDigest": "kvgSakWSAojqjpVE9x4s5Cr2/DcTP4DJDorH/EkVOnU=",
         "usagesDigest": "G9567r7BOo4v/0F+Q6wGrEvu7How52VjLhNqFE/f/yk=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},

--- a/tools/gcloud/repository_rules.bzl
+++ b/tools/gcloud/repository_rules.bzl
@@ -14,6 +14,6 @@ def _gcloud_sdk_impl(ctx):
 gcloud_sdk = repository_rule(
     implementation = _gcloud_sdk_impl,
     attrs = {
-        "version": attr.string(default = "412.0.0"),
+        "version": attr.string(default = "572.0.0"),
     },
 )


### PR DESCRIPTION
KMS has an org-policy enabled, requiring the usage of client certificate aware endpoints when performing the decryption of credentials.

Updating gcloud, so that it uses an updated compatible endpoint.