### PR TITLE
Add proto surface for PropertyGraph action

### DIFF
--- a/protos/BUILD
+++ b/protos/BUILD
@@ -14,6 +14,7 @@ proto_library(
         "jit.proto",
         "profiles.proto",
         "extension.proto",
+        "property_graph_config.proto",
     ],
     strip_import_prefix = "/protos",
     deps = [

--- a/protos/configs.proto
+++ b/protos/configs.proto
@@ -10,6 +10,7 @@ option go_package = "github.com/dataform-co/dataform/protos/dataform";
 
 import "google/protobuf/struct.proto";
 import "extension.proto";
+import "property_graph_config.proto";
 
 // Workflow Settings defines the contents of the `workflow_settings.yaml`
 // configuration file.
@@ -715,6 +716,7 @@ message ActionConfig {
     DeclarationConfig declaration = 6;
     NotebookConfig notebook = 7;
     DataPreparationConfig data_preparation = 8;
+    PropertyGraphConfig property_graph = 9;
   }
 
   message LoadModeConfig {

--- a/protos/core.proto
+++ b/protos/core.proto
@@ -438,6 +438,55 @@ message MergeLoadMode {
   repeated string unique_key = 1;
 }
 
+message PropertyGraph {
+  Target target = 1;
+  Target canonical_target = 2;
+  repeated Target dependency_targets = 3;
+  string file_name = 4;
+  string description = 5;
+  repeated GraphEntity entities = 6;
+  repeated GraphRelationship relationships = 7;
+  string graph_body = 8;
+}
+
+message GraphEntity {
+  string name = 1;
+  Target data_source = 2;
+  repeated string keys = 3;
+  repeated GraphLabel labels = 4;
+}
+
+message GraphRelationship {
+  string name = 1;
+  Target data_source = 2;
+  repeated string keys = 3;
+  GraphEndpoint source = 4;
+  GraphEndpoint destination = 5;
+  repeated GraphLabel labels = 6;
+}
+
+message GraphLabel {
+  string name = 1;
+  string description = 2;
+  repeated string synonyms = 3;
+  repeated GraphField fields = 4;
+  bool import_all = 5;
+  repeated string import_except = 6;
+}
+
+message GraphField {
+  string name = 1;
+  string expression = 2;
+  string description = 3;
+  repeated string synonyms = 4;
+}
+
+message GraphEndpoint {
+  string entity = 1;
+  repeated string relationship_columns = 2;
+  repeated string entity_columns = 3;
+}
+
 message CompiledGraph {
   ProjectConfig project_config = 4;
 
@@ -450,6 +499,7 @@ message CompiledGraph {
   repeated Test tests = 8;
   repeated Notebook notebooks = 12;
   repeated DataPreparation data_preparations = 13;
+  repeated PropertyGraph property_graphs = 16;
 
   GraphErrors graph_errors = 7;
 

--- a/protos/property_graph_config.proto
+++ b/protos/property_graph_config.proto
@@ -1,0 +1,105 @@
+syntax = "proto3";
+
+package dataform;
+
+option java_package = "com.dataform.protos";
+option java_outer_classname = "PropertyGraphConfigMeta";
+option java_multiple_files = true;
+
+option go_package = "github.com/dataform-co/dataform/protos/dataform";
+
+message PropertyGraphConfig {
+  string name = 1;
+  string description = 2;
+  TargetDataset target_dataset = 3;
+  repeated GraphEntityConfig entities = 4;
+  repeated GraphRelationshipConfig relationships = 5;
+
+  message TargetDataset {
+    string project_id = 1;
+    string dataset_id = 2;
+  }
+}
+
+message GraphEntityConfig {
+  string name = 1;
+  oneof data_source {
+    string data_source_string = 2;
+    DatasetDataSource data_source_dataset = 3;
+    CatalogDataSource data_source_catalog = 4;
+    GraphRef data_source_ref = 11;
+  }
+  repeated string keys = 5;
+  string description = 6;
+  repeated string synonyms = 7;
+  repeated GraphFieldConfig fields = 8;
+  GraphFieldWildcard field_wildcard = 9;
+  repeated GraphLabelConfig labels = 10;
+}
+
+message GraphRelationshipConfig {
+  string name = 1;
+  oneof data_source {
+    string data_source_string = 2;
+    DatasetDataSource data_source_dataset = 3;
+    CatalogDataSource data_source_catalog = 4;
+    GraphRef data_source_ref = 13;
+  }
+  repeated string keys = 5;
+  string description = 6;
+  repeated string synonyms = 7;
+  GraphEndpointConfig source = 8;
+  GraphEndpointConfig destination = 9;
+  repeated GraphFieldConfig fields = 10;
+  GraphFieldWildcard field_wildcard = 11;
+  repeated GraphLabelConfig labels = 12;
+}
+
+message GraphLabelConfig {
+  string name = 1;
+  string description = 2;
+  repeated string synonyms = 3;
+  repeated GraphFieldConfig fields = 4;
+  GraphFieldWildcard field_wildcard = 5;
+}
+
+message GraphFieldConfig {
+  string name = 1;
+  string expression = 2;
+  string description = 3;
+  repeated string synonyms = 4;
+}
+
+message GraphFieldWildcard {
+  bool import_all = 1;
+  repeated string except = 2;
+}
+
+message GraphEndpointConfig {
+  string entity = 1;
+  GraphJoinKeysConfig join_keys = 2;
+}
+
+message GraphJoinKeysConfig {
+  repeated string relationship_columns = 1;
+  repeated string entity_columns = 2;
+}
+
+message DatasetDataSource {
+  string project = 1;
+  string dataset = 2;
+  string table = 3;
+}
+
+message CatalogDataSource {
+  string project = 1;
+  string catalog = 2;
+  string namespace = 3;
+  string table = 4;
+}
+
+message GraphRef {
+  string name = 1;
+  string schema = 2;
+  string database = 3;
+}


### PR DESCRIPTION
Introduces config- and compiled-form protos for BigQuery Property Graphs.

- protos/property_graph_config.proto (new): PropertyGraphConfig and children, plus DatasetDataSource / CatalogDataSource / GraphRef variants for data_source. GraphRef lets an entity or relationship reference another Dataform action by name (with optional schema and database) instead of a fully qualified BigQuery table.
- protos/configs.proto: import property_graph_config.proto and add PropertyGraphConfig to ActionConfig.action.
- protos/core.proto: PropertyGraph and children. Wire repeated PropertyGraph property_graphs = 16 on CompiledGraph.
- protos/BUILD: include property_graph_config.proto in dataform_proto.

Config and compiled types are decoupled. Only core/actions/property_graph.ts will bridge them.