### PR TITLE
Support '*' wildcards in --actions selectors as documented (#2224)

### DIFF
--- a/core/utils.ts
+++ b/core/utils.ts
@@ -26,13 +26,25 @@ type actionsWithDependencies =
 export const nativeRequire =
   typeof __webpack_require__ === "function" ? __non_webpack_require__ : require;
 
-// Turn a selector pattern containing '*' wildcards into an anchored RegExp.
-// Every character except '*' is matched literally (regex metacharacters are
-// escaped); each '*' matches any run of characters, so "mrd*" -> /^mrd.*$/ and
+// Turns a selector pattern into an anchored RegExp in which "*" is a wildcard and
+// everything else is literal text, e.g. "mrd*" -> /^mrd.*$/ and
 // "*features*" -> /^.*features.*$/.
+//
+// Splitting on "*" first is what keeps the rest simple: every "*" in a pattern is a
+// wildcard by definition, so the pieces between them are pure literal text and can be
+// escaped wholesale, then rejoined with ".*".
+//
+// The escape is needed because an action name is not regex-safe. Names are
+// dot-separated ("project.dataset.name"), and "." in a regex matches any character, so
+// without escaping "schema.*" would also select "schemaXtable" - see the "literal dot"
+// case in utils_test.ts. The set below is the usual list of JavaScript regex
+// metacharacters with one deliberate omission: "*", which is left out because the split
+// above has already consumed every "*", so none can reach here. ("]" and "\" carry
+// backslashes for the character class's own syntax; "-" and "/" are not metacharacters
+// outside a class and so need no escaping.)
 function globToRegExp(pattern: string): RegExp {
-  const escaped = pattern.replace(/[.*+?^${}()|[\]\\]/g, "\\$&").replace(/\\\*/g, ".*");
-  return new RegExp(`^${escaped}$`);
+  const escapeLiteral = (literal: string) => literal.replace(/[.+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`^${pattern.split("*").map(escapeLiteral).join(".*")}$`);
 }
 
 export function matchPatterns(patterns: string[], values: string[]) {

--- a/core/utils.ts
+++ b/core/utils.ts
@@ -26,10 +26,33 @@ type actionsWithDependencies =
 export const nativeRequire =
   typeof __webpack_require__ === "function" ? __non_webpack_require__ : require;
 
+// Turn a selector pattern containing '*' wildcards into an anchored RegExp.
+// Every character except '*' is matched literally (regex metacharacters are
+// escaped); each '*' matches any run of characters, so "mrd*" -> /^mrd.*$/ and
+// "*features*" -> /^.*features.*$/.
+function globToRegExp(pattern: string): RegExp {
+  const escaped = pattern.replace(/[.*+?^${}()|[\]\\]/g, "\\$&").replace(/\\\*/g, ".*");
+  return new RegExp(`^${escaped}$`);
+}
+
 export function matchPatterns(patterns: string[], values: string[]) {
   const fullyQualifiedActions: string[] = [];
   patterns.forEach(pattern => {
-    if (pattern.includes(".")) {
+    if (pattern.includes("*")) {
+      // Wildcard selector. A pattern that contains "." matches against the
+      // fully-qualified action name; otherwise it matches against the unqualified
+      // name (last segment), mirroring the exact-match branches below. Wildcards
+      // are expected to select many actions, so no ambiguity error applies here.
+      const regExp = globToRegExp(pattern);
+      const scope = pattern.includes(".")
+        ? values
+        : values.map(value => value.split(".").slice(-1)[0]);
+      values.forEach((value, i) => {
+        if (regExp.test(scope[i])) {
+          fullyQualifiedActions.push(value);
+        }
+      });
+    } else if (pattern.includes(".")) {
       if (values.includes(pattern)) {
         fullyQualifiedActions.push(pattern);
       }

--- a/core/utils_test.ts
+++ b/core/utils_test.ts
@@ -6,6 +6,7 @@ import {
   getEffectiveTableFolderSubpath,
   getFileFormatValueForIcebergTable,
   getStorageUriForIcebergTable,
+  matchPatterns,
   validateConnectionFormat,
   validateNoMixedCompilationMode,
   validateStorageUriFormat,
@@ -297,6 +298,69 @@ suite('Dataform Utility Validations', () => {
         () => validateNoMixedCompilationMode(sessionStub, 'filename', 'query', 'where', ['op'], ['op']),
         'Cannot mix AoT and JiT compilation in action. The following AoT properties were found: query, where, postOps, preOps'
       );
+    });
+  });
+
+  suite('matchPatterns', () => {
+    const values = [
+      'schema.mrd_features_inference',
+      'schema.mrd_features_training',
+      'other.customer_orders',
+      'analytics.mrd_summary',
+    ];
+
+    test('exact unqualified name selects the single matching action', () => {
+      expect(matchPatterns(['mrd_features_inference'], values)).to.deep.equal([
+        'schema.mrd_features_inference',
+      ]);
+    });
+
+    test('exact fully-qualified name selects that action', () => {
+      expect(matchPatterns(['other.customer_orders'], values)).to.deep.equal([
+        'other.customer_orders',
+      ]);
+    });
+
+    test('ambiguous unqualified exact name still throws', () => {
+      // Two schemas, same unqualified name.
+      const dupes = ['a.dup', 'b.dup'];
+      expect(() => matchPatterns(['dup'], dupes)).to.throw();
+    });
+
+    test('bare "*" matches every action', () => {
+      expect(matchPatterns(['*'], values)).to.deep.equal(values);
+    });
+
+    test('prefix wildcard matches on the unqualified name', () => {
+      expect(matchPatterns(['mrd*'], values)).to.deep.equal([
+        'schema.mrd_features_inference',
+        'schema.mrd_features_training',
+        'analytics.mrd_summary',
+      ]);
+    });
+
+    test('surrounding wildcards match a substring of the unqualified name', () => {
+      expect(matchPatterns(['*features*'], values)).to.deep.equal([
+        'schema.mrd_features_inference',
+        'schema.mrd_features_training',
+      ]);
+    });
+
+    test('qualified wildcard matches against the fully-qualified name', () => {
+      expect(matchPatterns(['schema.*'], values)).to.deep.equal([
+        'schema.mrd_features_inference',
+        'schema.mrd_features_training',
+      ]);
+    });
+
+    test('wildcard with no matches returns empty (no ambiguity error)', () => {
+      expect(matchPatterns(['nope*'], values)).to.deep.equal([]);
+    });
+
+    test('literal dot in a qualified wildcard is not a regex wildcard', () => {
+      // "schemaXmrd..." must NOT match "schema.*" — the "." is literal.
+      const tricky = ['schema.mrd_a', 'schemaXmrd_b'];
+      expect(matchPatterns(['schema.*'], tricky)).to.deep.equal(['schema.mrd_a']);
     });
   });
 });


### PR DESCRIPTION
Fixes #2224 — following up on https://github.com/dataform-co/dataform/issues/2224#issuecomment-5079116804 ("Feel free to send a PR :)").

## Problem

The `--actions` help text for `run` and `compile` says patterns "can include '*' wildcards", but `matchPatterns` in `core/utils.ts` does plain string equality only, so no wildcard pattern ever matches — `dataform run --actions "*"` reports `No actions to run.` even when the compiled graph has actions.

## Fix

Wildcard patterns are compiled to an anchored `RegExp`:

- every non-`*` character matches literally (regex metacharacters are escaped, so `.` stays a literal dot);
- each `*` matches any run of characters (`mrd*` → `/^mrd.*$/`, `*features*` → `/^.*features.*$/`).

Scoping mirrors the existing exact-match branches: a pattern containing `.` matches against the fully-qualified action name; otherwise it matches against the unqualified last segment. Wildcard matches bypass the ambiguous-name error since selecting many actions is the intent. Exact (non-wildcard) selection behavior is completely unchanged.

## Tests

Adds a `matchPatterns` suite to `core/utils_test.ts` (the function was previously untested) covering: exact unqualified/qualified selection, the ambiguity error, bare `*`, prefix and substring wildcards, qualified wildcards (`schema.*`), no-match returning empty, and the literal-dot escaping edge case.

Understood that GCP Dataform's hosted actions filter doesn't use this implementation — this change only brings the open-source CLI in line with its own documented behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0171FwKo8gRQQ35VoYDtSHNU
