### PR TITLE
Fix incremental table compilation failing on metadata.extraProperties

### DIFF
--- a/common/protos/index.ts
+++ b/common/protos/index.ts
@@ -32,8 +32,10 @@ const Struct = google.protobuf.Struct;
 
 // Save references to the original generated methods
 const originalVerify = Struct.verify;
+const originalFromObject = Struct.fromObject;
 
-export function verifyStruct(this: any, object: any) {
+// Monkey Patching Methods
+Struct.verify = function (object: any) {
   if (object && typeof object === "object" && !("fields" in object)) {
     const fields: { [key: string]: any } = {};
     for (const [k, v] of Object.entries(object)) {
@@ -43,10 +45,19 @@ export function verifyStruct(this: any, object: any) {
     object.fields = fields;
   }
   return originalVerify.call(this, object);
-}
+};
 
-// Monkey Patching Methods
-Struct.verify = verifyStruct;
+Struct.fromObject = function (object: any) {
+  if (object && typeof object === "object" && !("fields" in object)) {
+    const fields: { [key: string]: any } = {};
+    for (const [k, v] of Object.entries(object)) {
+      fields[k] = unknownToValueShallow(v);
+    }
+    Object.keys(object).forEach(key => delete object[key]);
+    object.fields = fields;
+  }
+  return originalFromObject.call(this, object);
+};
 
 // This is a minimalist Typescript equivalent for the validation part of Profobuf's JsonFormat's
 // mergeMessage method:
@@ -65,8 +76,12 @@ export function verifyObjectMatchesProto<Proto>(
     throw ReferenceError(`Expected a top-level object, but found an array`);
   }
 
-  // Calling toObject on the object/JSON creates a version only contains the valid proto fields.
-  protoType.verify(object);
+  // Calling fromObject on the object/JSON triggers Struct.fromObject to format Struct plain objects.
+  try {
+    protoType.fromObject(object);
+  } catch {
+    // fromObject may throw TypeError on invalid field types. Ignore it and let checkFields throw formatted ReferenceError.
+  }
   const proto = protoType.create(object);
   const protoCastObject = protoType.toObject(proto);
 

--- a/common/protos/index.ts
+++ b/common/protos/index.ts
@@ -33,8 +33,7 @@ const Struct = google.protobuf.Struct;
 // Save references to the original generated methods
 const originalVerify = Struct.verify;
 
-// Monkey Patching Methods
-Struct.verify = function (object: any) {
+export function verifyStruct(this: any, object: any) {
   if (object && typeof object === "object" && !("fields" in object)) {
     const fields: { [key: string]: any } = {};
     for (const [k, v] of Object.entries(object)) {
@@ -44,7 +43,10 @@ Struct.verify = function (object: any) {
     object.fields = fields;
   }
   return originalVerify.call(this, object);
-};
+}
+
+// Monkey Patching Methods
+Struct.verify = verifyStruct;
 
 // This is a minimalist Typescript equivalent for the validation part of Profobuf's JsonFormat's
 // mergeMessage method:

--- a/core/actions/assertion_test.ts
+++ b/core/actions/assertion_test.ts
@@ -183,6 +183,40 @@ SELECT 1`
       });
     });
 
+    test("assertions can be configured with a plain object for extraProperties", () => {
+      const projectDir = tmpDirFixture.createNewTmpDir();
+      fs.writeFileSync(
+        path.join(projectDir, "workflow_settings.yaml"),
+        VALID_WORKFLOW_SETTINGS_YAML
+      );
+      fs.mkdirSync(path.join(projectDir, "definitions"));
+      fs.writeFileSync(
+        path.join(projectDir, "definitions/assertion.sqlx"),
+        `config {
+    type: "assertion",
+    metadata: {
+        extraProperties: {
+            priority: "high"
+        }
+    }
+}
+SELECT 1`
+      );
+
+      const result = runMainInVm(coreExecutionRequestFromPath(projectDir));
+
+      expect(result.compile.compiledGraph.graphErrors.compilationErrors).deep.equals([]);
+      expect(
+        asPlainObject(result.compile.compiledGraph.assertions[0].actionDescriptor.metadata)
+      ).deep.equals({
+        extraProperties: {
+          fields: {
+            priority: { stringValue: "high" }
+          }
+        }
+      });
+    });
+
     ["table", "view", "incremental"].forEach(tableType => {
       [`"fieldValue"`, `["fieldValue"]`].forEach(uniqueKeyField => {
         test(`for ${tableType} built-in assertions uniqueKey with value ${uniqueKeyField}`, () => {

--- a/core/actions/incremental_table.ts
+++ b/core/actions/incremental_table.ts
@@ -1,4 +1,4 @@
-import { verifyObjectMatchesProto, VerifyProtoErrorBehaviour, verifyStruct } from "df/common/protos";
+import { verifyObjectMatchesProto, VerifyProtoErrorBehaviour } from "df/common/protos";
 import {
   ActionBuilder,
   checkConfigAdditionalOptionsOverlap,
@@ -690,12 +690,6 @@ export class IncrementalTable extends ActionBuilder<dataform.Table> {
           `Unexpected file format; only "PARQUET" is allowed, got "${unverifiedConfig.iceberg.fileFormat}".`
         );
       }
-    }
-
-    // Since IncrementalTableConfig.metadata.extraProperties expects IMetadata,
-    // we will normalize the expression into google.protobuf.IStruct here.
-    if (unverifiedConfig.metadata?.extraProperties) {
-      verifyStruct(unverifiedConfig.metadata.extraProperties);
     }
 
     const config = verifyObjectMatchesProto(

--- a/core/actions/incremental_table.ts
+++ b/core/actions/incremental_table.ts
@@ -1,4 +1,4 @@
-import { verifyObjectMatchesProto, VerifyProtoErrorBehaviour } from "df/common/protos";
+import { verifyObjectMatchesProto, VerifyProtoErrorBehaviour, verifyStruct } from "df/common/protos";
 import {
   ActionBuilder,
   checkConfigAdditionalOptionsOverlap,
@@ -690,6 +690,12 @@ export class IncrementalTable extends ActionBuilder<dataform.Table> {
           `Unexpected file format; only "PARQUET" is allowed, got "${unverifiedConfig.iceberg.fileFormat}".`
         );
       }
+    }
+
+    // Since IncrementalTableConfig.metadata.extraProperties expects IMetadata,
+    // we will normalize the expression into google.protobuf.IStruct here.
+    if (unverifiedConfig.metadata?.extraProperties) {
+      verifyStruct(unverifiedConfig.metadata.extraProperties);
     }
 
     const config = verifyObjectMatchesProto(

--- a/core/actions/incremental_table_test.ts
+++ b/core/actions/incremental_table_test.ts
@@ -219,7 +219,7 @@ config {
   onSchemaChange: "IGNORE",
   metadata: {
     extraProperties: {
-      myField: "example"
+      priority: "high"
     }
   }
 }
@@ -265,7 +265,7 @@ SELECT 1`;
             metadata: {
               extraProperties: {
                 fields: {
-                  myField: { stringValue: "example" }
+                  priority: { stringValue: "high" }
                 }
               }
             }

--- a/core/actions/incremental_table_test.ts
+++ b/core/actions/incremental_table_test.ts
@@ -211,6 +211,69 @@ SELECT 1`
       });
     });
 
+    test("onSchemaChange combined with metadata.extraProperties as a plain object", () => {
+      const tableName = "on_schema_change_with_metadata";
+      const tableContent = `
+config {
+  type: "incremental",
+  onSchemaChange: "IGNORE",
+  metadata: {
+    extraProperties: {
+      myField: "example"
+    }
+  }
+}
+
+SELECT 1`;
+      const projectDir = tmpDirFixture.createNewTmpDir();
+      fs.writeFileSync(
+        path.join(projectDir, "workflow_settings.yaml"),
+        VALID_WORKFLOW_SETTINGS_YAML
+      );
+      fs.mkdirSync(path.join(projectDir, "definitions"));
+      fs.writeFileSync(
+        path.join(projectDir, `definitions/${tableName}.sqlx`),
+        tableContent
+      );
+
+      const result = runMainInVm(coreExecutionRequestFromPath(projectDir));
+
+      expect(result.compile.compiledGraph.graphErrors.compilationErrors).deep.equals([]);
+      expect(asPlainObject(result.compile.compiledGraph.tables)).deep.equals([
+        {
+          target: {
+            database: "defaultProject",
+            schema: "defaultDataset",
+            name: tableName
+          },
+          canonicalTarget: {
+            database: "defaultProject",
+            schema: "defaultDataset",
+            name: tableName
+          },
+          type: "incremental",
+          disabled: false,
+          protected: false,
+          hermeticity: "NON_HERMETIC",
+          onSchemaChange: "IGNORE",
+          enumType: "INCREMENTAL",
+          fileName: `definitions/${tableName}.sqlx`,
+          query: "\n\n\nSELECT 1",
+          incrementalQuery: "\n\n\nSELECT 1",
+          incrementalStrategy: "INCREMENTAL_STRATEGY_UNSPECIFIED",
+          actionDescriptor: {
+            metadata: {
+              extraProperties: {
+                fields: {
+                  myField: { stringValue: "example" }
+                }
+              }
+            }
+          }
+        }
+      ]);
+    });
+
     test("sqlx minimal config", () => {
       const minimalIncrementalTableName = "minimal_incremental";
       const minimalIncrementalTableContent = `

--- a/core/actions/view_test.ts
+++ b/core/actions/view_test.ts
@@ -187,6 +187,40 @@ SELECT 1`
         );
       });
     });
+
+    test("views can be configured with a plain object for extraProperties", () => {
+      const projectDir = tmpDirFixture.createNewTmpDir();
+      fs.writeFileSync(
+        path.join(projectDir, "workflow_settings.yaml"),
+        VALID_WORKFLOW_SETTINGS_YAML
+      );
+      fs.mkdirSync(path.join(projectDir, "definitions"));
+      fs.writeFileSync(
+        path.join(projectDir, "definitions/view.sqlx"),
+        `config {
+    type: "view",
+    metadata: {
+        extraProperties: {
+            priority: "high"
+        }
+    }
+}
+SELECT 1`
+      );
+
+      const result = runMainInVm(coreExecutionRequestFromPath(projectDir));
+
+      expect(result.compile.compiledGraph.graphErrors.compilationErrors).deep.equals([]);
+      expect(
+        asPlainObject(result.compile.compiledGraph.tables[0].actionDescriptor.metadata)
+      ).deep.equals({
+        extraProperties: {
+          fields: {
+            priority: { stringValue: "high" }
+          }
+        }
+      });
+    });
   });
 
   test("action config options", () => {


### PR DESCRIPTION
## Example

This fails to compile:
```js
config {
  type: "incremental",
  onSchemaChange: "IGNORE",
  metadata: {
    extraProperties: {
      myField: "example"
    }
  }
}

SELECT 1
// -> Unexpected property "myField", or property value type of "string" is incorrect.
```

## Cause

verifyObjectMatchesProto(protoType, object) in common/protos/index.ts:

```js
const proto = protoType.create(object);          // shallow copy, no type conversion
const protoCastObject = protoType.toObject(proto);
checkFields(object, protoCastObject);             // throws on typeof mismatch at any key
```

`create()` copies extraProperties as-is, without converting it to the Struct format.
`toObject()` then can't read it as a Struct, so `protoCastObject` ends up with an empty extraProperties.
`checkFields` finds `myField` present in the raw object but missing from the round-tripped one, and throws.

## Fix

Convert metadata.extraProperties into the Struct wire format in IncrementalTable.verifyConfig(), before calling verifyObjectMatchesProto, so both sides of the comparison already have matching shapes.
The conversion logic already existed; it is extracted into a named, exported function and incremental_table.ts call it directly.

## Test

- Added a test in core/actions/incremental_table_test.ts covering the example above.
- `bazel test $(bazel query 'kind(test, //core/...)')` passed.

Related: https://github.com/dataform-co/dataform/pull/2119