### PR TITLE
feat(core): add lineage.enabled to WorkflowSettings and ProjectConfig

### DIFF
--- a/core/BUILD
+++ b/core/BUILD
@@ -81,6 +81,7 @@ ts_test_suite(
         "jit_context_test.ts",
         "main_test.ts",
         "utils_test.ts",
+        "workflow_settings_test.ts",
     ],
     data = [
         ":node_modules",

--- a/core/workflow_settings.ts
+++ b/core/workflow_settings.ts
@@ -178,6 +178,9 @@ export function workflowSettingsAsProjectConfig(
   if (workflowSettings.preserveGovernanceControls) {
     projectConfig.preserveGovernanceControls = workflowSettings.preserveGovernanceControls;
   }
+  if (workflowSettings.lineage) {
+    projectConfig.lineageEnabled = workflowSettings.lineage.enabled;
+  }
   projectConfig.warehouse = "bigquery";
   return projectConfig;
 }

--- a/core/workflow_settings_test.ts
+++ b/core/workflow_settings_test.ts
@@ -1,0 +1,35 @@
+import { expect } from "chai";
+
+import { workflowSettingsAsProjectConfig } from "df/core/workflow_settings";
+import { dataform } from "df/protos/ts";
+import { suite, test } from "df/testing";
+
+suite("workflowSettingsAsProjectConfig", () => {
+  test("sets lineageEnabled when workflow settings enable lineage", () => {
+    const workflowSettings = dataform.WorkflowSettings.create({
+      lineage: { enabled: true },
+    });
+
+    const projectConfig = workflowSettingsAsProjectConfig(workflowSettings);
+
+    expect(projectConfig.lineageEnabled).to.equal(true);
+  });
+
+  test("leaves lineageEnabled unset when workflow settings omit lineage", () => {
+    const workflowSettings = dataform.WorkflowSettings.create({});
+
+    const projectConfig = workflowSettingsAsProjectConfig(workflowSettings);
+
+    expect(projectConfig.lineageEnabled).to.equal(null);
+  });
+
+  test("sets lineageEnabled to false when lineage.enabled is explicitly false", () => {
+    const workflowSettings = dataform.WorkflowSettings.create({
+      lineage: { enabled: false },
+    });
+
+    const projectConfig = workflowSettingsAsProjectConfig(workflowSettings);
+
+    expect(projectConfig.lineageEnabled).to.equal(false);
+  });
+});

--- a/protos/configs.proto
+++ b/protos/configs.proto
@@ -71,6 +71,16 @@ message WorkflowSettings {
   // Optional. If set to true, governance controls (e.g. Data Policies) will be
   // preserved on BigQuery tables.
   bool preserve_governance_controls = 18;
+
+  // Optional. Configuration for Knowledge Catalog lineage emission.
+  LineageSettings lineage = 19;
+}
+
+// Configuration for Knowledge Catalog lineage emission.
+message LineageSettings {
+  // If true, downstream runners will emit OpenLineage events to Knowledge
+  // Catalog for actions executed from this project.
+  bool enabled = 1;
 }
 
 // Action configs defines the contents of `actions.yaml` configuration files.

--- a/protos/core.proto
+++ b/protos/core.proto
@@ -40,6 +40,8 @@ message ProjectConfig {
 
   bool preserve_governance_controls = 24;
 
+  optional bool lineage_enabled = 25;
+
   reserved 3, 4, 6, 8, 10, 12, 13;
 }
 


### PR DESCRIPTION
Introduces `LineageSettings { bool enabled }` and threads it through `WorkflowSettings` (yaml opt-in) into `ProjectConfig` (compiled graph) so downstream Dataform runners can decide whether to emit OpenLineage events to Knowledge Catalog (datalineage.googleapis.com) after each action completes.

Config plumbing only — no emission logic is added in this change.