### PR TITLE
support client certificate environment in gcloud actions

### DIFF
--- a/scripts/publish
+++ b/scripts/publish
@@ -18,7 +18,7 @@ fi
 bazel run @nodejs//:yarn config set registry https://us-npm.pkg.dev/artifact-foundry-prod/ah-3p-staging-npm/
 bazel run //tools/registry-tools:switch_registry -- $(pwd)/yarn.lock https://us-npm.pkg.dev/artifact-foundry-prod/npm-3p-trusted/
 bazel run @nodejs//:yarn install -- --frozen-lockfile
-bazel test //... --build_tests_only
+bazel test //... --build_tests_only --action_env=CLOUDSDK_CONTEXT_AWARE_USE_CLIENT_CERTIFICATE
 
 # After the code is build with Airlock dependencies, we change the registry to public npmjs
 # to publish our npm package.

--- a/tools/gcloud/secrets.bzl
+++ b/tools/gcloud/secrets.bzl
@@ -14,6 +14,7 @@ def _gcloud_secret_impl(ctx):
             "--location=%s" % ctx.attr.location,
             "--project=%s" % ctx.attr.project,
         ],
+        use_default_shell_env = True,
         execution_requirements = {
             "local": "1",
         },


### PR DESCRIPTION
- Enable `use_default_shell_env` in `gcloud_secret` rule to pass host environment variables (like `CLOUDSDK_CONTEXT_AWARE_USE_CLIENT_CERTIFICATE`) to the gcloud tool.
- Pass `CLOUDSDK_CONTEXT_AWARE_USE_CLIENT_CERTIFICATE` to bazel test in `scripts/publish`.
-