### PR TITLE
Bump DF_VERSION from 3.0.64 to 3.0.65

### DIFF
--- a/version.bzl
+++ b/version.bzl
@@ -1,1 +1,1 @@
-DF_VERSION = "3.0.64"
+DF_VERSION = "3.0.65"


### PR DESCRIPTION
Bumps the npm package version to release the `PropertyGraph` action (#2243, #2246, #2249) and JiT assertion integration (#2185, #2223).