### PR TITLE
Add metadata field to AssertionConfig

### DIFF
--- a/core/actions/assertion.ts
+++ b/core/actions/assertion.ts
@@ -161,6 +161,12 @@ export class Assertion extends ActionBuilder<dataform.Assertion> {
       }
       this.proto.actionDescriptor.reservation = config.reservation;
     }
+    if (config.metadata) {
+      if (!this.proto.actionDescriptor) {
+        this.proto.actionDescriptor = {};
+      }
+      this.proto.actionDescriptor.metadata = config.metadata;
+    }
     return this;
   }
 

--- a/core/actions/assertion_test.ts
+++ b/core/actions/assertion_test.ts
@@ -104,6 +104,14 @@ actions:
   description: "description",
   hermetic: true,
   dependOnDependencyAssertions: true,
+  metadata: {
+      overview: "assertion overview",
+      extraProperties: {
+          fields: {
+              priority: { stringValue: "high" }
+          }
+      }
+  }
 }`;
     [
       {
@@ -147,7 +155,15 @@ SELECT 1`
                 name: "name"
               },
               actionDescriptor: {
-                description: "description"
+                description: "description",
+                metadata: {
+                  overview: "assertion overview",
+                  extraProperties: {
+                    fields: {
+                      priority: { stringValue: "high" }
+                    }
+                  }
+                }
               },
               dependencyTargets: [
                 {

--- a/protos/configs.proto
+++ b/protos/configs.proto
@@ -528,6 +528,9 @@ message ActionConfig {
     // If unset, the value from workflow_settings.yaml is used. If neither is set, default BigQuery behavior applies.
     // Dataform CLI only (GCP Dataform support pending).
     string reservation = 11;
+
+    // Metadata for this assertion.
+    Metadata metadata = 12;
   }
 
   message OperationConfig {


### PR DESCRIPTION
Mirrors TableConfig.metadata / ViewConfig.metadata so callers can attach key/value data that lands on
Assertion.action_descriptor.metadata.extra_properties.