### PR TITLE
Escape newlines in sqlString so multiline rowConditions produce valid SQL

### DIFF
--- a/core/actions/assertion_test.ts
+++ b/core/actions/assertion_test.ts
@@ -306,6 +306,38 @@ actions:
     );
   });
 
+  test(`multiline rowConditions compile to single-line failing_row_condition literals`, () => {
+    // Regression test for #2201: a multiline rowConditions entry must not produce a
+    // multiline single-quoted string literal, which BigQuery rejects.
+    const projectDir = tmpDirFixture.createNewTmpDir();
+    fs.writeFileSync(path.join(projectDir, "workflow_settings.yaml"), VALID_WORKFLOW_SETTINGS_YAML);
+    fs.mkdirSync(path.join(projectDir, "definitions"));
+    fs.writeFileSync(
+      path.join(projectDir, "definitions/test.sqlx"),
+      `config {
+        type: "table",
+        assertions: {
+          rowConditions: ["a > 0\n  AND b > 0"]
+        }
+      }
+      SELECT 1 AS a, 1 AS b`
+    );
+
+    const result = runMainInVm(coreExecutionRequestFromPath(projectDir));
+
+    expect(result.compile.compiledGraph.graphErrors.compilationErrors).deep.equals([]);
+    const rowConditionsAssertion = result.compile.compiledGraph.assertions.find(
+      assertion => assertion.target.name === "defaultDataset_test_assertions_rowConditions"
+    );
+    // The failing_row_condition string literal has its newline escaped, so the
+    // single-quoted literal stays on one line...
+    expect(rowConditionsAssertion.query).contains(
+      "'a > 0\\n  AND b > 0' AS failing_row_condition"
+    );
+    // ...while the WHERE NOT (...) clause keeps the raw, multiline expression.
+    expect(rowConditionsAssertion.query).contains("WHERE NOT (a > 0\n  AND b > 0)");
+  });
+
   suite("Assertions as dependencies", ({ beforeEach }) => {
     [
       WorkflowSettingsTemplates.bigquery,

--- a/core/compilation_sql/index.ts
+++ b/core/compilation_sql/index.ts
@@ -15,8 +15,17 @@ export class CompilationSql {
   }
 
   public sqlString(stringContents: string) {
-    // Escape escape characters, then escape single quotes, then wrap the string in single quotes.
-    return `'${stringContents.replace(/\\/g, "\\\\").replace(/'/g, "\\'")}'`;
+    // Escape escape characters, then single quotes, then newlines/carriage-returns,
+    // and wrap the string in single quotes. BigQuery single-quoted string literals
+    // cannot span multiple lines, so a raw newline becomes the two-char \n escape
+    // (which parses back to a newline, keeping the literal single-line). Backslash
+    // escaping runs first so the escape sequences introduced here are not themselves
+    // doubled.
+    return `'${stringContents
+      .replace(/\\/g, "\\\\")
+      .replace(/'/g, "\\'")
+      .replace(/\n/g, "\\n")
+      .replace(/\r/g, "\\r")}'`;
   }
 
   public indexAssertion(dataset: string, indexCols: string[]) {


### PR DESCRIPTION
Fixes #2201.

## Problem

A multiline `rowConditions` entry compiles to invalid SQL:

```
config {
  type: "table",
  assertions: {
    rowConditions: [`
      invalidCheck
    `]
  }
}
```

`rowConditionsAssertion` embeds the condition twice: once raw inside `WHERE NOT (...)` (fine — multiline is valid there), and once as a string-literal label via `sqlString(...)`. `sqlString` only escaped backslashes and single quotes, so a raw newline survived into the single-quoted `failing_row_condition` literal — which BigQuery rejects, since single-quoted literals can't span multiple lines.

## Fix

The bug belongs in `sqlString`, not the assertion template — any caller that quotes a multiline string hits it. `sqlString` now also escapes newlines/carriage-returns, turning a raw newline into the two-char `\n` escape (which parses back to a newline, keeping the literal single-line):

```ts
return `'${stringContents
  .replace(/\\/g, "\\\\")
  .replace(/'/g, "\\'")
  .replace(/\n/g, "\\n")
  .replace(/\r/g, "\\r")}'`;
```

Ordering matters: backslash-doubling runs first, otherwise the `\n`/`\r` introduced here would themselves get re-escaped into `\\n`/`\\r` and print a literal backslash-n.

The raw `WHERE NOT (...)` clause is untouched — the multiline expression stays as-authored; only the label literal is normalized:

```sql
SELECT
  'a > 0\n  AND b > 0' AS failing_row_condition,
  *
FROM `project.dataset.test`
WHERE NOT (a > 0
  AND b > 0)
```

**Why escape over triple-quoting** (the issue's other suggestion): escaping reuses the quote-escaping path already in `sqlString`, so one code path handles quotes, backslashes, and newlines uniformly. Triple-quoting would need its own rules for embedded `'''`.

## Test

Added a regression test in `core/actions/assertion_test.ts` that compiles a table with a multiline `rowConditions` entry and asserts the `failing_row_condition` literal stays single-line (escaped `\n`) while the `WHERE NOT (...)` clause keeps the raw, multiline expression.

This was raised in #2201 and a maintainer invited a PR. Happy to adjust style or placement.