### PR TITLE
feat(lineage): emit OpenLineage RunEvents from CLI to Knowledge Catalog Lineage

### DIFF
--- a/cli/api/BUILD
+++ b/cli/api/BUILD
@@ -10,6 +10,7 @@ ts_library(
         ["**/*.ts"],
         exclude = [
             "utils/**/*.*",
+            "lineage/testing/**/*.*",
             "**/*_test.ts",
         ],
     ),
@@ -27,6 +28,7 @@ ts_library(
         "//sqlx:lexer",
         "//cli/vm:vm",
         "@npm//@google-cloud/bigquery",
+        "@npm//@google-cloud/lineage",
         "@npm//@types/fs-extra",
         "@npm//@types/glob",
         "@npm//@types/js-beautify",
@@ -63,6 +65,10 @@ ts_test_suite(
         "commands/jit/rpc_test.ts",
         "dbadapters/bigquery_test.ts",
         "execution_sql_test.ts",
+        "lineage/emitter_factory_test.ts",
+        "lineage/emitter_test.ts",
+        "lineage/lineage_integration_test.ts",
+        "lineage/payload_builder_test.ts",
     ],
     data = [
         ":node_modules",
@@ -72,10 +78,12 @@ ts_test_suite(
     ] + glob(["goldens/**"]),
     deps = [
         ":api",
+        "//cli/api/lineage/testing",
         "//core",
         "//protos:ts",
         "//testing",
         "@npm//@google-cloud/bigquery",
+        "@npm//@google-cloud/lineage",
         "@npm//@types/chai",
         "@npm//@types/fs-extra",
         "@npm//@types/js-yaml",
@@ -84,6 +92,7 @@ ts_test_suite(
         "@npm//chai",
         "@npm//fs-extra",
         "@npm//js-yaml",
+        "@npm//long",
         "@npm//ts-mockito",
     ],
 )

--- a/cli/api/commands/run.ts
+++ b/cli/api/commands/run.ts
@@ -5,6 +5,7 @@ import { JitCompileChildProcess } from "df/cli/api/commands/jit/compiler";
 import * as dbadapters from "df/cli/api/dbadapters";
 import { IBigQueryExecutionOptions } from "df/cli/api/dbadapters/bigquery";
 import { ExecutionSql } from "df/cli/api/dbadapters/execution_sql";
+import { LineageEmitter } from "df/cli/api/lineage/emitter";
 import { Flags } from "df/common/flags";
 import { retry } from "df/common/promises";
 import { deepClone, equals } from "df/common/protos";
@@ -43,6 +44,7 @@ export interface IExecutionOptions {
     options?: IBigQueryExecutionOptions,
     onCancel?: (cancel: () => void) => void
   ) => Promise<dataform.IJitCompilationResponse>;
+  lineageEmitter?: LineageEmitter;
 }
 
 export type CancelReason = "timeout" | "user" | "cancellation";
@@ -412,6 +414,9 @@ export class Runner {
     actionResult.status = dataform.ActionResult.ExecutionStatus.RUNNING;
     const timer = Timer.start(resumedActionResult?.timing);
     actionResult.timing = timer.current();
+    if (this.executionOptions.lineageEmitter) {
+      this.executionOptions.lineageEmitter.emitForAction(action, actionResult);
+    }
     this.notifyListeners();
 
     if (action.jitCode) {
@@ -423,6 +428,11 @@ export class Runner {
           status: dataform.TaskResult.ExecutionStatus.FAILED,
           errorMessage: `JiT compilation error: ${e?.message || String(e)}`
         });
+        actionResult.timing = timer.end();
+        if (this.executionOptions.lineageEmitter) {
+          this.executionOptions.lineageEmitter.emitForAction(action, actionResult);
+        }
+        this.notifyListeners();
         return actionResult;
       }
     }
@@ -500,6 +510,9 @@ export class Runner {
     }
 
     actionResult.timing = timer.end();
+    if (this.executionOptions.lineageEmitter) {
+      this.executionOptions.lineageEmitter.emitForAction(action, actionResult);
+    }
     this.notifyListeners();
     return actionResult;
   }

--- a/cli/api/lineage/emitter.ts
+++ b/cli/api/lineage/emitter.ts
@@ -1,0 +1,140 @@
+import { LineageClient } from "@google-cloud/lineage";
+
+import { LineagePayloadBuilder, toProtoStruct } from "df/cli/api/lineage/payload_builder";
+import { coerceAsError } from "df/common/errors/errors";
+import { dataform } from "df/protos/ts";
+
+const GLOBAL_LINEAGE_ENDPOINT = "datalineage.googleapis.com";
+
+export interface IEmitterOptions {
+  lineageEnabled?: boolean;
+  dryRun?: boolean;
+  projectDir?: string;
+}
+
+/**
+ * Minimal writable stream shape used for stderr output. Injectable so tests can
+ * capture emitted skip-reason lines deterministically.
+ */
+export interface IStderrLike {
+  write(msg: string): unknown;
+}
+
+export type LineageClientProvider = (projectId: string, endpoint: string) => LineageClient;
+
+export function createLineageClientProvider(
+  credentials: dataform.IBigQuery
+): LineageClientProvider {
+  const clients = new Map<string, LineageClient>();
+  return (projectId: string, endpoint: string) => {
+    const targetProjectId = projectId || credentials.projectId;
+    const cacheKey = `${targetProjectId}::${endpoint}`;
+    if (!clients.has(cacheKey)) {
+      clients.set(
+        cacheKey,
+        new LineageClient({
+          projectId: targetProjectId,
+          apiEndpoint: endpoint,
+          credentials: credentials.credentials && JSON.parse(credentials.credentials)
+        })
+      );
+    }
+    return clients.get(cacheKey);
+  };
+}
+
+export class LineageEmitter {
+  private readonly clientProvider: LineageClientProvider;
+  private readonly credentials: dataform.IBigQuery;
+  private readonly emitterOptions: IEmitterOptions;
+  private readonly stderr: IStderrLike;
+  private readonly payloadBuilder: LineagePayloadBuilder;
+  private readonly pending = new Set<Promise<void>>();
+  private emissionDisabledThisRun = false;
+  private dryRunSkipLogged = false;
+
+  constructor(
+    credentials: dataform.IBigQuery,
+    emitterOptions: IEmitterOptions,
+    clientProvider?: LineageClientProvider,
+    stderr: IStderrLike = process.stderr
+  ) {
+    this.credentials = credentials;
+    this.emitterOptions = emitterOptions;
+    this.stderr = stderr;
+    this.clientProvider = clientProvider || createLineageClientProvider(credentials);
+    this.payloadBuilder = new LineagePayloadBuilder(emitterOptions.projectDir);
+  }
+
+  public emitForAction(
+    action: dataform.IExecutionAction,
+    actionResult: dataform.IActionResult
+  ): void {
+    if (this.emissionDisabledThisRun) {
+      return;
+    }
+
+    if (this.emitterOptions.dryRun) {
+      if (!this.dryRunSkipLogged) {
+        this.stderr.write(
+          "[lineage] Skipped lineage emission (dry-run mode; once-per-run): skip_reason=dry_run\n"
+        );
+        this.dryRunSkipLogged = true;
+      }
+      return;
+    }
+
+    // Non-table/non-operation actions (e.g., assertions, declarations) are not
+    // emitted. This is a scope decision, not a user-visible misconfiguration,
+    // so it is intentionally silent.
+    const isEligibleType = action.type === "table" || action.type === "operation";
+    if (!isEligibleType) {
+      return;
+    }
+
+    const p = this.emitForActionInternal(action, actionResult)
+      .catch(e => {
+        const err = coerceAsError(e);
+        this.emissionDisabledThisRun = true;
+        this.stderr.write(
+          `[lineage] Failed to emit lineage for action ${action.target.schema}.${action.target.name}: ${err.message}\n`
+        );
+      })
+      .finally(() => {
+        this.pending.delete(p);
+      });
+    this.pending.add(p);
+  }
+
+  public async drain(maxWaitMs = 15000): Promise<void> {
+    if (this.pending.size === 0) {
+      return;
+    }
+    await Promise.race([
+      Promise.allSettled([...this.pending]),
+      new Promise<void>(resolve => setTimeout(resolve, maxWaitMs))
+    ]);
+  }
+
+  private async emitForActionInternal(
+    action: dataform.IExecutionAction,
+    actionResult: dataform.IActionResult
+  ): Promise<void> {
+    const projectId = action.target.database || this.credentials.projectId;
+    const location = (this.credentials.location || "US").toLowerCase();
+    const parent = `projects/${projectId}/locations/${location}`;
+
+    const openLineagePayload = this.payloadBuilder.build(
+      action,
+      actionResult,
+      projectId,
+      location
+    );
+
+    const client = this.clientProvider(projectId, GLOBAL_LINEAGE_ENDPOINT);
+    await client.processOpenLineageRunEvent({
+      parent,
+      openLineage: toProtoStruct(openLineagePayload) as any
+    });
+  }
+}

