### PR TITLE
Follow-up to #2251: address PropertyGraph review comments

### DIFF
--- a/core/actions/property_graph.ts
+++ b/core/actions/property_graph.ts
@@ -9,7 +9,7 @@ const CATALOG_NOT_SUPPORTED_MESSAGE =
 export class PropertyGraph extends ActionBuilder<dataform.PropertyGraph> {
   public session: Session;
 
-  private proto = dataform.PropertyGraph.create();
+  private proto = dataform.PropertyGraph.create({ description: "", disabled: false });
 
   constructor(session?: Session, unverifiedConfig?: any, filename?: string) {
     super(session);
@@ -43,7 +43,12 @@ export class PropertyGraph extends ActionBuilder<dataform.PropertyGraph> {
 
     this.proto.fileName = filename;
     if (config.description) {
+      // Stored on the compiled proto but not yet emitted to graphBody OPTIONS;
+      // DDL propagation is planned.
       this.proto.description = config.description;
+    }
+    if (config.disabled) {
+      this.proto.disabled = config.disabled;
     }
 
     this.proto.entities = config.entities.map(entityConfig =>
@@ -259,10 +264,6 @@ export class PropertyGraph extends ActionBuilder<dataform.PropertyGraph> {
       const edgeEntries = this.proto.relationships.map(rel => renderEdge(rel));
       parts.push(`EDGE TABLES (\n  ${edgeEntries.join(",\n  ")}\n)`);
     }
-    const options = renderOptionsClause(this.proto.description, undefined);
-    if (options) {
-      parts.push(options);
-    }
     return parts.join("\n");
   }
 }
@@ -343,7 +344,12 @@ function buildLabels(
     );
   }
   if (configuredLabels.length > 0) {
-    return configuredLabels.map(label => buildLabel(label, where, false));
+    const built = configuredLabels.map(label => buildLabel(label, where, defaultLabelName));
+    const defaultCount = built.filter(label => label.isDefault).length;
+    if (defaultCount > 1) {
+      throw new Error(`${where}: only one DEFAULT label is allowed.`);
+    }
+    return built;
   }
   const hasRootData =
     rootFields.length > 0 ||
@@ -360,34 +366,45 @@ function buildLabels(
     fields: rootFields,
     fieldWildcard: rootWildcard
   });
