### PR TITLE
Fix malformed dot output for operations in --dot compile output

### DIFF
--- a/cli/console.ts
+++ b/cli/console.ts
@@ -567,7 +567,7 @@ export function dotRepresentation(graph: dataform.ICompiledGraph, interactive: b
 
   graph.operations?.forEach(operation => {
     const nodeName = `${formatTarget(operation.target)}`;
-    nodes.push(`"${nodeName}" [label="${formatTarget(operation.target)}"`);
+    nodes.push(`"${nodeName}" [label="${formatTarget(operation.target)}"]`);
     operation.dependencyTargets?.forEach(dependencyTarget => {
       edges.push(`"${formatTarget(dependencyTarget)}" -> "${nodeName}"`);
     });


### PR DESCRIPTION
follow-up https://github.com/dataform-co/dataform/pull/2116/

The operation node label in dotRepresentation() was missing its closing "]", producing invalid dot syntax whenever a project contained operations.


```
# name.sqlx
config {
  type: "operation",
}
```

`dataform compile --dot`

```
# before
digraph {
"schema.name" [label="schema.name";
...
}

# after
digraph {
"schema.name" [label="schema.name"];
...
}
```