--- a/cli/api/lineage/emitter_factory.ts
+++ b/cli/api/lineage/emitter_factory.ts
@@ -1,0 +1,61 @@
+import { IEmitterOptions, IStderrLike, LineageClientProvider, LineageEmitter } from "df/cli/api/lineage/emitter";
+import { dataform } from "df/protos/ts";
+
+/**
+ * Structured input for {@link createLineageEmitter}. Prefer this over passing
+ * yargs argv + executionGraph directly so the factory stays independent of
+ * yargs and easy to unit-test.
+ */
+export interface ILineageEmitterFactoryInput {
+  /** Value of --emit-lineage CLI flag. `undefined` means the flag was not passed. */
+  cliEmitLineage: boolean | undefined;
+  /** Value of workflow_settings.yaml `lineage.enabled`. `undefined` means not set. */
+  workflowLineageEnabled: boolean | undefined;
+  /** True when the CLI was invoked with --dry-run. */
+  dryRun: boolean;
+  /** Absolute path of the Dataform project directory (used to derive the workdir hash). */
+  projectDir: string;
+  /** BigQuery credentials; `undefined` when unavailable. */
+  readCredentials: dataform.IBigQuery | undefined;
+}
+
+/**
+ * Constructs a {@link LineageEmitter} from the effective settings, or returns
+ * `undefined` when lineage emission is disabled. When lineage is disabled by an
+ * explicit user choice — CLI flag or workflow_settings — a single structured
+ * `[lineage] Skipped lineage emission: skip_reason=<label>` line is written to
+ * stderr so a troubleshooting user can see WHY nothing was emitted. When
+ * neither surface has been touched, we stay silent (opt-in is the default).
+ */
+export function createLineageEmitter(
+  input: ILineageEmitterFactoryInput,
+  stderr: IStderrLike = process.stderr,
+  clientProvider?: LineageClientProvider
+): LineageEmitter | undefined {
+  if (!input.readCredentials) {
+    return undefined;
+  }
+
+  const lineageEnabled =
+    input.cliEmitLineage ?? input.workflowLineageEnabled ?? false;
+
+  if (!lineageEnabled) {
+    if (input.cliEmitLineage === false) {
+      stderr.write(
+        "[lineage] Skipped lineage emission: skip_reason=invocation_override (--emit-lineage=false)\n"
+      );
+    } else if (input.workflowLineageEnabled === false) {
+      stderr.write(
+        "[lineage] Skipped lineage emission: skip_reason=workflow_opt_out (workflow_settings.yaml lineage.enabled=false)\n"
+      );
+    }
+    return undefined;
+  }
+
+  const options: IEmitterOptions = {
+    lineageEnabled: true,
+    dryRun: input.dryRun,
+    projectDir: input.projectDir
+  };
+  return new LineageEmitter(input.readCredentials, options, clientProvider, stderr);
+}

--- a/cli/api/lineage/emitter_factory_test.ts
+++ b/cli/api/lineage/emitter_factory_test.ts
@@ -1,0 +1,110 @@
+import { expect } from "chai";
+
+import { LineageEmitter } from "df/cli/api/lineage/emitter";
+import {
+  createLineageEmitter,
+  ILineageEmitterFactoryInput
+} from "df/cli/api/lineage/emitter_factory";
+import { dataform } from "df/protos/ts";
+import { suite, test } from "df/testing";
+
+class StderrCapture {
+  public writes: string[] = [];
+  public write(msg: string): boolean {
+    this.writes.push(msg);
+    return true;
+  }
+  public get combined(): string {
+    return this.writes.join("");
+  }
+}
+
+const credentials = dataform.BigQuery.create({
+  projectId: "test-project",
+  location: "US"
+});
+
+function baseInput(overrides: Partial<ILineageEmitterFactoryInput> = {}): ILineageEmitterFactoryInput {
+  return {
+    cliEmitLineage: undefined,
+    workflowLineageEnabled: undefined,
+    dryRun: false,
+    projectDir: "/workspaces/my-project",
+    readCredentials: credentials,
+    ...overrides
+  };
+}
+
+suite("createLineageEmitter", () => {
+  test("skip_reason=workflow_opt_out is logged once when workflow_settings opts out and no CLI flag was passed", () => {
+    const stderr = new StderrCapture();
+    const emitter = createLineageEmitter(
+      baseInput({ workflowLineageEnabled: false }),
+      stderr
+    );
+    expect(emitter).to.equal(undefined);
+    expect(stderr.writes.length).to.equal(1);
+    expect(stderr.combined).to.contain("skip_reason=workflow_opt_out");
+    expect(stderr.combined).to.contain("workflow_settings.yaml lineage.enabled=false");
+  });
+
+  test("skip_reason=invocation_override is logged once when --emit-lineage=false was passed", () => {
+    const stderr = new StderrCapture();
+    const emitter = createLineageEmitter(
+      baseInput({ cliEmitLineage: false, workflowLineageEnabled: true }),
+      stderr
+    );
+    expect(emitter).to.equal(undefined);
+    expect(stderr.writes.length).to.equal(1);
+    expect(stderr.combined).to.contain("skip_reason=invocation_override");
+    expect(stderr.combined).to.contain("--emit-lineage=false");
+  });
+
+  test("skip_reason=invocation_override wins even when workflow_settings also opts out", () => {
+    const stderr = new StderrCapture();
+    const emitter = createLineageEmitter(
+      baseInput({ cliEmitLineage: false, workflowLineageEnabled: false }),
+      stderr
+    );
+    expect(emitter).to.equal(undefined);
+    expect(stderr.combined).to.contain("skip_reason=invocation_override");
+    expect(stderr.combined).to.not.contain("skip_reason=workflow_opt_out");
+  });
+
+  test("stays silent when neither surface has been touched (opt-in is the default)", () => {
+    const stderr = new StderrCapture();
+    const emitter = createLineageEmitter(baseInput(), stderr);
+    expect(emitter).to.equal(undefined);
+    expect(stderr.writes).to.deep.equal([]);
+  });
+
+  test("constructs a LineageEmitter and stays silent when CLI flag opts in", () => {
+    const stderr = new StderrCapture();
+    const emitter = createLineageEmitter(
+      baseInput({ cliEmitLineage: true }),
+      stderr
+    );
+    expect(emitter).to.be.instanceOf(LineageEmitter);
+    expect(stderr.writes).to.deep.equal([]);
+  });
+
+  test("constructs a LineageEmitter and stays silent when workflow_settings opts in", () => {
+    const stderr = new StderrCapture();
+    const emitter = createLineageEmitter(
+      baseInput({ workflowLineageEnabled: true }),
+      stderr
+    );
+    expect(emitter).to.be.instanceOf(LineageEmitter);
+    expect(stderr.writes).to.deep.equal([]);
+  });
+
+  test("returns undefined without logging when credentials are missing", () => {
+    const stderr = new StderrCapture();
+    const emitter = createLineageEmitter(
+      baseInput({ cliEmitLineage: true, readCredentials: undefined }),
+      stderr
+    );
+    expect(emitter).to.equal(undefined);
+    expect(stderr.writes).to.deep.equal([]);
+  });
+});