-  return [buildLabel(synthesized, where, true)];
+  return [buildLabel(synthesized, where, defaultLabelName, true)];
 }
 
 function buildLabel(
   label: dataform.IGraphLabelConfig,
   where: string,
-  isDefault: boolean
+  defaultLabelName: string,
+  forceDefault = false
 ): dataform.GraphLabel {
-  if (!label.name) {
-    throw new Error(`${where}: every label must have a 'name'.`);
+  const isDefault = forceDefault || !label.name || label.name.toUpperCase() === "DEFAULT";
+  if (!isDefault && !label.name) {
+    throw new Error(`${where}: every non-default label must have a 'name'.`);
   }
+  const labelId = isDefault ? "DEFAULT" : `'${label.name}'`;
   const wildcard = label.fieldWildcard;
   if (wildcard && wildcard.importAll === false && wildcard.except && wildcard.except.length > 0) {
     throw new Error(
-      `${where}: label '${label.name}' has 'fieldWildcard.except' set but 'importAll' is false.`
+      `${where}: label ${labelId} has 'fieldWildcard.except' set but 'importAll' is false.`
     );
   }
   const hasFields = !!(label.fields && label.fields.length > 0);
   const hasWildcard = !!(wildcard && wildcard.importAll);
-  const hasOptions = !!label.description || !!(label.synonyms && label.synonyms.length > 0);
+  const hasDescription = !!label.description;
+  const hasSynonyms = !!(label.synonyms && label.synonyms.length > 0);
+  const hasOptions = hasDescription || hasSynonyms;
+  if (!isDefault && hasOptions) {
+    throw new Error(
+      `${where}: label ${labelId} cannot declare 'description' or 'synonyms'; ` +
+        `these are only allowed on the DEFAULT label (name absent or 'DEFAULT').`
+    );
+  }
   if (!hasFields && !hasWildcard && !hasOptions) {
     throw new Error(
-      `${where}: label '${label.name}' must declare at least one of: 'fields', ` +
+      `${where}: label ${labelId} must declare at least one of: 'fields', ` +
         `'fieldWildcard', 'description', or 'synonyms'.`
     );
   }
   return dataform.GraphLabel.create({
-    name: label.name,
+    name: isDefault ? defaultLabelName : label.name,
     description: label.description,
     synonyms: label.synonyms || [],
     fields: (label.fields || []).map(field =>
@@ -463,9 +480,11 @@ function renderEndpoint(role: "SOURCE" | "DESTINATION", endpoint: dataform.IGrap
 function renderLabelClause(label: dataform.IGraphLabel): string {
   const head = label.isDefault ? "DEFAULT LABEL" : `LABEL ${label.name}`;
   const parts: string[] = [head];
-  const options = renderOptionsClause(label.description, label.synonyms);
-  if (options) {
-    parts.push(options);
+  if (label.isDefault) {
+    const options = renderOptionsClause(label.description, label.synonyms);
+    if (options) {
+      parts.push(options);
+    }
   }
   const properties = renderPropertiesClause(label);
   if (properties) {

--- a/core/actions/property_graph_test.ts
+++ b/core/actions/property_graph_test.ts
@@ -43,6 +43,8 @@ suite("property_graph", () => {
         target: graphTarget("Simple"),
         canonicalTarget: graphTarget("Simple"),
         fileName: "definitions/graph.yaml",
+        description: "",
+        disabled: false,
         entities: [
           {
             name: "Account",
@@ -68,6 +70,8 @@ suite("property_graph", () => {
         target: graphTarget("G"),
         canonicalTarget: graphTarget("G"),
         fileName: "definitions/graph.yaml",
+        description: "",
+        disabled: false,
         entities: [
           {
             name: "A",
@@ -93,6 +97,8 @@ suite("property_graph", () => {
         target: graphTarget("G"),
         canonicalTarget: graphTarget("G"),
         fileName: "definitions/graph.yaml",
+        description: "",
+        disabled: false,
         entities: [
           {
             name: "A",
@@ -122,6 +128,8 @@ suite("property_graph", () => {
         target: graphTarget("G"),
         canonicalTarget: graphTarget("G"),
         fileName: "definitions/graph.yaml",
+        description: "",
+        disabled: false,
         entities: [
           {
             name: "A",
@@ -152,6 +160,8 @@ suite("property_graph", () => {
         target: graphTarget("G"),
         canonicalTarget: graphTarget("G"),
         fileName: "definitions/graph.yaml",
+        description: "",
+        disabled: false,
         entities: [
           {
             name: "Account",
@@ -192,6 +202,8 @@ suite("property_graph", () => {
         target: graphTarget("G"),
         canonicalTarget: graphTarget("G"),
         fileName: "definitions/graph.yaml",
+        description: "",
+        disabled: false,
         entities: [
           {
             name: "A",
@@ -235,6 +247,8 @@ suite("property_graph", () => {
         target: graphTarget("G"),
         canonicalTarget: graphTarget("G"),
         fileName: "definitions/graph.yaml",
+        description: "",
+        disabled: false,
         entities: [
           {
             name: "A",
@@ -269,6 +283,8 @@ suite("property_graph", () => {
         target: graphTarget("G"),
         canonicalTarget: graphTarget("G"),
         fileName: "definitions/graph.yaml",
+        description: "",
+        disabled: false,
         entities: [
           {
             name: "A",
@@ -313,6 +329,8 @@ suite("property_graph", () => {
         target: graphTarget("G"),
         canonicalTarget: graphTarget("G"),
         fileName: "definitions/graph.yaml",
+        description: "",
+        disabled: false,
         entities: [
           {
             name: "Account",
@@ -369,6 +387,8 @@ suite("property_graph", () => {
         target: graphTarget("FinGraph"),
         canonicalTarget: graphTarget("FinGraph"),
         fileName: "definitions/graph.yaml",
+        description: "",
+        disabled: false,
         entities: [
           {
             name: "Account",
@@ -428,6 +448,8 @@ suite("property_graph", () => {
         target: graphTarget("G"),
         canonicalTarget: graphTarget("G"),
         fileName: "definitions/graph.yaml",
+        description: "",
+        disabled: false,
         entities: [
           {
             name: "Account",
@@ -488,6 +510,8 @@ suite("property_graph", () => {
         target: graphTarget("G"),
         canonicalTarget: graphTarget("G"),
         fileName: "definitions/graph.yaml",
+        description: "",
+        disabled: false,
         entities: [
           {
             name: "Account",
@@ -688,6 +712,8 @@ suite("property_graph", () => {
         target: graphTarget("G"),
         canonicalTarget: graphTarget("G"),
         fileName: "definitions/graph.yaml",
+        description: "",
+        disabled: false,
         entities: [
           {
             name: "A",
@@ -721,6 +747,8 @@ suite("property_graph", () => {
         target: graphTarget("G"),
         canonicalTarget: graphTarget("G"),
         fileName: "definitions/graph.yaml",
+        description: "",
+        disabled: false,
         entities: [
           {
             name: "Account",
@@ -787,6 +815,8 @@ suite("property_graph", () => {
         target: graphTarget("G"),
         canonicalTarget: graphTarget("G"),
         fileName: "definitions/graph.yaml",
+        description: "",
+        disabled: false,
         entities: [
           {
             name: "A",
@@ -821,6 +851,8 @@ suite("property_graph", () => {
         target: graphTarget("G"),
         canonicalTarget: graphTarget("G"),
         fileName: "definitions/graph.yaml",
+        description: "",
+        disabled: false,
         entities: [
           {
             name: "A",
@@ -862,6 +894,8 @@ suite("property_graph", () => {
         target: graphTarget("G"),
         canonicalTarget: graphTarget("G"),
         fileName: "definitions/graph.yaml",
+        description: "",
+        disabled: false,
         entities: [
           {
             name: "Account",
@@ -904,6 +938,8 @@ suite("property_graph", () => {
         target: graphTarget("G"),
         canonicalTarget: graphTarget("G"),
         fileName: "definitions/graph.yaml",
+        description: "",
+        disabled: false,
         entities: [
           {
             name: "Account",
@@ -925,54 +961,46 @@ suite("property_graph", () => {
     );
   });
 
-  test("named label description and synonyms render as inline LABEL OPTIONS", () => {
-    const compiled = compile({
-      name: "G",
-      entities: [
-        {
-          name: "Account",
-          dataSourceString: "p.d.A",
-          keys: ["id"],
-          labels: [
-            {
-              name: "Account",
-              description: "customer accounts",
-              synonyms: ["customer", "user_account"],
-              fields: [{ name: "id", expression: "id" }]
-            }
-          ]
-        }
-      ]
-    });
-
-    expect(asPlainObject(compiled)).deep.equals(
-      asPlainObject({
-        target: graphTarget("G"),
-        canonicalTarget: graphTarget("G"),
-        fileName: "definitions/graph.yaml",
+  test("errors when a non-default label declares description or synonyms", () => {
+    expect(() =>
+      compile({
+        name: "G",
         entities: [
           {
             name: "Account",
-            dataSource: { database: "p", schema: "d", name: "A" },
+            dataSourceString: "p.d.A",
             keys: ["id"],
             labels: [
               {
                 name: "Account",
                 description: "customer accounts",
-                synonyms: ["customer", "user_account"],
-                fields: [{ name: "id", expression: "id" }],
-                importAll: false,
-                isDefault: false
+                fields: [{ name: "id", expression: "id" }]
               }
             ]
           }
-        ],
-        graphBody:
-          "NODE TABLES (\n  `p.d.A` AS Account KEY (id) LABEL Account " +
-          `OPTIONS(description="customer accounts", ` +
-          `synonyms=["customer", "user_account"]) PROPERTIES (id)\n)`
+        ]
       })
-    );
+    ).to.throw("only allowed on the DEFAULT label");
+
+    expect(() =>
+      compile({
+        name: "G",
+        entities: [
+          {
+            name: "Account",
+            dataSourceString: "p.d.A",
+            keys: ["id"],
+            labels: [
+              {
+                name: "Account",
+                synonyms: ["customer"],
+                fields: [{ name: "id", expression: "id" }]
+              }
+            ]
+          }
+        ]
+      })
+    ).to.throw("only allowed on the DEFAULT label");
   });
 
   test("field description and synonyms render as per-field OPTIONS(...)", () => {
@@ -1000,6 +1028,8 @@ suite("property_graph", () => {
         target: graphTarget("G"),
         canonicalTarget: graphTarget("G"),
         fileName: "definitions/graph.yaml",
+        description: "",
+        disabled: false,
         entities: [
           {
             name: "A",
@@ -1030,13 +1060,11 @@ suite("property_graph", () => {
     );
   });
 
-  test("graph-level description appends OPTIONS(description=...) after NODE/EDGE TABLES", () => {
+  test("graph-level description is stored on the compiled proto but not emitted to graphBody", () => {
     const compiled = compile({
       name: "G",
       description: "high-value customer graph",
-      entities: [
-        { name: "A", dataSourceString: "p.d.A", keys: ["id"] }
-      ]
+      entities: [{ name: "A", dataSourceString: "p.d.A", keys: ["id"] }]
     });
 
     expect(asPlainObject(compiled)).deep.equals(
@@ -1044,6 +1072,7 @@ suite("property_graph", () => {
         target: graphTarget("G"),
         canonicalTarget: graphTarget("G"),
         fileName: "definitions/graph.yaml",
+        disabled: false,
         description: "high-value customer graph",
         entities: [
           {
@@ -1052,9 +1081,7 @@ suite("property_graph", () => {
             keys: ["id"]
           }
         ],
-        graphBody:
-          "NODE TABLES (\n  `p.d.A` AS A KEY (id)\n)\n" +
-          `OPTIONS(description="high-value customer graph")`
+        graphBody: "NODE TABLES (\n  `p.d.A` AS A KEY (id)\n)"
       })
     );
   });
@@ -1077,6 +1104,8 @@ suite("property_graph", () => {
         target: graphTarget("G"),
         canonicalTarget: graphTarget("G"),
         fileName: "definitions/graph.yaml",
+        description: "",
+        disabled: false,
         entities: [
           {
             name: "Account",
@@ -1117,6 +1146,8 @@ suite("property_graph", () => {
         target: graphTarget("G"),
         canonicalTarget: graphTarget("G"),
         fileName: "definitions/graph.yaml",
+        description: "",
+        disabled: false,
         entities: [
           {
             name: "A",
@@ -1142,9 +1173,13 @@ suite("property_graph", () => {
   test("string quoting in OPTIONS escapes newlines carriage returns and tabs", () => {
     const compiled = compile({
       name: "G",
-      description: "line1\nline2\r\nline3\ttab",
       entities: [
-        { name: "A", dataSourceString: "p.d.A", keys: ["id"] }
+        {
+          name: "A",
+          dataSourceString: "p.d.A",
+          keys: ["id"],
+          description: "line1\nline2\r\nline3\ttab"
+        }
       ]
     });
 
@@ -1153,7 +1188,159 @@ suite("property_graph", () => {
         target: graphTarget("G"),
         canonicalTarget: graphTarget("G"),
         fileName: "definitions/graph.yaml",
-        description: "line1\nline2\r\nline3\ttab",
+        description: "",
+        disabled: false,
+        entities: [
+          {
+            name: "A",
+            dataSource: { database: "p", schema: "d", name: "A" },
+            keys: ["id"],
+            labels: [
+              {
+                name: "A",
+                description: "line1\nline2\r\nline3\ttab",
+                importAll: false,
+                isDefault: true
+              }
+            ]
+          }
+        ],
+        graphBody:
+          "NODE TABLES (\n  `p.d.A` AS A KEY (id) DEFAULT LABEL " +
+          `OPTIONS(description="line1\\nline2\\r\\nline3\\ttab")\n)`
+      })
+    );
+  });
+
+  test("label with name 'DEFAULT' is treated as DEFAULT LABEL", () => {
+    const compiled = compile({
+      name: "G",
+      entities: [
+        {
+          name: "A",
+          dataSourceString: "p.d.A",
+          keys: ["id"],
+          labels: [
+            {
+              name: "DEFAULT",
+              description: "the default",
+              synonyms: ["main"],
+              fields: [{ name: "id", expression: "id" }]
+            }
+          ]
+        }
+      ]
+    });
+
+    expect(asPlainObject(compiled)).deep.equals(
+      asPlainObject({
+        target: graphTarget("G"),
+        canonicalTarget: graphTarget("G"),
+        fileName: "definitions/graph.yaml",
+        description: "",
+        disabled: false,
+        entities: [
+          {
+            name: "A",
+            dataSource: { database: "p", schema: "d", name: "A" },
+            keys: ["id"],
+            labels: [
+              {
+                name: "A",
+                description: "the default",
+                synonyms: ["main"],
+                fields: [{ name: "id", expression: "id" }],
+                importAll: false,
+                isDefault: true
+              }
+            ]
+          }
+        ],
+        graphBody:
+          "NODE TABLES (\n  `p.d.A` AS A KEY (id) DEFAULT LABEL " +
+          `OPTIONS(description="the default", synonyms=["main"]) PROPERTIES (id)\n)`
+      })
+    );
+  });
+
+  test("label name 'default' is case-insensitive and treated as DEFAULT LABEL", () => {
+    const compiled = compile({
+      name: "G",
+      entities: [
+        {
+          name: "A",
+          dataSourceString: "p.d.A",
+          keys: ["id"],
+          labels: [
+            {
+              name: "default",
+              fields: [{ name: "id", expression: "id" }]
+            }
+          ]
+        }
+      ]
+    });
+
+    expect(asPlainObject(compiled)).deep.equals(
+      asPlainObject({
+        target: graphTarget("G"),
+        canonicalTarget: graphTarget("G"),
+        fileName: "definitions/graph.yaml",
+        description: "",
+        disabled: false,
+        entities: [
+          {
+            name: "A",
+            dataSource: { database: "p", schema: "d", name: "A" },
+            keys: ["id"],
+            labels: [
+              {
+                name: "A",
+                fields: [{ name: "id", expression: "id" }],
+                importAll: false,
+                isDefault: true
+              }
+            ]
+          }
+        ],
+        graphBody: "NODE TABLES (\n  `p.d.A` AS A KEY (id) DEFAULT LABEL PROPERTIES (id)\n)"
+      })
+    );
+  });
+
+  test("errors when more than one DEFAULT label is declared", () => {
+    expect(() =>
+      compile({
+        name: "G",
+        entities: [
+          {
+            name: "A",
+            dataSourceString: "p.d.A",
+            keys: ["id"],
+            labels: [
+              { name: "DEFAULT", fields: [{ name: "id", expression: "id" }] },
+              { name: "default", fields: [{ name: "id", expression: "id" }] }
+            ]
+          }
+        ]
+      })
+    ).to.throw("only one DEFAULT label is allowed");
+  });
+
+  test("disabled=true propagates onto the compiled PropertyGraph", () => {
+    const compiled = compile({
+      name: "G",
+      disabled: true,
+      entities: [{ name: "A", dataSourceString: "p.d.A", keys: ["id"] }]
+    });
+
+    expect(asPlainObject(compiled)).deep.equals(
+      asPlainObject({
+        target: graphTarget("G"),
+        canonicalTarget: graphTarget("G"),
+        fileName: "definitions/graph.yaml",
+        description: "",
+        disabled: true,
         entities: [
           {
             name: "A",
@@ -1161,9 +1348,7 @@ suite("property_graph", () => {
             keys: ["id"]
           }
         ],
-        graphBody:
-          "NODE TABLES (\n  `p.d.A` AS A KEY (id)\n)\n" +
-          `OPTIONS(description="line1\\nline2\\r\\nline3\\ttab")`
+        graphBody: "NODE TABLES (\n  `p.d.A` AS A KEY (id)\n)"
       })
     );
   });

--- a/core/main_test.ts
+++ b/core/main_test.ts
@@ -2441,6 +2441,8 @@ entities:
               database: "defaultProject"
             },
             fileName: "definitions/graph.yaml",
+            description: "",
+            disabled: false,
             entities: [
               {
                 name: "Customer",
@@ -2558,6 +2560,8 @@ entities:
               database: "defaultProject"
             },
             fileName: "definitions/graph.yaml",
+            description: "",
+            disabled: false,
             entities: [
               {
                 name: "Customer",
@@ -2632,6 +2636,8 @@ entities:
               database: "defaultProject"
             },
             fileName: "definitions/graph.yaml",
+            description: "",
+            disabled: false,
             entities: [
               {
                 name: "Customer",
@@ -2827,6 +2833,8 @@ relationships:
               database: "defaultProject"
             },
             fileName: "definitions/graph.yaml",
+            description: "",
+            disabled: false,
             entities: [
               {
                 name: "Customer",
@@ -3015,6 +3023,7 @@ relationships:
             },
             fileName: "definitions/graph.yaml",
             description: "end to end snake case",
+            disabled: false,
             entities: [
               {
                 name: "Account",
@@ -3064,8 +3073,7 @@ relationships:
               "  `defaultProject.defaultDataset.ownership` AS Owns " +
               "SOURCE KEY (owner_id) REFERENCES Account (id) " +
               "DESTINATION KEY (owned_id) REFERENCES Account (id)\n" +
-              ")\n" +
-              `OPTIONS(description="end to end snake case")`
+              ")"
           }
         ]
       }));

--- a/protos/core.proto
+++ b/protos/core.proto
@@ -447,6 +447,7 @@ message PropertyGraph {
   repeated GraphEntity entities = 6;
   repeated GraphRelationship relationships = 7;
   string graph_body = 8;
+  bool disabled = 9;
 }
 
 message GraphEntity {

--- a/protos/property_graph_config.proto
+++ b/protos/property_graph_config.proto
@@ -14,6 +14,7 @@ message PropertyGraphConfig {
   TargetDataset target_dataset = 3;
   repeated GraphEntityConfig entities = 4;
   repeated GraphRelationshipConfig relationships = 5;
+  bool disabled = 6;
 
   message TargetDataset {
     string project_id = 1;
@@ -27,7 +28,7 @@ message GraphEntityConfig {
     string data_source_string = 2;
     DatasetDataSource data_source_dataset = 3;
     CatalogDataSource data_source_catalog = 4;
-    GraphRef data_source_ref = 11;
+    DataSourceRef data_source_ref = 11;
   }
   repeated string keys = 5;
   string description = 6;
@@ -43,7 +44,7 @@ message GraphRelationshipConfig {
     string data_source_string = 2;
     DatasetDataSource data_source_dataset = 3;
     CatalogDataSource data_source_catalog = 4;
-    GraphRef data_source_ref = 13;
+    DataSourceRef data_source_ref = 13;
   }
   repeated string keys = 5;
   string description = 6;
@@ -98,7 +99,7 @@ message CatalogDataSource {
   string table = 4;
 }
 
-message GraphRef {
+message DataSourceRef {
   string name = 1;
   string schema = 2;
   string database = 3;


### PR DESCRIPTION
- Rename `GraphRef` to `DataSourceRef` in `PropertyGraphConfig` so the type name matches its field shape (a target identifier not a graph reference).
- Restrict `description` and `synonyms` OPTIONS to the DEFAULT label. Non-DEFAULT labels that declare either now error out. A label named `DEFAULT` (case-insensitive) is treated as the default and only one DEFAULT label is allowed per entity or relationship.
- Keep graph-level `description` on the compiled proto but stop emitting it in `graphBody`. DDL propagation is planned.
- Add `disabled` field to `PropertyGraphConfig` and propagate it onto the compiled `PropertyGraph` proto matching the convention used by Table View Assertion and Operation actions.