### PR TITLE
PR1 version bump

### DIFF
--- a/version.bzl
+++ b/version.bzl
@@ -1,1 +1,1 @@
-DF_VERSION = "3.0.59"
+DF_VERSION = "3.0.60"


### PR DESCRIPTION
### Description
Resolves the version.bzl merge conflict when syncing main into dataproc-poc.

### Changes
* Resolved conflict in `version.bzl` by setting `DF_VERSION = "3.0.62-alpha.1"`.