--- a/cli/api/lineage/emitter_test.ts
+++ b/cli/api/lineage/emitter_test.ts
@@ -1,0 +1,387 @@
+import { expect } from "chai";
+import Long from "long";
+
+import { LineageEmitter } from "df/cli/api/lineage/emitter";
+import { dataform } from "df/protos/ts";
+import { suite, test } from "df/testing";
+
+class StderrCapture {
+  public writes: string[] = [];
+  public write(msg: string): boolean {
+    this.writes.push(msg);
+    return true;
+  }
+}
+
+class MockLineageClient {
+  public processOpenLineageRunEventCalledWith: any[] = [];
+  public processOpenLineageRunEventError: Error | null = null;
+
+  public async processOpenLineageRunEvent(request: any): Promise<any> {
+    this.processOpenLineageRunEventCalledWith.push(request);
+    if (this.processOpenLineageRunEventError) {
+      throw this.processOpenLineageRunEventError;
+    }
+  }
+}
+
+suite("LineageEmitter", () => {
+  const credentials = dataform.BigQuery.create({
+    projectId: "test-project",
+    location: "US"
+  });
+
+  test("emits open lineage run event with correct payload", async () => {
+    const mockClient = new MockLineageClient();
+    const emitter = new LineageEmitter(
+      credentials,
+      { lineageEnabled: true, projectDir: "/workspaces/my-dataform-project" },
+      () => mockClient as any
+    );
+
+    const action = dataform.ExecutionAction.create({
+      target: {
+        database: "target-project",
+        schema: "target_dataset",
+        name: "target_table"
+      },
+      type: "table",
+      fileName: "definitions/target_table.sqlx",
+      dependencyTargets: [
+        {
+          database: "source-project",
+          schema: "source_dataset",
+          name: "source_table"
+        }
+      ],
+      tasks: [
+        {
+          statement: "CREATE TABLE target_table AS SELECT * FROM source_table"
+        }
+      ]
+    });
+
+    const startResult = dataform.ActionResult.create({
+      status: dataform.ActionResult.ExecutionStatus.RUNNING,
+      timing: { startTimeMillis: Long.fromNumber(1000) }
+    });
+    emitter.emitForAction(action, startResult);
+
+    const completeResult = dataform.ActionResult.create({
+      status: dataform.ActionResult.ExecutionStatus.SUCCESSFUL,
+      timing: {
+        startTimeMillis: Long.fromNumber(1000),
+        endTimeMillis: Long.fromNumber(2000)
+      },
+      tasks: [{ status: dataform.TaskResult.ExecutionStatus.SUCCESSFUL }]
+    });
+    emitter.emitForAction(action, completeResult);
+
+    await emitter.drain();
+
+    expect(mockClient.processOpenLineageRunEventCalledWith.length).to.equal(2);
+
+    const startPayload = mockClient.processOpenLineageRunEventCalledWith[0];
+    expect(startPayload.parent).to.equal("projects/target-project/locations/us");
+    const startOpenLineage = fromProtoStruct(startPayload.openLineage);
+    expect(startOpenLineage.eventType).to.equal("START");
+    expect(startOpenLineage.job.name).to.equal(
+      "target-project.us.cli.my-dataform-project-0b5d3e86.target_dataset.target_table"
+    );
+
+    const completePayload = mockClient.processOpenLineageRunEventCalledWith[1];
+    expect(completePayload.parent).to.equal("projects/target-project/locations/us");
+    const openLineage = fromProtoStruct(completePayload.openLineage);
+    expect(openLineage.run.runId).to.equal(startOpenLineage.run.runId);
+    expect(openLineage.eventType).to.equal("COMPLETE");
+    expect(openLineage.producer).to.equal("https://github.com/dataform-co/dataform");
+    expect(openLineage.job.name).to.equal(
+      "target-project.us.cli.my-dataform-project-0b5d3e86.target_dataset.target_table"
+    );
+    expect(openLineage.inputs[0].namespace).to.equal("bigquery");
+    expect(openLineage.inputs[0].name).to.equal("source-project.source_dataset.source_table");
+    expect(openLineage.outputs[0].namespace).to.equal("bigquery");
+    expect(openLineage.outputs[0].name).to.equal("target-project.target_dataset.target_table");
+
+    expect(openLineage.run.facets.parent.job.name).to.equal(
+      "target-project.us.cli.my-dataform-project-0b5d3e86.run"
+    );
+    expect(openLineage.run.facets.parent.run.runId).to.be.a("string");
+
+    expect(openLineage.run.facets.nominalTime.nominalStartTime).to.equal(
+      new Date(1000).toISOString()
+    );
+    expect(openLineage.run.facets.nominalTime.nominalEndTime).to.equal(
+      new Date(2000).toISOString()
+    );
+
+    expect(openLineage.job.facets.gcp_lineage.displayName).to.equal(
+      "BigQuery Pipelines action target_dataset.target_table"
+    );
+    expect(openLineage.job.facets.gcp_lineage.origin.sourceType).to.equal("BIGQUERY_PIPELINES");
+    expect(openLineage.job.facets.gcp_lineage.origin.name).to.equal(
+      "projects/target-project/locations/us/cli/my-dataform-project-0b5d3e86"
+    );
+
+    expect(openLineage.run.facets.gcp_bq_pipelines_run.runType).to.equal("cli-manual");
+  });
+
+  test("emits FAIL eventType on action failure", async () => {
+    const mockClient = new MockLineageClient();
+    const emitter = new LineageEmitter(
+      credentials,
+      { lineageEnabled: true, projectDir: "/workspaces/my-dataform-project" },
+      () => mockClient as any
+    );
+
+    const action = dataform.ExecutionAction.create({
+      target: {
+        database: "target-project",
+        schema: "target_dataset",
+        name: "failing_table"
+      },
+      type: "table"
+    });
+
+    emitter.emitForAction(action, dataform.ActionResult.create({
+      status: dataform.ActionResult.ExecutionStatus.RUNNING,
+      timing: { startTimeMillis: Long.fromNumber(1000) }
+    }));
+    emitter.emitForAction(action, dataform.ActionResult.create({
+      status: dataform.ActionResult.ExecutionStatus.FAILED,
+      timing: {
+        startTimeMillis: Long.fromNumber(1000),
+        endTimeMillis: Long.fromNumber(1500)
+      }
+    }));
+
+    await emitter.drain();
+
+    expect(mockClient.processOpenLineageRunEventCalledWith.length).to.equal(2);
+    const failPayload = mockClient.processOpenLineageRunEventCalledWith[1];
+    const openLineage = fromProtoStruct(failPayload.openLineage);
+    expect(openLineage.eventType).to.equal("FAIL");
+    expect(openLineage.run.facets.nominalTime.nominalEndTime).to.equal(
+      new Date(1500).toISOString()
+    );
+  });
+
+  test("disables emission for the rest of the run after the first failure", async () => {
+    const mockClient = new MockLineageClient();
+    const err: any = new Error("something broke");
+    err.code = 13;
+    mockClient.processOpenLineageRunEventError = err;
+
+    const emitter = new LineageEmitter(
+      credentials,
+      { lineageEnabled: true },
+      () => mockClient as any
+    );
+
+    const action = dataform.ExecutionAction.create({
+      target: { database: "proj", schema: "schema", name: "table" },
+      type: "table"
+    });
+    const startResult = dataform.ActionResult.create({
+      status: dataform.ActionResult.ExecutionStatus.RUNNING
+    });
+
+    emitter.emitForAction(action, startResult);
+    await emitter.drain();
+    expect(mockClient.processOpenLineageRunEventCalledWith.length).to.equal(1);
+
+    // Subsequent emits must not hit the client.
+    for (let i = 0; i < 4; i++) {
+      emitter.emitForAction(action, startResult);
+    }
+    await emitter.drain();
+    expect(mockClient.processOpenLineageRunEventCalledWith.length).to.equal(1);
+  });
+
+  test("skip_reason=dry_run is logged once per run, not once per action", async () => {
+    const mockClient = new MockLineageClient();
+    const stderr = new StderrCapture();
+    const emitter = new LineageEmitter(
+      credentials,
+      { lineageEnabled: true, dryRun: true },
+      () => mockClient as any,
+      stderr
+    );
+
+    const action = dataform.ExecutionAction.create({
+      target: { database: "proj", schema: "schema", name: "table" },
+      type: "table"
+    });
+    const startResult = dataform.ActionResult.create({
+      status: dataform.ActionResult.ExecutionStatus.RUNNING
+    });
+
+    emitter.emitForAction(action, startResult);
+    emitter.emitForAction(action, startResult);
+    emitter.emitForAction(action, startResult);
+    await emitter.drain();
+
+    const dryRunLines = stderr.writes.filter(w => w.includes("skip_reason=dry_run"));
+    expect(dryRunLines.length).to.equal(1);
+    expect(dryRunLines[0]).to.contain("dry-run mode");
+    expect(mockClient.processOpenLineageRunEventCalledWith.length).to.equal(0);
+  });
+
+  test("ineligible action types are skipped silently (no stderr line, no emission)", async () => {
+    const mockClient = new MockLineageClient();
+    const stderr = new StderrCapture();
+    const emitter = new LineageEmitter(
+      credentials,
+      { lineageEnabled: true },
+      () => mockClient as any,
+      stderr
+    );
+
+    const assertion = dataform.ExecutionAction.create({
+      target: { database: "proj", schema: "schema", name: "assertion" },
+      type: "assertion"
+    });
+    const declaration = dataform.ExecutionAction.create({
+      target: { database: "proj", schema: "schema", name: "declaration" },
+      type: "declaration"
+    });
+    const startResult = dataform.ActionResult.create({
+      status: dataform.ActionResult.ExecutionStatus.RUNNING
+    });
+
+    emitter.emitForAction(assertion, startResult);
+    emitter.emitForAction(declaration, startResult);
+    await emitter.drain();
+
+    expect(stderr.writes).to.deep.equal([]);
+    expect(mockClient.processOpenLineageRunEventCalledWith.length).to.equal(0);
+  });
+
+  test("sanitizes projectDir basename with special chars in workdirIdentifier", async () => {
+    const mockClient = new MockLineageClient();
+    const emitter = new LineageEmitter(
+      credentials,
+      { lineageEnabled: true, projectDir: "/workspaces/My Project! v2" },
+      () => mockClient as any
+    );
+
+    const action = dataform.ExecutionAction.create({
+      target: { database: "target-project", schema: "s", name: "t" },
+      type: "table"
+    });
+
+    emitter.emitForAction(action, dataform.ActionResult.create({
+      status: dataform.ActionResult.ExecutionStatus.SUCCESSFUL,
+      tasks: [{ status: dataform.TaskResult.ExecutionStatus.SUCCESSFUL }]
+    }));
+    await emitter.drain();
+
+    const openLineage = fromProtoStruct(
+      mockClient.processOpenLineageRunEventCalledWith[0].openLineage
+    );
+    // "My Project! v2" -> "my-project-v2" + "-" + 8-hex hash slice.
+    expect(openLineage.job.facets.gcp_lineage.origin.name).to.match(
+      /^projects\/target-project\/locations\/us\/cli\/my-project-v2-[0-9a-f]{8}$/
+    );
+  });
+
+  test("falls back to 'unknown-workdir' when projectDir is not provided", async () => {
+    const mockClient = new MockLineageClient();
+    const emitter = new LineageEmitter(
+      credentials,
+      { lineageEnabled: true },
+      () => mockClient as any
+    );
+
+    const action = dataform.ExecutionAction.create({
+      target: { database: "target-project", schema: "s", name: "t" },
+      type: "table"
+    });
+
+    emitter.emitForAction(action, dataform.ActionResult.create({
+      status: dataform.ActionResult.ExecutionStatus.SUCCESSFUL,
+      tasks: [{ status: dataform.TaskResult.ExecutionStatus.SUCCESSFUL }]
+    }));
+    await emitter.drain();
+
+    const openLineage = fromProtoStruct(
+      mockClient.processOpenLineageRunEventCalledWith[0].openLineage
+    );
+    expect(openLineage.job.facets.gcp_lineage.origin.name).to.equal(
+      "projects/target-project/locations/us/cli/unknown-workdir"
+    );
+  });
+
+  test("emit failures never surface as unhandled rejections", async () => {
+    // Isolation contract: lineage errors must never propagate to the
+    // surrounding BQ executor.
+    const rejections: unknown[] = [];
+    const onUnhandled = (r: unknown) => rejections.push(r);
+    process.on("unhandledRejection", onUnhandled);
+    try {
+      const mockClient = new MockLineageClient();
+      const genericError: any = new Error("something broke");
+      genericError.code = 13;
+      mockClient.processOpenLineageRunEventError = genericError;
+
+      const emitter = new LineageEmitter(
+        credentials,
+        { lineageEnabled: true },
+        () => mockClient as any
+      );
+      const action = dataform.ExecutionAction.create({
+        target: { database: "proj", schema: "s", name: "t" },
+        type: "table"
+      });
+      const startResult = dataform.ActionResult.create({
+        status: dataform.ActionResult.ExecutionStatus.RUNNING
+      });
+
+      for (let i = 0; i < 5; i++) {
+        emitter.emitForAction(action, startResult);
+      }
+      await emitter.drain();
+      await new Promise(r => setImmediate(r));
+
+      expect(rejections).to.deep.equal([]);
+    } finally {
+      process.removeListener("unhandledRejection", onUnhandled);
+    }
+  });
+});
+
+function fromProtoStruct(struct: any): any {
+  if (!struct || !struct.fields) {
+    return {};
+  }
+  const obj: any = {};
+  for (const key of Object.keys(struct.fields)) {
+    obj[key] = fromProtoValue(struct.fields[key]);
+  }
+  return obj;
+}
+
+function fromProtoValue(value: any): any {
+  if (!value) {
+    return null;
+  }
+  if (value.nullValue !== undefined) {
+    return null;
+  }
+  if (value.stringValue !== undefined) {
+    return value.stringValue;
+  }
+  if (value.numberValue !== undefined) {
+    return value.numberValue;
+  }
+  if (value.boolValue !== undefined) {
+    return value.boolValue;
+  }
+  if (value.listValue && value.listValue.values) {
+    return value.listValue.values.map(fromProtoValue);
+  }
+  if (value.structValue) {
+    return fromProtoStruct(value.structValue);
+  }
+  return null;
+}

