### PR TITLE
Preserve Governance Controls in Dataform.

### DIFF
--- a/core/actions/table.ts
+++ b/core/actions/table.ts
@@ -199,6 +199,7 @@ export class Table extends ActionBuilder<dataform.Table> {
       partitionExpirationDays: config.partitionExpirationDays,
       requirePartitionFilter: config.requirePartitionFilter,
       additionalOptions: config.additionalOptions,
+      preserveGovernanceControls: config.preserveGovernanceControls ?? session.projectConfig.preserveGovernanceControls ?? false,
       ...(config.iceberg ? {
         connection: getConnectionForIcebergTable(
           config.iceberg.connection,

--- a/core/main_test.ts
+++ b/core/main_test.ts
@@ -2310,5 +2310,74 @@ publish("name", {type: "${fromType}", schema: "schemaOverride"}).type("${toType}
       expect(result.compile.compiledGraph.graphErrors.compilationErrors[0].message).contains("storing compilation error as requested!");
       expect(result.compile.compiledGraph.targets?.map(t => t.name)).deep.equals(["sample-action", "e", "file"]);
     });
+    
+    test("preserveGovernanceControls propagates to compiled graph", () => {
+      const projectDir = tmpDirFixture.createNewTmpDir();
+      fs.writeFileSync(
+        path.join(projectDir, "workflow_settings.yaml"),
+        VALID_WORKFLOW_SETTINGS_YAML
+      );
+      fs.mkdirSync(path.join(projectDir, "definitions"));
+      fs.writeFileSync(
+        path.join(projectDir, "definitions/file.sqlx"),
+        `
+config {
+  type: "table",
+  preserveGovernanceControls: true
+}
+select 1 as a`
+      );
+      const result = runMainInVm(coreExecutionRequestFromPath(projectDir));
+      expect(result.compile.compiledGraph.graphErrors.compilationErrors).deep.equals([]);
+      expect(result.compile.compiledGraph.tables[0].bigquery.preserveGovernanceControls).equals(true);
+    });
+
+    test("preserveGovernanceControls in workflow_settings.yaml propagates to compiled graph", () => {
+      const projectDir = tmpDirFixture.createNewTmpDir();
+      fs.writeFileSync(
+        path.join(projectDir, "workflow_settings.yaml"),
+        `
+defaultProject: "project"
+defaultDataset: "dataset"
+preserveGovernanceControls: true`
+      );
+      fs.mkdirSync(path.join(projectDir, "definitions"));
+      fs.writeFileSync(
+        path.join(projectDir, "definitions/file.sqlx"),
+        `
+config {
+  type: "table"
+}
+select 1 as a`
+      );
+      const result = runMainInVm(coreExecutionRequestFromPath(projectDir));
+      expect(result.compile.compiledGraph.graphErrors.compilationErrors).deep.equals([]);
+      expect(result.compile.compiledGraph.tables[0].bigquery.preserveGovernanceControls).equals(true);
+    });
+
+    test("preserveGovernanceControls on table overrides workflow_settings.yaml", () => {
+      const projectDir = tmpDirFixture.createNewTmpDir();
+      fs.writeFileSync(
+        path.join(projectDir, "workflow_settings.yaml"),
+        `
+defaultProject: "project"
+defaultDataset: "dataset"
+preserveGovernanceControls: true`
+      );
+      fs.mkdirSync(path.join(projectDir, "definitions"));
+      fs.writeFileSync(
+        path.join(projectDir, "definitions/file.sqlx"),
+        `
+config {
+  type: "table",
+  partitionBy: "somePartition",
+  preserveGovernanceControls: false
+}
+select 1 as a`
+      );
+      const result = runMainInVm(coreExecutionRequestFromPath(projectDir));
+      expect(result.compile.compiledGraph.graphErrors.compilationErrors).deep.equals([]);
+      expect(result.compile.compiledGraph.tables[0].bigquery.preserveGovernanceControls).equals(false);
+    });
   });
 });

--- a/core/workflow_settings.ts
+++ b/core/workflow_settings.ts
@@ -175,7 +175,9 @@ export function workflowSettingsAsProjectConfig(
   if (workflowSettings.includeTestsInCompiledGraph) {
     projectConfig.includeTestsInCompiledGraph = workflowSettings.includeTestsInCompiledGraph;
   }
-
+  if (workflowSettings.preserveGovernanceControls) {
+    projectConfig.preserveGovernanceControls = workflowSettings.preserveGovernanceControls;
+  }
   projectConfig.warehouse = "bigquery";
   return projectConfig;
 }

--- a/protos/configs.proto
+++ b/protos/configs.proto
@@ -67,6 +67,10 @@ message WorkflowSettings {
 
   // Optional. If set to true, unit tests will be included in the compiled graph.
   bool include_tests_in_compiled_graph = 16;
+
+  // Optional. If set to true, governance controls (e.g. Data Policies) will be
+  // preserved on BigQuery tables.
+  bool preserve_governance_controls = 18;
 }
 
 // Action configs defines the contents of `actions.yaml` configuration files.
@@ -262,6 +266,10 @@ message ActionConfig {
     // If unset, the value from workflow_settings.yaml is used. If neither is set, default BigQuery behavior applies.
     // Dataform CLI only (GCP Dataform support pending).
     string reservation = 24;
+
+    // Optional. If true, preserves existing BigQuery column governance controls
+    // (e.g. data policy) when recreating a table.
+    optional bool preserve_governance_controls = 25;
   }
 
   message Metadata {

--- a/protos/core.proto
+++ b/protos/core.proto
@@ -38,6 +38,8 @@ message ProjectConfig {
 
   bool include_tests_in_compiled_graph = 22;
 
+  bool preserve_governance_controls = 24;
+
   reserved 3, 4, 6, 8, 10, 12, 13;
 }
 
@@ -111,6 +113,7 @@ message BigQueryOptions {
   FileFormat file_format = 10;
   string storage_uri = 11;
   repeated string incremental_predicates = 12;
+  bool preserve_governance_controls = 13;
 }
 
 message GraphErrors {


### PR DESCRIPTION
Adding flags to enable preserving governance controls such as Data Policies, and Data Governance Tags during the tables creations.