### PR TITLE
Bump DF_VERSION from 3.0.63 to 3.0.64

### DIFF
--- a/version.bzl
+++ b/version.bzl
@@ -1,1 +1,1 @@
-DF_VERSION = "3.0.63"
+DF_VERSION = "3.0.64"


### PR DESCRIPTION
Bumps the npm package version so `@dataform/core` to release `lineage.enabled` on `WorkflowSettings` / `ProjectConfig` (#2235) and JiT compilation integration (#2211).