--- a/cli/api/lineage/lineage_integration_test.ts
+++ b/cli/api/lineage/lineage_integration_test.ts
@@ -1,0 +1,273 @@
+import { expect } from "chai";
+
+import { run } from "df/cli/api/commands/run";
+import { IDbAdapter, IDbClient, IExecutionResult, IExecutionResultRaw } from "df/cli/api/dbadapters";
+import { QueryOrAction } from "df/cli/api/dbadapters/execution_sql";
+import { createLineageEmitter, ILineageEmitterFactoryInput } from "df/cli/api/lineage/emitter_factory";
+import { recorderProvider, RecordingLineageClient } from "df/cli/api/lineage/testing/mock_lineage_client";
+import { dataform } from "df/protos/ts";
+import { suite, test } from "df/testing";
+
+/**
+ * Integration coverage for the CLI --emit-lineage path. Drives `createLineageEmitter`
+ * + `run()` in-process against a fake IDbAdapter and a RecordingLineageClient.
+ * Assertions target recorder.calls, recorder.providerCalls, and the presence of
+ * `skip_reason=...` markers in stderr — never the wording of debug lines. See
+ * task_T37_impl_assertion_strategy.md for the anti-checklist.
+ */
+
+class StderrCapture {
+  public writes: string[] = [];
+  public write(msg: string): boolean {
+    this.writes.push(msg);
+    return true;
+  }
+  public contains(needle: string): boolean {
+    return this.writes.some(w => w.includes(needle));
+  }
+}
+
+/**
+ * Minimal IDbAdapter fake: unconditionally successful execute(), no-op schema
+ * lifecycle, no metadata calls. The Runner's contract with the adapter is
+ * exercised end-to-end without touching BigQuery.
+ */
+class FakeDbAdapter implements IDbAdapter {
+  public executed: string[] = [];
+
+  public async execute(statement: string): Promise<IExecutionResult> {
+    this.executed.push(statement);
+    return { rows: [], metadata: {} };
+  }
+  public async executeRaw(statement: string): Promise<IExecutionResultRaw> {
+    return { rows: [], metadata: {} };
+  }
+  public async withClientLock<T>(cb: (client: IDbClient) => Promise<T>): Promise<T> {
+    return cb(this);
+  }
+  public async evaluate(queryOrAction: QueryOrAction): Promise<dataform.IQueryEvaluation[]> {
+    return [];
+  }
+  public async schemas(database: string): Promise<string[]> {
+    return [];
+  }
+  public async createSchema(database: string, schema: string): Promise<void> {
+    return;
+  }
+  public async tables(database: string, schema?: string): Promise<dataform.ITableMetadata[]> {
+    return [];
+  }
+  public async search(): Promise<dataform.ITableMetadata[]> {
+    return [];
+  }
+  public async table(target: dataform.ITarget): Promise<dataform.ITableMetadata> {
+    return null;
+  }
+  public async deleteTable(target: dataform.ITarget): Promise<void> {
+    return;
+  }
+  public async setMetadata(action: dataform.IExecutionAction): Promise<void> {
+    return;
+  }
+}
+
+function makeLinearGraph(): dataform.IExecutionGraph {
+  return dataform.ExecutionGraph.create({
+    projectConfig: { warehouse: "bigquery", defaultDatabase: "test-project", defaultLocation: "US" },
+    runConfig: {},
+    warehouseState: { tables: [] },
+    actions: [
+      {
+        target: { database: "test-project", schema: "s", name: "table_a" },
+        type: "table",
+        tasks: [{ type: "statement", statement: "CREATE TABLE test-project.s.table_a AS SELECT 1" }],
+        dependencyTargets: []
+      },
+      {
+        target: { database: "test-project", schema: "s", name: "table_b" },
+        type: "table",
+        tasks: [{ type: "statement", statement: "CREATE TABLE test-project.s.table_b AS SELECT * FROM table_a" }],
+        dependencyTargets: [{ database: "test-project", schema: "s", name: "table_a" }]
+      }
+    ]
+  });
+}
+
+function factoryInput(overrides: Partial<ILineageEmitterFactoryInput> = {}): ILineageEmitterFactoryInput {
+  return {
+    cliEmitLineage: undefined,
+    workflowLineageEnabled: undefined,
+    dryRun: false,
+    projectDir: "/workspaces/test-project",
+    readCredentials: dataform.BigQuery.create({ projectId: "test-project", location: "US" }),
+    ...overrides
+  };
+}
+
+suite("--emit-lineage integration", { parallel: true }, () => {
+  test("Case 1 — CLI flag alone enables emission (2*N recorder calls, pairing invariant)", async () => {
+    const recorder = new RecordingLineageClient();
+    const stderr = new StderrCapture();
+    const emitter = createLineageEmitter(
+      factoryInput({ cliEmitLineage: true }),
+      stderr,
+      recorderProvider(recorder)
+    );
+    expect(emitter).to.not.equal(undefined);
+
+    const dbadapter = new FakeDbAdapter();
+    const runner = run(dbadapter, makeLinearGraph(), { lineageEmitter: emitter });
+    await runner.result();
+    await emitter!.drain();
+
+    // 2 actions × (START + COMPLETE)
+    expect(recorder.calls.length).to.equal(4);
+
+    const runIdsPerTable = new Map<string, Set<string>>();
+    const eventTypesPerRunId = new Map<string, string[]>();
+    for (const call of recorder.calls) {
+      const ol = fromProtoStruct(call.request.openLineage);
+      const jobName = ol.job.name as string;
+      const runId = ol.run.runId as string;
+      const eventType = ol.eventType as string;
+      if (!runIdsPerTable.has(jobName)) {
+        runIdsPerTable.set(jobName, new Set());
+      }
+      runIdsPerTable.get(jobName).add(runId);
+      if (!eventTypesPerRunId.has(runId)) {
+        eventTypesPerRunId.set(runId, []);
+      }
+      eventTypesPerRunId.get(runId).push(eventType);
+    }
+
+    // Every action's START and COMPLETE share exactly one runId.
+    expect(runIdsPerTable.size).to.equal(2);
+    for (const runIds of runIdsPerTable.values()) {
+      expect(runIds.size).to.equal(1);
+    }
+    // Every runId has exactly one START and one COMPLETE.
+    for (const events of eventTypesPerRunId.values()) {
+      expect(events.sort()).to.deep.equal(["COMPLETE", "START"]);
+    }
+  });
+
+  test("Case 2 — workflow lineage.enabled=true (no CLI flag) enables emission", async () => {
+    const recorder = new RecordingLineageClient();
+    const emitter = createLineageEmitter(
+      factoryInput({ workflowLineageEnabled: true }),
+      new StderrCapture(),
+      recorderProvider(recorder)
+    );
+    expect(emitter).to.not.equal(undefined);
+
+    const runner = run(new FakeDbAdapter(), makeLinearGraph(), { lineageEmitter: emitter });
+    await runner.result();
+    await emitter!.drain();
+
+    expect(recorder.calls.length).to.equal(4);
+  });
+
+  test("Case 3 — neither flag nor config produces no emission and no factory-provider call", async () => {
+    const recorder = new RecordingLineageClient();
+    const stderr = new StderrCapture();
+    const emitter = createLineageEmitter(factoryInput(), stderr, recorderProvider(recorder));
+
+    expect(emitter).to.equal(undefined);
+    expect(recorder.calls.length).to.equal(0);
+    expect(recorder.providerCalls.length).to.equal(0);
+    // Silent default — no skip line either.
+    expect(stderr.contains("skip_reason=")).to.equal(false);
+  });
+
+  test("Case 4 — CLI --emit-lineage=false overrides workflow lineage.enabled=true", async () => {
+    const recorder = new RecordingLineageClient();
+    const stderr = new StderrCapture();
+    const emitter = createLineageEmitter(
+      factoryInput({ cliEmitLineage: false, workflowLineageEnabled: true }),
+      stderr,
+      recorderProvider(recorder)
+    );
+
+    expect(emitter).to.equal(undefined);
+    expect(recorder.calls.length).to.equal(0);
+    // Precedence surface: CLI-driven override emits a skip_reason line.
+    expect(stderr.contains("skip_reason=invocation_override")).to.equal(true);
+  });
+
+  test("Case 5 — lineage emit failure is fail-open (run exits SUCCESSFUL)", async () => {
+    // Fail-open contract: any lineage emission failure — whatever the gRPC
+    // code — must not affect the workflow status. The dataform run continues,
+    // dbadapter still executes every action.
+    const recorder = new RecordingLineageClient();
+    recorder.throwOnNextCallWith(7, "Permission Denied");
+    const stderr = new StderrCapture();
+    const emitter = createLineageEmitter(
+      factoryInput({ cliEmitLineage: true }),
+      stderr,
+      recorderProvider(recorder)
+    );
+
+    const dbadapter = new FakeDbAdapter();
+    const runner = run(dbadapter, makeLinearGraph(), { lineageEmitter: emitter });
+    const runResult = await runner.result();
+    await emitter!.drain();
+
+    expect(runResult.status).to.equal(dataform.RunResult.ExecutionStatus.SUCCESSFUL);
+    expect(dbadapter.executed.length).to.equal(2);
+  });
+
+  test("Case 6 — drain is bounded when the client hangs indefinitely", async () => {
+    const recorder = new RecordingLineageClient();
+    recorder.hangForever();
+    const emitter = createLineageEmitter(
+      factoryInput({ cliEmitLineage: true }),
+      new StderrCapture(),
+      recorderProvider(recorder)
+    );
+
+    const runner = run(new FakeDbAdapter(), makeLinearGraph(), { lineageEmitter: emitter });
+    await runner.result();
+
+    const started = Date.now();
+    await emitter!.drain(200);
+    const elapsed = Date.now() - started;
+    // 200ms bound + generous slack for CI jitter.
+    expect(elapsed).to.be.lessThan(2000);
+  });
+});
+
+function fromProtoStruct(struct: any): any {
+  if (!struct || !struct.fields) {
+    return {};
+  }
+  const obj: any = {};
+  for (const key of Object.keys(struct.fields)) {
+    obj[key] = fromProtoValue(struct.fields[key]);
+  }
+  return obj;
+}
+
+function fromProtoValue(value: any): any {
+  if (!value) {
+    return null;
+  }
+  if (value.nullValue !== undefined) {
+    return null;
+  }
+  if (value.stringValue !== undefined) {
+    return value.stringValue;
+  }
+  if (value.numberValue !== undefined) {
+    return value.numberValue;
+  }
+  if (value.boolValue !== undefined) {
+    return value.boolValue;
+  }
+  if (value.listValue && value.listValue.values) {
+    return value.listValue.values.map(fromProtoValue);
+  }
+  if (value.structValue) {
+    return fromProtoStruct(value.structValue);
+  }
+  return null;
+}

