### PR TITLE
Bump DF_VERSION from 3.0.65 to 3.0.66

### DIFF
--- a/version.bzl
+++ b/version.bzl
@@ -1,1 +1,1 @@
-DF_VERSION = "3.0.65"
+DF_VERSION = "3.0.66"


### PR DESCRIPTION
## Summary
Bumps the npm package version to release the `--timeout` / `--execution-timeout` fix (#2247): restores `--timeout` as compile-only (3.0.63 semantics), adds `--execution-timeout` for the whole-run deadline, and surfaces a top-level reason line on cancellation so runs no longer exit 1 silently.