### PR TITLE
Add ignore js flag to format subcommand

### DIFF
--- a/cli/index.ts
+++ b/cli/index.ts
@@ -225,6 +225,15 @@ const icebergOption: INamedOption<yargs.Options> = {
   },
 };
 
+const fmtIgnoreJsOptionName: INamedOption<yargs.Options> = {
+  name: "ignore-js-files",
+  option: {
+    describe: "If set, the formatter will not consider javascript files (.js)",
+    type: "boolean",
+    default: false,
+  },
+};
+
 const testConnectionOptionName = "test-connection";
 
 const watchOptionName = "watch";
@@ -718,7 +727,8 @@ export function runCli() {
           }
         ],
         processFn: async argv => {
-          let actions = ["{definitions,includes}/**/*.{js,sqlx}"];
+          const extensions = argv[fmtIgnoreJsOptionName.name] ? "*.sqlx" : "*.{js,sqlx}"
+          let actions = [`{definitions,includes}/**/${extensions}`];
           if (actionsOption.name in argv && argv[actionsOption.name].length > 0) {
             actions = argv[actionsOption.name];
           }

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -225,6 +225,15 @@ const icebergOption: INamedOption<yargs.Options> = {
   },
 };
 
+const fmtIgnoreJsOption: INamedOption<yargs.Options> = {
+  name: "ignore-js-files",
+  option: {
+    describe: "If set, the formatter will not consider javascript files (.js)",
+    type: "boolean",
+    default: false,
+  },
+};
+
 const testConnectionOptionName = "test-connection";
 
 const watchOptionName = "watch";
@@ -708,6 +717,7 @@ export function runCli() {
         positionalOptions: [projectDirMustExistOption],
         options: [
           actionsOption,
+          fmtIgnoreJsOption,
           {
             name: checkOptionName,
             option: {
@@ -718,7 +728,8 @@ export function runCli() {
           }
         ],
         processFn: async argv => {
-          let actions = ["{definitions,includes}/**/*.{js,sqlx}"];
+          const extensions = argv[fmtIgnoreJsOption.name] ? "*.sqlx" : "*.{js,sqlx}";
+          let actions = [`{definitions,includes}/**/${extensions}`];
           if (actionsOption.name in argv && argv[actionsOption.name].length > 0) {
             actions = argv[actionsOption.name];
           }

--- a/cli/index_help_test.ts
+++ b/cli/index_help_test.ts
@@ -92,5 +92,7 @@ suite("help command", () => {
     expect(output).to.include("--check");
     expect(output).to.include("Check if files are formatted correctly without modifying them.");
     expect(output).to.include("--actions");
+    expect(output).to.include("--ignore-js-files");
+    expect(output).to.include("If set, the formatter will not consider javascript files (.js)");
   });
 });

--- a/cli/index_project_test.ts
+++ b/cli/index_project_test.ts
@@ -125,5 +125,80 @@ SELECT  1  as   test
       expect(afterFormatCheckResult.exitCode).equals(0);
       expect(afterFormatCheckResult.stdout).contains("All files are formatted correctly");
     });
+
+    test("test for format command ignore js files", async () => {
+      const projectDir = tmpDirFixture.createNewTmpDir();
+      const npmCacheDir = tmpDirFixture.createNewTmpDir();
+      const workflowSettingsPath = path.join(projectDir, "workflow_settings.yaml");
+      const packageJsonPath = path.join(projectDir, "package.json");
+
+      // Initialize a project using the CLI, don't install packages.
+      await getProcessResult(
+        execFile(nodePath, [cliEntryPointPath, "init", projectDir, DEFAULT_DATABASE, DEFAULT_LOCATION])
+      );
+
+      // Install packages manually to get around bazel read-only sandbox issues.
+      const workflowSettings = dataform.WorkflowSettings.create(
+        loadYaml(fs.readFileSync(workflowSettingsPath, "utf8"))
+      );
+      delete workflowSettings.dataformCoreVersion;
+      fs.writeFileSync(workflowSettingsPath, dumpYaml(workflowSettings));
+      fs.writeFileSync(
+        packageJsonPath,
+        `{
+  "dependencies":{
+    "@dataform/core": "${version}"
+  }
+}`
+      );
+      await getProcessResult(
+        execFile(npmPath, [
+          "install",
+          "--prefix",
+          projectDir,
+          "--cache",
+          npmCacheDir,
+          corePackageTarPath
+        ])
+      );
+
+      // Create files that need formatting and ensure that the js file is not modified
+      const unformattedFilePath = path.join(projectDir, "definitions", "unformatted.sqlx");
+      fs.ensureFileSync(unformattedFilePath);
+      fs.writeFileSync(
+        unformattedFilePath,
+        `
+config {   type:  "table"   }
+SELECT  1  as   test
+`
+      );
+
+
+      const jsContents = `
+function myCoolFn() {
+  return true; }
+
+modules.exports = {
+  myCoolFn, }
+`
+      const unformattedJsFilePath = path.join(projectDir, "includes", "someMod.js");
+      fs.ensureFileSync(unformattedJsFilePath);
+      fs.writeFileSync(
+        unformattedJsFilePath,
+        jsContents,
+      );
+
+      // Run formatter
+      const formatCmdRun = await getProcessResult(
+        execFile(nodePath, [cliEntryPointPath, "format", "--ignore-js-files", projectDir])
+      );
+
+      expect(formatCmdRun.exitCode).equals(0);
+
+      // Ensure the js file didn't change
+      const bufFromFile = fs.readFileSync(unformattedJsFilePath);
+      const bufFromContents = Buffer.from(jsContents, 'utf-8');
+      expect(bufFromContents.equals(bufFromFile)).equals(true)
+    });
   });
 });


### PR DESCRIPTION
Updated for latest changes (from #1349) 

Allows users to only format `.sqlx` files in case they use different formatters for js files.