--- a/cli/api/lineage/payload_builder.ts
+++ b/cli/api/lineage/payload_builder.ts
@@ -1,0 +1,198 @@
+import { createHash, randomUUID } from "crypto";
+import Long from "long";
+import * as path from "path";
+
+import { dataform } from "df/protos/ts";
+
+const PRODUCER_URL = "https://github.com/dataform-co/dataform";
+
+/**
+ * Assembles OpenLineage RunEvent payloads for Dataform actions.
+ *
+ * Stateful across the lifetime of one dataform run:
+ * - `parentRunId` — one UUID per run, shared by every action's ParentRunFacet
+ * - `activeRunIds` — maps action key → runId so START and terminal events
+ *   share the same runId (OpenLineage requires this to correlate a run)
+ * - `workdirHash` — lazily computed once from `projectDir`
+ *
+ * All state is derived from inputs. No I/O.
+ */
+export class LineagePayloadBuilder {
+  private readonly projectDir?: string;
+  private readonly parentRunId: string;
+  private readonly activeRunIds = new Map<string, string>();
+  private workdirHash: string = "";
+
+  constructor(projectDir?: string) {
+    this.projectDir = projectDir;
+    this.parentRunId = randomUUID();
+  }
+
+  public build(
+    action: dataform.IExecutionAction,
+    actionResult: dataform.IActionResult,
+    projectId: string,
+    location: string
+  ): { [key: string]: any } {
+    if (!this.workdirHash && this.projectDir) {
+      this.workdirHash = createHash("sha256").update(this.projectDir).digest("hex").slice(0, 16);
+    }
+
+    const eventTime = new Date().toISOString();
+    const actionKey = `${action.target.database || ""}.${action.target.schema}.${action.target.name}`;
+    let runId = this.activeRunIds.get(actionKey);
+    if (!runId) {
+      runId = randomUUID();
+      this.activeRunIds.set(actionKey, runId);
+    }
+
+    let eventType: "START" | "COMPLETE" | "FAIL" | "ABORT" = "START";
+    if (actionResult.status === dataform.ActionResult.ExecutionStatus.RUNNING) {
+      eventType = "START";
+    } else {
+      this.activeRunIds.delete(actionKey);
+      if (actionResult.status === dataform.ActionResult.ExecutionStatus.FAILED) {
+        eventType = "FAIL";
+      } else if (actionResult.status === dataform.ActionResult.ExecutionStatus.CANCELLED) {
+        eventType = "ABORT";
+      } else if (actionResult.status === dataform.ActionResult.ExecutionStatus.SUCCESSFUL) {
+        eventType = "COMPLETE";
+      }
+    }
+
+    const inputs = (action.dependencyTargets || []).map(dep => ({
+      namespace: "bigquery",
+      name: `${dep.database || projectId}.${dep.schema}.${dep.name}`
+    }));
+
+    const outputs = [
+      {
+        namespace: "bigquery",
+        name: `${action.target.database || projectId}.${action.target.schema}.${action.target.name}`
+      }
+    ];
+
+    const workdirIdentifier = this.buildWorkdirIdentifier();
+    const canonicalActionTarget = `${action.target.schema}.${action.target.name}`;
+    const jobName = `${projectId}.${location}.cli.${workdirIdentifier}.${canonicalActionTarget}`;
+    const parentJobName = `${projectId}.${location}.cli.${workdirIdentifier}.run`;
+
+    const nominalTime: any = {
+      _schemaURL: "https://openlineage.io/spec/facets/1-0-1/NominalTimeRunFacet.json",
+      nominalStartTime: new Date(
+        toMillis(actionResult.timing?.startTimeMillis) ?? Date.now()
+      ).toISOString()
+    };
+    if (actionResult.timing?.endTimeMillis) {
+      nominalTime.nominalEndTime = new Date(
+        toMillis(actionResult.timing.endTimeMillis)
+      ).toISOString();
+    }
+
+    const runFacets: any = {
+      nominalTime,
+      parent: {
+        _producer: PRODUCER_URL,
+        _schemaURL:
+          "https://openlineage.io/spec/facets/1-0-1/ParentRunFacet.json#/$defs/ParentRunFacet",
+        job: {
+          namespace: "dataform",
+          name: parentJobName
+        },
+        run: {
+          runId: this.parentRunId
+        }
+      },
+      gcp_bq_pipelines_run: {
+        runType: "cli-manual"
+      }
+    };
+
+    const jobFacets: any = {};
+    jobFacets.gcp_lineage = {
+      _producer: PRODUCER_URL,
+      _schemaURL:
+        "https://openlineage.io/spec/facets/1-0-0/GcpLineageJobFacet.json#/$defs/GcpLineageJobFacet",
+      displayName: `BigQuery Pipelines action ${canonicalActionTarget}`,
+      origin: {
+        name: `projects/${projectId}/locations/${location}/cli/${workdirIdentifier}`,
+        sourceType: "BIGQUERY_PIPELINES"
+      }
+    };
+
+    return {
+      eventType,
+      eventTime,
+      run: {
+        runId,
+        facets: runFacets
+      },
+      job: {
+        namespace: "dataform",
+        name: jobName,
+        facets: jobFacets
+      },
+      inputs,
+      outputs,
+      producer: PRODUCER_URL,
+      schemaURL: "https://openlineage.io/spec/1-0-2/OpenLineage.json#/definitions/RunEvent"
+    };
+  }
+
+  private buildWorkdirIdentifier(): string {
+    if (!this.workdirHash || !this.projectDir) {
+      return "unknown-workdir";
+    }
+    const rawBase = path.basename(this.projectDir);
+    const sanitized = rawBase
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "");
+    const base = sanitized || "workdir";
+    const shortHash = this.workdirHash.slice(0, 8);
+    return `${base}-${shortHash}`;
+  }
+}
+
+function toMillis(val: Long | number | undefined | null): number | undefined {
+  if (typeof val === "number") {
+    return val;
+  }
+  if (val && typeof (val as Long).toNumber === "function") {
+    return (val as Long).toNumber();
+  }
+  return undefined;
+}
+
+export function toProtoStruct(obj: { [key: string]: any }): any {
+  const fields: { [key: string]: any } = {};
+  for (const key of Object.keys(obj)) {
+    const val = obj[key];
+    if (val !== undefined) {
+      fields[key] = toProtoValue(val);
+    }
+  }
+  return { fields };
+}
+
+function toProtoValue(val: any): any {
+  if (val === null) {
+    return { nullValue: 0 };
+  }
+  if (typeof val === "string") {
+    return { stringValue: val };
+  }
+  if (typeof val === "number") {
+    return { numberValue: val };
+  }
+  if (typeof val === "boolean") {
+    return { boolValue: val };
+  }
+  if (Array.isArray(val)) {
+    return { listValue: { values: val.map(toProtoValue) } };
+  }
+  if (typeof val === "object") {
+    return { structValue: toProtoStruct(val) };
+  }
+  return { nullValue: 0 };
+}

--- a/cli/api/lineage/payload_builder_test.ts
+++ b/cli/api/lineage/payload_builder_test.ts
@@ -1,0 +1,108 @@
+import { expect } from "chai";
+import Long from "long";
+
+import { LineagePayloadBuilder } from "df/cli/api/lineage/payload_builder";
+import { dataform } from "df/protos/ts";
+import { suite, test } from "df/testing";
+
+const ACTION = dataform.ExecutionAction.create({
+  target: { database: "proj", schema: "schema", name: "table" },
+  type: "table",
+  tasks: [{ statement: "SELECT 1" }]
+});
+
+const START_RESULT = dataform.ActionResult.create({
+  status: dataform.ActionResult.ExecutionStatus.RUNNING,
+  timing: { startTimeMillis: Long.fromNumber(1_700_000_000_000) }
+});
+
+const COMPLETE_RESULT = dataform.ActionResult.create({
+  status: dataform.ActionResult.ExecutionStatus.SUCCESSFUL,
+  timing: {
+    startTimeMillis: Long.fromNumber(1_700_000_000_000),
+    endTimeMillis: Long.fromNumber(1_700_000_010_000)
+  },
+  tasks: [{ metadata: { bigquery: { jobId: "job-abc" } } }]
+});
+
+suite("LineagePayloadBuilder", () => {
+  test("maps ActionResult status to OpenLineage eventType", () => {
+    const builder = new LineagePayloadBuilder("/tmp/proj");
+    const running = builder.build(ACTION, START_RESULT, "proj", "us");
+    const successful = builder.build(ACTION, COMPLETE_RESULT, "proj", "us");
+    const failed = builder.build(
+      ACTION,
+      dataform.ActionResult.create({ status: dataform.ActionResult.ExecutionStatus.FAILED }),
+      "proj",
+      "us"
+    );
+    const cancelled = builder.build(
+      ACTION,
+      dataform.ActionResult.create({ status: dataform.ActionResult.ExecutionStatus.CANCELLED }),
+      "proj",
+      "us"
+    );
+    expect(running.eventType).to.equal("START");
+    expect(successful.eventType).to.equal("COMPLETE");
+    expect(failed.eventType).to.equal("FAIL");
+    expect(cancelled.eventType).to.equal("ABORT");
+  });
+
+  test("correlates START and terminal event via shared runId per action", () => {
+    const builder = new LineagePayloadBuilder("/tmp/proj");
+    const start = builder.build(ACTION, START_RESULT, "proj", "us");
+    const complete = builder.build(ACTION, COMPLETE_RESULT, "proj", "us");
+    expect(start.run.runId).to.equal(complete.run.runId);
+  });
+
+  test("issues a fresh runId for the next START on the same action after terminal", () => {
+    const builder = new LineagePayloadBuilder("/tmp/proj");
+    const firstStart = builder.build(ACTION, START_RESULT, "proj", "us");
+    builder.build(ACTION, COMPLETE_RESULT, "proj", "us");
+    const secondStart = builder.build(ACTION, START_RESULT, "proj", "us");
+    expect(secondStart.run.runId).to.not.equal(firstStart.run.runId);
+  });
+
+  test("shares parentRunId across different actions in the same builder", () => {
+    const builder = new LineagePayloadBuilder("/tmp/proj");
+    const otherAction = dataform.ExecutionAction.create({
+      target: { database: "proj", schema: "schema", name: "other" },
+      type: "table"
+    });
+    const first = builder.build(ACTION, START_RESULT, "proj", "us");
+    const second = builder.build(otherAction, START_RESULT, "proj", "us");
+    expect(first.run.facets.parent.run.runId).to.equal(second.run.facets.parent.run.runId);
+  });
+
+  test("workdirIdentifier includes sanitized basename + 8-char hash prefix", () => {
+    const builder = new LineagePayloadBuilder("/tmp/My_Project.Dir");
+    const payload = builder.build(ACTION, START_RESULT, "proj", "us");
+    // gcp_lineage.origin.name is the only place workdirIdentifier is spliced in.
+    const originName = payload.job.facets.gcp_lineage.origin.name;
+    expect(originName).to.match(/^projects\/proj\/locations\/us\/cli\/my-project-dir-[0-9a-f]{8}$/);
+  });
+
+  test("workdirIdentifier falls back to 'unknown-workdir' with no projectDir", () => {
+    const builder = new LineagePayloadBuilder();
+    const payload = builder.build(ACTION, START_RESULT, "proj", "us");
+    const originName = payload.job.facets.gcp_lineage.origin.name;
+    expect(originName).to.equal("projects/proj/locations/us/cli/unknown-workdir");
+  });
+
+  test("inputs list mirrors action.dependencyTargets in bigquery namespace", () => {
+    const actionWithDeps = dataform.ExecutionAction.create({
+      target: { database: "proj", schema: "schema", name: "table" },
+      type: "table",
+      dependencyTargets: [
+        { database: "p1", schema: "s1", name: "n1" },
+        { database: "p2", schema: "s2", name: "n2" }
+      ]
+    });
+    const builder = new LineagePayloadBuilder("/tmp/proj");
+    const payload = builder.build(actionWithDeps, START_RESULT, "proj", "us");
+    expect(payload.inputs).to.deep.equal([
+      { namespace: "bigquery", name: "p1.s1.n1" },
+      { namespace: "bigquery", name: "p2.s2.n2" }
+    ]);
+  });
+});

--- a/cli/api/lineage/testing/BUILD
+++ b/cli/api/lineage/testing/BUILD
@@ -1,0 +1,12 @@
+package(default_visibility = ["//visibility:public"])
+
+load("//tools:ts_library.bzl", "ts_library")
+
+ts_library(
+    name = "testing",
+    srcs = glob(["**/*.ts"]),
+    deps = [
+        "@npm//@google-cloud/lineage",
+        "@npm//@types/node",
+    ],
+)

--- a/cli/api/lineage/testing/mock_lineage_client.ts
+++ b/cli/api/lineage/testing/mock_lineage_client.ts
@@ -1,0 +1,73 @@
+import { LineageClient } from "@google-cloud/lineage";
+
+export interface IRecordedCall {
+  request: any;
+  timestamp: number;
+}
+
+export interface IProviderCall {
+  projectId: string;
+  endpoint: string;
+}
+
+type NextResponse =
+  | { kind: "ok" }
+  | { kind: "throw"; code: number; message?: string }
+  | { kind: "hang" };
+
+/**
+ * Test double for `@google-cloud/lineage`'s LineageClient that records every
+ * processOpenLineageRunEvent call for later assertion, and can be programmed
+ * to fail or hang on the next call. Used by lineage integration tests to
+ * observe emitted OpenLineage payloads without hitting the real API.
+ *
+ * The recorder is the load-bearing observable — assertions target
+ * `recorder.calls`, never stderr message strings.
+ */
+export class RecordingLineageClient {
+  public readonly calls: IRecordedCall[] = [];
+  public readonly providerCalls: IProviderCall[] = [];
+  private nextResponse: NextResponse = { kind: "ok" };
+
+  public async processOpenLineageRunEvent(request: any): Promise<any> {
+    this.calls.push({ request, timestamp: Date.now() });
+    if (this.nextResponse.kind === "throw") {
+      const err: any = new Error(this.nextResponse.message || `injected code=${this.nextResponse.code}`);
+      err.code = this.nextResponse.code;
+      throw err;
+    }
+    if (this.nextResponse.kind === "hang") {
+      await new Promise(() => { /* never resolves */ });
+    }
+    const runId = request?.openLineage?.fields?.run?.structValue?.fields?.runId?.stringValue || "unknown";
+    return { name: `projects/test/locations/us/processes/${runId}` };
+  }
+
+  public throwOnNextCallWith(grpcCode: number, message?: string): void {
+    this.nextResponse = { kind: "throw", code: grpcCode, message };
+  }
+
+  public hangForever(): void {
+    this.nextResponse = { kind: "hang" };
+  }
+
+  public reset(): void {
+    this.calls.length = 0;
+    this.providerCalls.length = 0;
+    this.nextResponse = { kind: "ok" };
+  }
+}
+
+/**
+ * Returns a LineageClientProvider-shaped factory that always yields the given
+ * recorder, and remembers every (projectId, endpoint) pair the emitter asks
+ * for so tests can assert on endpoint selection (case 5 in T37).
+ */
+export function recorderProvider(
+  recorder: RecordingLineageClient
+): (projectId: string, endpoint: string) => LineageClient {
+  return (projectId: string, endpoint: string) => {
+    recorder.providerCalls.push({ projectId, endpoint });
+    return recorder as unknown as LineageClient;
+  };
+}

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -8,6 +8,8 @@ import yargs from "yargs";
 import { build, compile, credentials, init, install, prune, run, test } from "df/cli/api";
 import { CREDENTIALS_FILENAME } from "df/cli/api/commands/credentials";
 import { BigQueryDbAdapter } from "df/cli/api/dbadapters/bigquery";
+import { LineageEmitter } from "df/cli/api/lineage/emitter";
+import { createLineageEmitter as createLineageEmitterFromFactory } from "df/cli/api/lineage/emitter_factory";
 import { prettyJsonStringify } from "df/cli/api/utils";
 import {
   compiledGraphOutputType,
@@ -37,6 +39,12 @@ import { dataform } from "df/protos/ts";
 import { formatFile } from "df/sqlx/format";
 
 const RECOMPILE_DELAY = 500;
+
+// Maximum time to wait for outstanding lineage emissions to complete before
+// `dataform run` returns. Lineage emission is fail-open — if we don't drain
+// within this window, in-flight requests are abandoned and the run status is
+// unaffected.
+const LINEAGE_DRAIN_TIMEOUT_MS = 15_000;
 
 process.on("unhandledRejection", async (reason: any) => {
   printError(`Unhandled promise rejection: ${reason?.stack || reason}`);
@@ -184,6 +192,16 @@ const credentialsOption: INamedOption<yargs.Options> = {
   },
   check: (argv: yargs.Arguments<any>) =>
     getCredentialsPath(argv[projectDirOption.name], argv[credentialsOption.name])
+};
+
+const emitLineageOption: INamedOption<yargs.Options> = {
+  name: "emit-lineage",
+  option: {
+    describe:
+      "If set, emit OpenLineage RunEvents to Knowledge Catalog Lineage for each executed action. " +
+      "Overrides workflow_settings.yaml lineage.enabled when specified.",
+    type: "boolean"
+  }
 };
 
 const jsonOutputOption: INamedOption<yargs.Options> = {
@@ -665,6 +683,7 @@ export function runCli() {
           },
           actionsOption,
           credentialsOption,
+          emitLineageOption,
           fullRefreshOption,
           includeDepsOption,
           includeDependentsOption,
@@ -769,10 +788,16 @@ export function runCli() {
             logger.log("Running...\n");
           }
 
+          const lineageEmitter = createLineageEmitter(argv, executionGraph, readCredentials);
+
           const runner = run(
             dbadapter,
             executionGraph,
-            { projectDir: argv[projectDirOption.name], bigquery: bigqueryOptions }
+            {
+              projectDir: argv[projectDirOption.name],
+              bigquery: bigqueryOptions,
+              lineageEmitter
+            }
           );
           process.on("SIGINT", () => {
             runner.cancel();
@@ -804,6 +829,9 @@ export function runCli() {
             runner.onChange(printExecutedGraph);
           }
           const runResult = await runner.result();
+          if (lineageEmitter) {
+            await lineageEmitter.drain(LINEAGE_DRAIN_TIMEOUT_MS);
+          }
           if (!isJsonOutput) {
             printExecutedGraph(runResult);
           }
@@ -925,6 +953,20 @@ export function runCli() {
   if (!builtYargs._[0]) {
     yargs.showHelp();
   }
+}
+
+function createLineageEmitter(
+  argv: yargs.Arguments<any>,
+  executionGraph: dataform.IExecutionGraph,
+  readCredentials: dataform.IBigQuery | undefined
+): LineageEmitter | undefined {
+  return createLineageEmitterFromFactory({
+    cliEmitLineage: argv[emitLineageOption.name] as boolean | undefined,
+    workflowLineageEnabled: executionGraph.projectConfig?.lineageEnabled ?? undefined,
+    dryRun: !!argv[dryRunOptionName],
+    projectDir: argv[projectDirOption.name] || process.cwd(),
+    readCredentials
+  });
 }
 
 class ProjectConfigOptions {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@bazel/typescript": "^3.0.0",
     "@google-cloud/storage": "^7.19.0",
     "@google-cloud/bigquery": "~8.3.0",
+    "@google-cloud/lineage": "^2.1.1",
     "@rollup/plugin-node-resolve": "^7.1.3",
     "@types/chai": "^4.1.7",
     "@types/diff": "^4.0.2",

--- a/packages/@dataform/cli/BUILD
+++ b/packages/@dataform/cli/BUILD
@@ -32,6 +32,7 @@ nodejs_binary(
 
 externals = [
     "@google-cloud/bigquery",
+    "@google-cloud/lineage",
     "chokidar",
     "deepmerge",
     "fs-extra",

--- a/yarn.lock
+++ b/yarn.lock
@@ -167,6 +167,13 @@
     retry-request "^8.0.0"
     teeny-request "^10.0.0"
 
+"@google-cloud/lineage@^2.1.1":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@google-cloud/lineage/-/lineage-2.1.1.tgz#b9d62b8f308749b984bb78a78c1098c82e41ade6"
+  integrity sha512-msSvjRxsWYLIL8FunF7arUdIaYl/5nZwFlaVmbXVUu0HInbF2yK53qAPV3V5B7lY02SPr2qyfnNGQjf4LSeJfQ==
+  dependencies:
+    google-gax "^5.0.0"
+
 "@google-cloud/paginator@^5.0.0":
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/@google-cloud/paginator/-/paginator-5.0.2.tgz#86ad773266ce9f3b82955a8f75e22cd012ccc889"
@@ -227,6 +234,24 @@
     retry-request "^7.0.0"
     teeny-request "^9.0.0"
     uuid "^8.0.0"
+
+"@grpc/grpc-js@^1.12.6":
+  version "1.14.4"
+  resolved "https://registry.yarnpkg.com/@grpc/grpc-js/-/grpc-js-1.14.4.tgz#e73ff57d97802f063999545f43ebb2b1eca65d9d"
+  integrity sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==
+  dependencies:
+    "@grpc/proto-loader" "^0.8.0"
+    "@js-sdsl/ordered-map" "^4.4.2"
+
+"@grpc/proto-loader@^0.8.0":
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/@grpc/proto-loader/-/proto-loader-0.8.1.tgz#5a6b290ccbfb1ae2f6775afb74e9898bd8c5d4e8"
+  integrity sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==
+  dependencies:
+    lodash.camelcase "^4.3.0"
+    long "^5.0.0"
+    protobufjs "^7.5.5"
+    yargs "^17.7.2"
 
 "@humanwhocodes/config-array@^0.13.0":
   version "0.13.0"
@@ -298,6 +323,11 @@
   dependencies:
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
+
+"@js-sdsl/ordered-map@^4.4.2":
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz#9299f82874bab9e4c7f9c48d865becbfe8d6907c"
+  integrity sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==
 
 "@jsdoc/salty@^0.2.1":
   version "0.2.12"
@@ -1385,6 +1415,15 @@ cliui@^7.0.2:
   dependencies:
     string-width "^4.2.0"
     strip-ansi "^6.0.0"
+    wrap-ansi "^7.0.0"
+
+cliui@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-8.0.1.tgz#0c04b075db02cbfe60dc8e6cf2f5486b1a3608aa"
+  integrity sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==
+  dependencies:
+    string-width "^4.2.0"
+    strip-ansi "^6.0.1"
     wrap-ansi "^7.0.0"
 
 clone-deep@^4.0.1:
@@ -2482,7 +2521,7 @@ globby@^11.1.0:
     merge2 "^1.4.1"
     slash "^3.0.0"
 
-google-auth-library@^10.0.0-rc.1:
+google-auth-library@10.5.0, google-auth-library@^10.0.0-rc.1:
   version "10.5.0"
   resolved "https://registry.yarnpkg.com/google-auth-library/-/google-auth-library-10.5.0.tgz#3f0ebd47173496b91d2868f572bb8a8180c4b561"
   integrity sha512-7ABviyMOlX5hIVD60YOfHw4/CxOfBhyduaYB+wbFWCWoni4N7SLcV46hrVRktuBbZjFC9ONyqamZITN7q3n32w==
@@ -2507,15 +2546,32 @@ google-auth-library@^9.6.3:
     gtoken "^7.0.0"
     jws "^4.0.0"
 
+google-gax@^5.0.0:
+  version "5.0.8"
+  resolved "https://registry.yarnpkg.com/google-gax/-/google-gax-5.0.8.tgz#7f1ceab60482c2352387da824400cfc23aff5972"
+  integrity sha512-M4vpZcXQIC1gqIVGQ7eaU3jXQA6zecStyTXu514TYfThlgSurYJOxHZo9fzU6hAgwPWvuEynAVHWyaIk80VeEA==
+  dependencies:
+    "@grpc/grpc-js" "^1.12.6"
+    "@grpc/proto-loader" "^0.8.0"
+    duplexify "^4.1.3"
+    google-auth-library "10.5.0"
+    google-logging-utils "1.1.3"
+    node-fetch "^3.3.2"
+    object-hash "^3.0.0"
+    proto3-json-serializer "3.0.4"
+    protobufjs "^7.5.4"
+    retry-request "^8.0.2"
+    rimraf "^5.0.1"
+
+google-logging-utils@1.1.3, google-logging-utils@^1.0.0:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/google-logging-utils/-/google-logging-utils-1.1.3.tgz#17b71f1f95d266d2ddd356b8f00178433f041b17"
+  integrity sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==
+
 google-logging-utils@^0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/google-logging-utils/-/google-logging-utils-0.0.2.tgz#5fd837e06fa334da450433b9e3e1870c1594466a"
   integrity sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==
-
-google-logging-utils@^1.0.0:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/google-logging-utils/-/google-logging-utils-1.1.3.tgz#17b71f1f95d266d2ddd356b8f00178433f041b17"
-  integrity sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==
 
 google-sql-syntax-ts@^1.0.3:
   version "1.0.3"
@@ -2990,14 +3046,7 @@ js-yaml@^3.13.1:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
-js-yaml@^4.1.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.3.0.tgz#d1900572a7f7cf0b5f540c83673e60bad3436592"
-  integrity sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==
-  dependencies:
-    argparse "^2.0.1"
-
-js-yaml@^4.2.0:
+js-yaml@^4.1.0, js-yaml@^4.2.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.3.0.tgz#d1900572a7f7cf0b5f540c83673e60bad3436592"
   integrity sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==
@@ -3256,6 +3305,11 @@ locate-path@^6.0.0:
   dependencies:
     p-locate "^5.0.0"
 
+lodash.camelcase@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
+  integrity sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==
+
 lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
@@ -3271,7 +3325,7 @@ long@^4.0.0:
   resolved "https://registry.yarnpkg.com/long/-/long-4.0.0.tgz#9a7b71cfb7d361a194ea555241c92f7468d5bf28"
   integrity "sha1-mntxz7fTYaGU6lVSQckvdGjVvyg= sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
 
-long@^5.3.2:
+long@^5.0.0, long@^5.3.2:
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/long/-/long-5.3.2.tgz#1d84463095999262d7d7b7f8bfd4a8cc55167f83"
   integrity sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==
@@ -3611,6 +3665,11 @@ object-copy@^0.1.0:
     define-property "^0.2.5"
     kind-of "^3.0.3"
 
+object-hash@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-3.0.0.tgz#73f97f753e7baffc0e2cc9d6e079079744ac82e9"
+  integrity sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==
+
 object-inspect@^1.9.0:
   version "1.10.2"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.10.2.tgz#b6385a3e2b7cae0b5eafcf90cddf85d128767f30"
@@ -3908,6 +3967,13 @@ proto-list@~1.2.1:
   resolved "https://registry.yarnpkg.com/proto-list/-/proto-list-1.2.4.tgz#212d5bfe1318306a420f6402b8e26ff39647a849"
   integrity "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk= sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA=="
 
+proto3-json-serializer@3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/proto3-json-serializer/-/proto3-json-serializer-3.0.4.tgz#e8065316901d94cb5a08733855ed279ade84c72c"
+  integrity sha512-E1sbAYg3aEbXrq0n1ojJkRHQJGE1kaE/O6GLA94y8rnJBfgvOPTOd1b9hOceQK1FFZI9qMh1vBERCyO2ifubcw==
+  dependencies:
+    protobufjs "^7.4.0"
+
 protobufjs-cli@^1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/protobufjs-cli/-/protobufjs-cli-1.3.3.tgz#72ed54b9b634e9191351d2a4db68363dde76fc4a"
@@ -3924,7 +3990,7 @@ protobufjs-cli@^1.3.3:
     tmp "^0.2.1"
     uglify-js "^3.7.7"
 
-protobufjs@6.8.8, protobufjs@^7.0.0, protobufjs@^7.6.5:
+protobufjs@6.8.8, protobufjs@^7.0.0, protobufjs@^7.4.0, protobufjs@^7.5.4, protobufjs@^7.5.5, protobufjs@^7.6.5:
   version "7.6.5"
   resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-7.6.5.tgz#7b9250cdaf4a06139a9f0fe468a40d7d4febca71"
   integrity sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==
@@ -4184,6 +4250,14 @@ retry-request@^8.0.0:
   version "8.0.2"
   resolved "https://registry.yarnpkg.com/retry-request/-/retry-request-8.0.2.tgz#c9b247b79e6347eb7cbae0cf5f1b981b87c29083"
   integrity sha512-JzFPAfklk1kjR1w76f0QOIhoDkNkSqW8wYKT08n9yysTmZfB+RQ2QoXoTAeOi1HD9ZipTyTAZg3c4pM/jeqgSw==
+  dependencies:
+    extend "^3.0.2"
+    teeny-request "^10.0.0"
+
+retry-request@^8.0.2:
+  version "8.0.4"
+  resolved "https://registry.yarnpkg.com/retry-request/-/retry-request-8.0.4.tgz#54fd0d655409efd2d6dd377c1a5fc89eb4c1807a"
+  integrity sha512-pI6/7eabUYkZxamkOq0g0uMxKLLGnjzhefY+vL8bVXag5rto4OU2YBTPytWLuHH7aEKD6fn7kJycQfid0Mwnkw==
   dependencies:
     extend "^3.0.2"
     teeny-request "^10.0.0"
@@ -4504,7 +4578,7 @@ stream-shift@^1.0.2:
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.1"
 
-string-width@4.1.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^5.1.2:
+string-width@4.1.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3, string-width@^5.1.2:
   version "4.1.0"
   resolved "https://registry.npmjs.org/string-width/-/string-width-4.1.0.tgz#ba846d1daa97c3c596155308063e075ed1c99aff"
   integrity sha512-NrX+1dVVh+6Y9dnQ19pR0pP4FiEIlUvdTGn8pw6CKTNq5sgib2nIhmUNT5TAmhWmvKr3WcxBcP3E8nWezuipuQ==
@@ -4527,7 +4601,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -4540,13 +4614,6 @@ strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.2.0"
@@ -5252,6 +5319,11 @@ yargs-parser@^20.2.2:
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.7.tgz#61df85c113edfb5a7a4e36eb8aa60ef423cbc90a"
   integrity "sha1-Yd+FwRPt+1p6TjbriqYO9CPLyQo= sha512-FiNkvbeHzB/syOjIUxFDCnhSfzAL8R5vs40MgLFBorXACCOAEaWu0gRZl14vG8MR9AOJIZbmkjhusqBYZ3HTHw=="
 
+yargs-parser@^21.1.1:
+  version "21.1.1"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.1.1.tgz#9096bceebf990d21bb31fa9516e0ede294a77d35"
+  integrity sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==
+
 yargs@^16.2.0:
   version "16.2.0"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-16.2.0.tgz#1c82bf0f6b6a66eafce7ef30e376f49a12477f66"
@@ -5264,6 +5336,19 @@ yargs@^16.2.0:
     string-width "^4.2.0"
     y18n "^5.0.5"
     yargs-parser "^20.2.2"
+
+yargs@^17.7.2:
+  version "17.7.3"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.7.3.tgz#779dffe6bcafec596a7172e983289a588647faaa"
+  integrity sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==
+  dependencies:
+    cliui "^8.0.1"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.3"
+    y18n "^5.0.5"
+    yargs-parser "^21.1.1"
 
 yauzl@^2.3.1:
   version "2.10.0"


### PR DESCRIPTION
Adds an opt-in lineage emitter that publishes OpenLineage
START/COMPLETE/FAIL/ABORT RunEvents to Knowledge Catalog Lineage
(datalineage.googleapis.com) for each action executed by
`dataform run`. Off by default. Enabled via `--emit-lineage`
on the CLI or `lineageEnabled: true` in workflow_settings.

PR 1 of a 3-PR series. Scope: emitter + payload builder +
factory + integration tests. Facets included: parent,
nominalTime, gcp_lineage, gcp_bq_pipelines_run.runType.
Fail-open: lineage failures never affect workflow status.

Excluded from this PR (later PRs): endpoint router with REP
fallback, gax retry, structured error classification,
externalQuery/errorMessage/sql/jobType/gcp_bq_pipelines_job
facets, staging endpoint override.