### PR TITLE
feat(lineage): harden CLI lineage emission (endpoint routing, retry)

### DIFF
--- a/cli/api/BUILD
+++ b/cli/api/BUILD
@@ -65,11 +65,7 @@ ts_test_suite(
         "commands/jit/rpc_test.ts",
         "dbadapters/bigquery_test.ts",
         "execution_sql_test.ts",
-        "lineage/emitter_factory_test.ts",
-        "lineage/emitter_test.ts",
-        "lineage/lineage_integration_test.ts",
-        "lineage/payload_builder_test.ts",
-    ],
+    ] + glob(["lineage/*_test.ts"]),
     data = [
         ":node_modules",
         "//packages/@dataform/core:package_tar",

--- a/cli/api/lineage/emitter.ts
+++ b/cli/api/lineage/emitter.ts
@@ -1,10 +1,13 @@
 import { LineageClient } from "@google-cloud/lineage";
 
+import {
+  GLOBAL_LINEAGE_ENDPOINT,
+  LineageEndpointRouter
+} from "df/cli/api/lineage/endpoint_router";
 import { LineagePayloadBuilder, toProtoStruct } from "df/cli/api/lineage/payload_builder";
 import { coerceAsError } from "df/common/errors/errors";
+import { version } from "df/core/version";
 import { dataform } from "df/protos/ts";
-
-const GLOBAL_LINEAGE_ENDPOINT = "datalineage.googleapis.com";
 
 export interface IEmitterOptions {
   lineageEnabled?: boolean;
@@ -22,6 +25,8 @@ export interface IStderrLike {
 
 export type LineageClientProvider = (projectId: string, endpoint: string) => LineageClient;
 
+const DATAFORM_CLI_LIB_NAME = "dataform-cli";
+
 export function createLineageClientProvider(
   credentials: dataform.IBigQuery
 ): LineageClientProvider {
@@ -35,7 +40,9 @@ export function createLineageClientProvider(
         new LineageClient({
           projectId: targetProjectId,
           apiEndpoint: endpoint,
-          credentials: credentials.credentials && JSON.parse(credentials.credentials)
+          credentials: credentials.credentials && JSON.parse(credentials.credentials),
+          libName: DATAFORM_CLI_LIB_NAME,
+          libVersion: version
         })
       );
     }
@@ -43,12 +50,70 @@ export function createLineageClientProvider(
   };
 }
 
+const GRPC_CODE_NAMES: { [k: number]: string } = {
+  0: "OK",
+  1: "CANCELLED",
+  2: "UNKNOWN",
+  3: "INVALID_ARGUMENT",
+  4: "DEADLINE_EXCEEDED",
+  5: "NOT_FOUND",
+  6: "ALREADY_EXISTS",
+  7: "PERMISSION_DENIED",
+  8: "RESOURCE_EXHAUSTED",
+  9: "FAILED_PRECONDITION",
+  10: "ABORTED",
+  11: "OUT_OF_RANGE",
+  12: "UNIMPLEMENTED",
+  13: "INTERNAL",
+  14: "UNAVAILABLE",
+  15: "DATA_LOSS",
+  16: "UNAUTHENTICATED"
+};
+
+function gRpcCodeName(code: number | undefined): string {
+  if (code === undefined) {
+    return "UNKNOWN";
+  }
+  return GRPC_CODE_NAMES[code] || "UNKNOWN";
+}
+
+/**
+ * Retry policy for ProcessOpenLineageRunEvent, delegated to google-gax.
+ *
+ * Transient set per gRPC canonical retry semantics (https://google.aip.dev/194):
+ *   4  DEADLINE_EXCEEDED    – RPC timed out
+ *   8  RESOURCE_EXHAUSTED   – quota/rate-limit (needs backoff, hence gax)
+ *   10 ABORTED              – concurrency conflict
+ *   13 INTERNAL             – transient server error
+ *   14 UNAVAILABLE          – server briefly unreachable
+ *
+ * Backoff: 1s / 2s / 4s exponential; total budget 15s. Per-attempt RPC
+ * timeout 2s (matches prior CallOptions.timeout).
+ *
+ * REP→global endpoint fallback is NOT expressed here — gax cannot reconfigure
+ * the client's endpoint on error. That logic stays in the outer try/catch in
+ * emitOpenLineageEvent.
+ */
+export const LINEAGE_RETRY_CONFIG = {
+  retryCodes: [4, 8, 10, 13, 14],
+  backoffSettings: {
+    initialRetryDelayMillis: 1000,
+    retryDelayMultiplier: 2.0,
+    maxRetryDelayMillis: 4000,
+    initialRpcTimeoutMillis: 2000,
+    rpcTimeoutMultiplier: 1.0,
+    maxRpcTimeoutMillis: 2000,
+    totalTimeoutMillis: 15000
+  }
+};
+
 export class LineageEmitter {
   private readonly clientProvider: LineageClientProvider;
   private readonly credentials: dataform.IBigQuery;
   private readonly emitterOptions: IEmitterOptions;
   private readonly stderr: IStderrLike;
   private readonly payloadBuilder: LineagePayloadBuilder;
+  private readonly endpointRouter: LineageEndpointRouter;
   private readonly pending = new Set<Promise<void>>();
   private emissionDisabledThisRun = false;
   private dryRunSkipLogged = false;
@@ -64,6 +129,7 @@ export class LineageEmitter {
     this.stderr = stderr;
     this.clientProvider = clientProvider || createLineageClientProvider(credentials);
     this.payloadBuilder = new LineagePayloadBuilder(emitterOptions.projectDir);
+    this.endpointRouter = new LineageEndpointRouter();
   }
 
   public emitForAction(
@@ -94,10 +160,12 @@ export class LineageEmitter {
 
     const p = this.emitForActionInternal(action, actionResult)
       .catch(e => {
-        const err = coerceAsError(e);
-        this.emissionDisabledThisRun = true;
+        const code = (e as any).code;
+        const endpoint = (e as any).lineageEndpoint || "unknown";
+        const location = (e as any).lineageLocation || "unknown";
         this.stderr.write(
-          `[lineage] Failed to emit lineage for action ${action.target.schema}.${action.target.name}: ${err.message}\n`
+          `[lineage] Failed to emit lineage for action ${action.target.schema}.${action.target.name}: ` +
+            `code=${gRpcCodeName(code)}(${code ?? "?"}) endpoint=${endpoint} location=${location} message=${e.message}\n`
         );
       })
       .finally(() => {
@@ -132,10 +200,128 @@ export class LineageEmitter {
       this.credentials.projectId
     );
 
-    const client = this.clientProvider(projectId, GLOBAL_LINEAGE_ENDPOINT);
-    await client.processOpenLineageRunEvent({
-      parent,
-      openLineage: toProtoStruct(openLineagePayload) as any
-    });
+    // Emit payload via ProcessOpenLineageRunEvent. Retry policy is delegated
+    // to google-gax (see LINEAGE_RETRY_CONFIG). Outer loop only handles
+    // behaviors gax cannot express: REP→global endpoint fallback (requires
+    // reconfiguring the client) and PERMISSION_DENIED / SERVICE_DISABLED
+    // skip-with-reason (error-swallow-with-stderr).
+    // Runs at most twice — initial invocation + one REP fallback.
+    let currentEndpoint = this.endpointRouter.endpointForLocation(location);
+    for (let repFallbackAttempts = 0; repFallbackAttempts < 2; repFallbackAttempts++) {
+      try {
+        const client = this.clientProvider(projectId, currentEndpoint);
+        await client.processOpenLineageRunEvent(
+          {
+            parent,
+            openLineage: toProtoStruct(openLineagePayload) as any
+          },
+          { retry: LINEAGE_RETRY_CONFIG }
+        );
+        return;
+      } catch (e) {
+        const err = coerceAsError(e);
+        const code = (err as any).code;
+
+        // Fall back from REP to global when the endpoint isn't serving this
+        // location — either unresolvable via DNS or reachable-but-returning
+        // an HTTP 302 (GFE routing signal that the endpoint has no route for
+        // this region).
+        const onRepEndpoint = currentEndpoint !== GLOBAL_LINEAGE_ENDPOINT;
+        if (
+          onRepEndpoint &&
+          (this.isEndpointUnresolvable(err) || this.isEndpointRegionMismatch(err))
+        ) {
+          this.stderr.write(
+            `[lineage] Regional endpoint ${currentEndpoint} is not serving location ${location}. Falling back to ${GLOBAL_LINEAGE_ENDPOINT} for this and subsequent emits in this location.\n`
+          );
+          this.endpointRouter.markRepUnavailable(location);
+          currentEndpoint = GLOBAL_LINEAGE_ENDPOINT;
+          continue;
+        }
+
+        // Endpoint returned HTTP 302 (region mismatch) and we can't retry from
+        // here — skip the rest of this run so we don't repeat a guaranteed
+        // failure for every action.
+        if (this.isEndpointRegionMismatch(err)) {
+          if (!this.emissionDisabledThisRun) {
+            this.emissionDisabledThisRun = true;
+            this.stderr.write(
+              `[lineage] Skipped lineage emission for the rest of this run: skip_reason=endpoint_region_mismatch (endpoint '${currentEndpoint}' returned HTTP 302 for location '${location}'; the endpoint does not serve this region)\n`
+            );
+          }
+          return;
+        }
+
+        // Check for permission or API disabled status codes. Multiple in-flight
+        // calls can hit the same failure concurrently; guard the write so the
+        // skip line is printed at most once per run.
+        //
+        // PERMISSION_DENIED is ambiguous on Google Cloud: it fires both for
+        // missing IAM and for "API not enabled" (the enablement check often
+        // returns 7 rather than 9). Surface both hints so the user doesn't
+        // chase one root cause when the other is at fault.
+        if (code === 7 || err.message?.includes("PERMISSION_DENIED")) {
+          if (!this.emissionDisabledThisRun) {
+            this.emissionDisabledThisRun = true;
+            this.stderr.write(
+              `[lineage] Skipped lineage emission for the rest of this run: skip_reason=api_disabled (ensure the credential has 'datalineage.googleapis.com/locations.processOpenLineageMessage' OR that the Lineage API is enabled in project ${projectId} via 'gcloud services enable datalineage.googleapis.com')\n`
+            );
+          }
+          return;
+        }
+        if (
+          code === 9 ||
+          err.message?.includes("SERVICE_DISABLED") ||
+          err.message?.includes("FAILED_PRECONDITION")
+        ) {
+          if (!this.emissionDisabledThisRun) {
+            this.emissionDisabledThisRun = true;
+            this.stderr.write(
+              `[lineage] Skipped lineage emission for the rest of this run: skip_reason=api_disabled (Lineage API is not enabled in project ${projectId}; run 'gcloud services enable datalineage.googleapis.com')\n`
+            );
+          }
+          return;
+        }
+
+        // gax has already exhausted retries on transient codes; propagate to
+        // the outer catch with endpoint/location metadata attached so the
+        // structured `[lineage] Failed to emit ...` line can name them.
+        (err as any).lineageEndpoint = currentEndpoint;
+        (err as any).lineageLocation = location;
+        throw err;
+      }
+    }
+  }
+
+  private isEndpointUnresolvable(err: Error): boolean {
+    // Match on the DNS signature in the message string rather than the outer
+    // grpc code. google-gax wraps repeated UNAVAILABLE(14) errors from the
+    // grpc DNS resolver in an outer DEADLINE_EXCEEDED(4) once its retry
+    // budget expires; the inner "Name resolution failed" text is only in the
+    // message. The signatures below are unique enough on their own that a
+    // false positive is not a concern.
+    const cause = (err as any).cause;
+    const causeMessage =
+      typeof cause === "object" && cause ? String(cause.message || cause.code || "") : "";
+    const combined = `${err.message || ""} ${causeMessage}`;
+    return /ENOTFOUND|EAI_AGAIN|getaddrinfo|(?:DNS|Name) resolution failed/i.test(combined);
+  }
+
+  private isEndpointRegionMismatch(err: Error): boolean {
+    // HTTP 302 to a gRPC client is a GFE / uberproxy redirect — the endpoint
+    // has no backend route for this region, so the frontend responds with a
+    // Location header instead of gRPC frames. gRPC surfaces this as
+    // UNKNOWN(2) because there is no canonical status attached.
+    if ((err as any).code !== 2) {
+      return false;
+    }
+    const cause = (err as any).cause;
+    const causeMessage =
+      typeof cause === "object" && cause ? String(cause.message || cause.code || "") : "";
+    const combined = `${err.message || ""} ${causeMessage}`;
+    // Two shapes seen in practice: "Received http2 header with status: 302"
+    // (grpc-js internal wrap) and "302:Found" (stringified HTTP status, as
+    // returned by our observed live run).
+    return /Received http2 header with status: 30[12]|\b30[12]:\s*Found\b/i.test(combined);
   }
 }

--- a/cli/api/lineage/emitter_test.ts
+++ b/cli/api/lineage/emitter_test.ts
@@ -1,7 +1,11 @@
 import { expect } from "chai";
 import Long from "long";
 
-import { LineageEmitter } from "df/cli/api/lineage/emitter";
+import {
+  createLineageClientProvider,
+  LINEAGE_RETRY_CONFIG,
+  LineageEmitter
+} from "df/cli/api/lineage/emitter";
 import { dataform } from "df/protos/ts";
 import { suite, test } from "df/testing";
 
@@ -14,8 +18,18 @@ class StderrCapture {
 }
 
 class MockLineageClient {
+  public listProcessesCalledWith: any[] = [];
   public processOpenLineageRunEventCalledWith: any[] = [];
+  public listProcessesError: Error | null = null;
   public processOpenLineageRunEventError: Error | null = null;
+
+  public async listProcesses(request: any): Promise<any> {
+    this.listProcessesCalledWith.push(request);
+    if (this.listProcessesError) {
+      throw this.listProcessesError;
+    }
+    return [[]];
+  }
 
   public async processOpenLineageRunEvent(request: any): Promise<any> {
     this.processOpenLineageRunEventCalledWith.push(request);
@@ -61,53 +75,64 @@ suite("LineageEmitter", () => {
       ]
     });
 
+    // 1. Emit START event
     const startResult = dataform.ActionResult.create({
       status: dataform.ActionResult.ExecutionStatus.RUNNING,
-      timing: { startTimeMillis: Long.fromNumber(1000) }
+      timing: {
+        startTimeMillis: Long.fromNumber(1000)
+      }
     });
     emitter.emitForAction(action, startResult);
 
+    // 2. Emit COMPLETE event
     const completeResult = dataform.ActionResult.create({
       status: dataform.ActionResult.ExecutionStatus.SUCCESSFUL,
       timing: {
         startTimeMillis: Long.fromNumber(1000),
         endTimeMillis: Long.fromNumber(2000)
       },
-      tasks: [{ status: dataform.TaskResult.ExecutionStatus.SUCCESSFUL }]
+      tasks: [
+        {
+          status: dataform.TaskResult.ExecutionStatus.SUCCESSFUL
+        }
+      ]
     });
     emitter.emitForAction(action, completeResult);
 
+    // Wait for all background emissions to drain
     await emitter.drain();
 
+    // No preflight was called (no listProcesses)
+    expect(mockClient.listProcessesCalledWith.length).to.equal(0);
+
+    // Two events were emitted
     expect(mockClient.processOpenLineageRunEventCalledWith.length).to.equal(2);
 
+    // Assert START event
     const startPayload = mockClient.processOpenLineageRunEventCalledWith[0];
     expect(startPayload.parent).to.equal("projects/target-project/locations/us");
     const startOpenLineage = fromProtoStruct(startPayload.openLineage);
     expect(startOpenLineage.eventType).to.equal("START");
-    expect(startOpenLineage.job.name).to.equal(
-      "target-project.us.cli.my-dataform-project-0b5d3e86.target_dataset.target_table"
-    );
+    expect(startOpenLineage.job.name).to.equal("target-project.us.cli.my-dataform-project-0b5d3e86.target_dataset.target_table");
 
+    // Assert COMPLETE event
     const completePayload = mockClient.processOpenLineageRunEventCalledWith[1];
     expect(completePayload.parent).to.equal("projects/target-project/locations/us");
     const openLineage = fromProtoStruct(completePayload.openLineage);
     expect(openLineage.run.runId).to.equal(startOpenLineage.run.runId);
     expect(openLineage.eventType).to.equal("COMPLETE");
     expect(openLineage.producer).to.equal("https://github.com/dataform-co/dataform");
-    expect(openLineage.job.name).to.equal(
-      "target-project.us.cli.my-dataform-project-0b5d3e86.target_dataset.target_table"
-    );
+    expect(openLineage.job.name).to.equal("target-project.us.cli.my-dataform-project-0b5d3e86.target_dataset.target_table");
     expect(openLineage.inputs[0].namespace).to.equal("bigquery");
     expect(openLineage.inputs[0].name).to.equal("source-project.source_dataset.source_table");
     expect(openLineage.outputs[0].namespace).to.equal("bigquery");
     expect(openLineage.outputs[0].name).to.equal("target-project.target_dataset.target_table");
 
-    expect(openLineage.run.facets.parent.job.name).to.equal(
-      "target-project.us.cli.my-dataform-project-0b5d3e86.run"
-    );
+    // Assert Parent run facet
+    expect(openLineage.run.facets.parent.job.name).to.equal("target-project.us.cli.my-dataform-project-0b5d3e86.run");
     expect(openLineage.run.facets.parent.run.runId).to.be.a("string");
 
+    // Nominal time run facet verified
     expect(openLineage.run.facets.nominalTime.nominalStartTime).to.equal(
       new Date(1000).toISOString()
     );
@@ -115,18 +140,23 @@ suite("LineageEmitter", () => {
       new Date(2000).toISOString()
     );
 
-    expect(openLineage.job.facets.gcp_lineage.displayName).to.equal(
-      "BigQuery Pipelines action target_dataset.target_table"
-    );
-    expect(openLineage.job.facets.gcp_lineage.origin.sourceType).to.equal("BIGQUERY_PIPELINES");
-    expect(openLineage.job.facets.gcp_lineage.origin.name).to.equal(
-      "projects/target-project/locations/us/cli/my-dataform-project-0b5d3e86"
+    // SQL job facet verified
+    expect(openLineage.job.facets.sql.query).to.equal(
+      "CREATE TABLE target_table AS SELECT * FROM source_table"
     );
 
-    expect(openLineage.run.facets.gcp_bq_pipelines_run.runType).to.equal("cli-manual");
+    // GCP lineage job facet verified
+    expect(openLineage.job.facets.gcp_lineage.displayName).to.equal("BigQuery Pipelines action target_dataset.target_table");
+    expect(openLineage.job.facets.gcp_lineage.origin.sourceType).to.equal("BIGQUERY_PIPELINES");
+    expect(openLineage.job.facets.gcp_lineage.origin.name).to.equal("projects/target-project/locations/us/cli/my-dataform-project-0b5d3e86");
+
+    // Job type facet verified
+    expect(openLineage.job.facets.jobType.integration).to.equal("BIGQUERY_PIPELINES");
+    expect(openLineage.job.facets.jobType.jobType).to.equal("ACTION");
+    expect(openLineage.job.facets.jobType.processingType).to.equal("BATCH");
   });
 
-  test("emits FAIL eventType on action failure", async () => {
+  test("emits open lineage run event with correct payload on action failure", async () => {
     const mockClient = new MockLineageClient();
     const emitter = new LineageEmitter(
       credentials,
@@ -140,43 +170,212 @@ suite("LineageEmitter", () => {
         schema: "target_dataset",
         name: "failing_table"
       },
-      type: "table"
+      type: "table",
+      fileName: "definitions/failing_table.sqlx"
     });
 
-    emitter.emitForAction(action, dataform.ActionResult.create({
+    // 1. Emit START event
+    const startResult = dataform.ActionResult.create({
       status: dataform.ActionResult.ExecutionStatus.RUNNING,
-      timing: { startTimeMillis: Long.fromNumber(1000) }
-    }));
-    emitter.emitForAction(action, dataform.ActionResult.create({
+      timing: {
+        startTimeMillis: Long.fromNumber(1000)
+      }
+    });
+    emitter.emitForAction(action, startResult);
+
+    // 2. Emit FAIL event with error message
+    const failResult = dataform.ActionResult.create({
       status: dataform.ActionResult.ExecutionStatus.FAILED,
       timing: {
         startTimeMillis: Long.fromNumber(1000),
         endTimeMillis: Long.fromNumber(1500)
-      }
-    }));
+      },
+      tasks: [
+        {
+          status: dataform.TaskResult.ExecutionStatus.FAILED,
+          errorMessage: "bigquery error: Syntax error: Unexpected \"\\\" at [3:15]"
+        }
+      ]
+    });
+    emitter.emitForAction(action, failResult);
 
+    // Wait for background emissions to drain
     await emitter.drain();
 
     expect(mockClient.processOpenLineageRunEventCalledWith.length).to.equal(2);
+
+    // Assert FAIL event payload
     const failPayload = mockClient.processOpenLineageRunEventCalledWith[1];
+    expect(failPayload.parent).to.equal("projects/target-project/locations/us");
+    
     const openLineage = fromProtoStruct(failPayload.openLineage);
     expect(openLineage.eventType).to.equal("FAIL");
+    expect(openLineage.job.name).to.equal("target-project.us.cli.my-dataform-project-0b5d3e86.target_dataset.failing_table");
+
+    // Error message run facet verified
+    expect(openLineage.run.facets.errorMessage.message).to.equal(
+      "bigquery error: Syntax error: Unexpected \"\\\" at [3:15]"
+    );
+    expect(openLineage.run.facets.errorMessage.programmingLanguage).to.equal("typescript");
+
+    // Nominal time run facet verified (nominalEndTime matches failure timing)
+    expect(openLineage.run.facets.nominalTime.nominalStartTime).to.equal(
+      new Date(1000).toISOString()
+    );
     expect(openLineage.run.facets.nominalTime.nominalEndTime).to.equal(
       new Date(1500).toISOString()
     );
   });
 
-  test("disables emission for the rest of the run after the first failure", async () => {
+  test("emits externalQuery run facet on COMPLETE when a task carries bigquery.jobId", async () => {
     const mockClient = new MockLineageClient();
-    const err: any = new Error("something broke");
-    err.code = 13;
-    mockClient.processOpenLineageRunEventError = err;
+    const emitter = new LineageEmitter(credentials, { lineageEnabled: true }, () => mockClient as any);
 
-    const emitter = new LineageEmitter(
-      credentials,
-      { lineageEnabled: true },
-      () => mockClient as any
-    );
+    const action = dataform.ExecutionAction.create({
+      target: { database: "target-project", schema: "s", name: "t" },
+      type: "table",
+      tasks: [{ statement: "SELECT 1" }]
+    });
+
+    emitter.emitForAction(action, dataform.ActionResult.create({
+      status: dataform.ActionResult.ExecutionStatus.RUNNING
+    }));
+    emitter.emitForAction(action, dataform.ActionResult.create({
+      status: dataform.ActionResult.ExecutionStatus.SUCCESSFUL,
+      tasks: [
+        {
+          status: dataform.TaskResult.ExecutionStatus.SUCCESSFUL,
+          metadata: { bigquery: { jobId: "job_abc123" } }
+        }
+      ]
+    }));
+    await emitter.drain();
+
+    const startFacets = fromProtoStruct(mockClient.processOpenLineageRunEventCalledWith[0].openLineage).run.facets;
+    expect(startFacets.externalQuery).to.equal(undefined);
+
+    const completeFacets = fromProtoStruct(mockClient.processOpenLineageRunEventCalledWith[1].openLineage).run.facets;
+    expect(completeFacets.externalQuery.externalQueryId).to.equal("test-project.us.job_abc123");
+    expect(completeFacets.externalQuery.source).to.equal("bigquery");
+    expect(completeFacets.externalQuery._producer).to.equal("https://github.com/dataform-co/dataform");
+  });
+
+  test("emits externalQuery run facet on FAIL when a task carries bigquery.jobId", async () => {
+    const mockClient = new MockLineageClient();
+    const emitter = new LineageEmitter(credentials, { lineageEnabled: true }, () => mockClient as any);
+
+    const action = dataform.ExecutionAction.create({
+      target: { database: "target-project", schema: "s", name: "t" },
+      type: "table"
+    });
+
+    emitter.emitForAction(action, dataform.ActionResult.create({
+      status: dataform.ActionResult.ExecutionStatus.FAILED,
+      tasks: [
+        {
+          status: dataform.TaskResult.ExecutionStatus.FAILED,
+          metadata: { bigquery: { jobId: "job_xyz789" } },
+          errorMessage: "bigquery error: something"
+        }
+      ]
+    }));
+    await emitter.drain();
+
+    const failFacets = fromProtoStruct(mockClient.processOpenLineageRunEventCalledWith[0].openLineage).run.facets;
+    expect(failFacets.externalQuery.externalQueryId).to.equal("test-project.us.job_xyz789");
+    expect(failFacets.externalQuery.source).to.equal("bigquery");
+  });
+
+  test("picks the last non-empty jobId when the action has multiple tasks", async () => {
+    const mockClient = new MockLineageClient();
+    const emitter = new LineageEmitter(credentials, { lineageEnabled: true }, () => mockClient as any);
+
+    const action = dataform.ExecutionAction.create({
+      target: { database: "target-project", schema: "s", name: "t" },
+      type: "table"
+    });
+
+    emitter.emitForAction(action, dataform.ActionResult.create({
+      status: dataform.ActionResult.ExecutionStatus.SUCCESSFUL,
+      tasks: [
+        { status: dataform.TaskResult.ExecutionStatus.SUCCESSFUL, metadata: { bigquery: { jobId: "job_preop" } } },
+        { status: dataform.TaskResult.ExecutionStatus.SUCCESSFUL, metadata: { bigquery: { jobId: "job_main" } } },
+        { status: dataform.TaskResult.ExecutionStatus.SUCCESSFUL, metadata: {} }
+      ]
+    }));
+    await emitter.drain();
+
+    const facets = fromProtoStruct(mockClient.processOpenLineageRunEventCalledWith[0].openLineage).run.facets;
+    expect(facets.externalQuery.externalQueryId).to.equal("test-project.us.job_main");
+  });
+
+  test("omits externalQuery run facet when no task carries bigquery.jobId", async () => {
+    const mockClient = new MockLineageClient();
+    const emitter = new LineageEmitter(credentials, { lineageEnabled: true }, () => mockClient as any);
+
+    const action = dataform.ExecutionAction.create({
+      target: { database: "target-project", schema: "s", name: "t" },
+      type: "table"
+    });
+
+    emitter.emitForAction(action, dataform.ActionResult.create({
+      status: dataform.ActionResult.ExecutionStatus.SUCCESSFUL,
+      tasks: [{ status: dataform.TaskResult.ExecutionStatus.SUCCESSFUL, metadata: {} }]
+    }));
+    await emitter.drain();
+
+    const facets = fromProtoStruct(mockClient.processOpenLineageRunEventCalledWith[0].openLineage).run.facets;
+    expect(facets.externalQuery).to.equal(undefined);
+  });
+
+  test("handles permission denied error by disabling emission on subsequent calls", async () => {
+    const mockClient = new MockLineageClient();
+    const permissionError: any = new Error("Permission Denied");
+    permissionError.code = 7;
+    mockClient.processOpenLineageRunEventError = permissionError;
+
+    const emitter = new LineageEmitter(credentials, { lineageEnabled: true }, () => mockClient as any);
+
+    const action = dataform.ExecutionAction.create({
+      target: { database: "proj", schema: "schema", name: "table" },
+      type: "table"
+    });
+    const startResult = dataform.ActionResult.create({
+      status: dataform.ActionResult.ExecutionStatus.RUNNING
+    });
+
+    // Run first action (fails on write, setting emissionDisabledThisRun to true)
+    emitter.emitForAction(action, startResult);
+    await emitter.drain();
+
+    expect(mockClient.processOpenLineageRunEventCalledWith.length).to.equal(1);
+
+    // Run second action (should skip immediately because emissionDisabledThisRun is true)
+    emitter.emitForAction(action, startResult);
+    await emitter.drain();
+
+    // Still only 1 call total
+    expect(mockClient.processOpenLineageRunEventCalledWith.length).to.equal(1);
+  });
+
+  test("LINEAGE_RETRY_CONFIG declares canonical transient set + exponential backoff", () => {
+    expect(LINEAGE_RETRY_CONFIG.retryCodes).to.deep.equal([4, 8, 10, 13, 14]);
+    expect(LINEAGE_RETRY_CONFIG.backoffSettings).to.deep.include({
+      initialRetryDelayMillis: 1000,
+      retryDelayMultiplier: 2.0,
+      maxRetryDelayMillis: 4000,
+      maxRpcTimeoutMillis: 2000,
+      totalTimeoutMillis: 15000
+    });
+  });
+
+  test("non-transient errors propagate without outer-loop retry", async () => {
+    const mockClient = new MockLineageClient();
+    const invalidArgErr: any = new Error("bad request");
+    invalidArgErr.code = 3; // INVALID_ARGUMENT — not in LINEAGE_RETRY_CONFIG.retryCodes
+    mockClient.processOpenLineageRunEventError = invalidArgErr;
+
+    const emitter = new LineageEmitter(credentials, { lineageEnabled: true }, () => mockClient as any);
 
     const action = dataform.ExecutionAction.create({
       target: { database: "proj", schema: "schema", name: "table" },
@@ -188,14 +387,127 @@ suite("LineageEmitter", () => {
 
     emitter.emitForAction(action, startResult);
     await emitter.drain();
-    expect(mockClient.processOpenLineageRunEventCalledWith.length).to.equal(1);
 
-    // Subsequent emits must not hit the client.
-    for (let i = 0; i < 4; i++) {
-      emitter.emitForAction(action, startResult);
-    }
-    await emitter.drain();
+    // Mock bypasses gax, so gax retry never engages. Outer loop makes exactly
+    // one call for non-transient errors (no REP fallback, no skip code).
     expect(mockClient.processOpenLineageRunEventCalledWith.length).to.equal(1);
+  });
+
+  test("falls back from regional endpoint to global on DNS-unresolvable REP", async () => {
+    const mockClient = new MockLineageClient();
+    const dnsError: any = new Error("14 UNAVAILABLE: DNS resolution failed for datalineage.us.rep.googleapis.com");
+    dnsError.code = 14;
+    dnsError.cause = { code: "ENOTFOUND", message: "getaddrinfo ENOTFOUND datalineage.us.rep.googleapis.com" };
+
+    let callCount = 0;
+    const endpointsUsed: string[] = [];
+    const provider = (projectId: string, endpoint: string) => {
+      endpointsUsed.push(endpoint);
+      callCount++;
+      mockClient.processOpenLineageRunEventError = callCount === 1 ? dnsError : null;
+      return mockClient as any;
+    };
+
+    const emitter = new LineageEmitter(credentials, { lineageEnabled: true }, provider);
+
+    const action = dataform.ExecutionAction.create({
+      target: { database: "proj", schema: "schema", name: "table" },
+      type: "table"
+    });
+    const startResult = dataform.ActionResult.create({
+      status: dataform.ActionResult.ExecutionStatus.RUNNING
+    });
+
+    emitter.emitForAction(action, startResult);
+    await emitter.drain();
+
+    expect(endpointsUsed).to.deep.equal([
+      "datalineage.us.rep.googleapis.com",
+      "datalineage.googleapis.com"
+    ]);
+    expect(mockClient.processOpenLineageRunEventCalledWith.length).to.equal(2);
+  });
+
+  test("caches REP-unavailable decision across subsequent emits", async () => {
+    const mockClient = new MockLineageClient();
+    const dnsError: any = new Error("14 UNAVAILABLE: getaddrinfo ENOTFOUND datalineage.us.rep.googleapis.com");
+    dnsError.code = 14;
+    dnsError.cause = { code: "ENOTFOUND", message: "getaddrinfo ENOTFOUND" };
+
+    let callCount = 0;
+    const endpointsUsed: string[] = [];
+    const provider = (projectId: string, endpoint: string) => {
+      endpointsUsed.push(endpoint);
+      callCount++;
+      mockClient.processOpenLineageRunEventError = callCount === 1 ? dnsError : null;
+      return mockClient as any;
+    };
+
+    const emitter = new LineageEmitter(credentials, { lineageEnabled: true }, provider);
+
+    const action = dataform.ExecutionAction.create({
+      target: { database: "proj", schema: "schema", name: "table" },
+      type: "table"
+    });
+    const startResult = dataform.ActionResult.create({
+      status: dataform.ActionResult.ExecutionStatus.RUNNING
+    });
+
+    // First emit: REP fails with ENOTFOUND, falls back to global.
+    emitter.emitForAction(action, startResult);
+    await emitter.drain();
+
+    // Second emit: should skip REP entirely and go straight to global.
+    emitter.emitForAction(action, startResult);
+    await emitter.drain();
+
+    expect(endpointsUsed).to.deep.equal([
+      "datalineage.us.rep.googleapis.com",
+      "datalineage.googleapis.com",
+      "datalineage.googleapis.com"
+    ]);
+  });
+
+  test("falls back on real gRPC 'Name resolution failed' error shape", async () => {
+    // Reproduces the exact error shape emitted by the @grpc/grpc-js DNS resolver
+    // when a REP hostname does not exist. This locks in that isEndpointUnresolvable
+    // matches the production message (regression: earlier regex only matched
+    // 'DNS resolution', missing the gRPC 'Name resolution failed' phrasing).
+    const mockClient = new MockLineageClient();
+    // Exact shape observed in a live run: google-gax wraps the underlying
+    // UNAVAILABLE(14) into a DEADLINE_EXCEEDED(4) after its retry budget
+    // expires. The DNS signature is only in the message string.
+    const grpcDnsError: any = new Error(
+      "Total timeout of API google.cloud.datacatalog.lineage.v1.Lineage exceeded 2000 milliseconds retrying error Error: 14 UNAVAILABLE: Name resolution failed for target dns:datalineage.bogusregion.rep.googleapis.com:443"
+    );
+    grpcDnsError.code = 4;
+
+    let callCount = 0;
+    const endpointsUsed: string[] = [];
+    const provider = (projectId: string, endpoint: string) => {
+      endpointsUsed.push(endpoint);
+      callCount++;
+      mockClient.processOpenLineageRunEventError = callCount === 1 ? grpcDnsError : null;
+      return mockClient as any;
+    };
+
+    const emitter = new LineageEmitter(credentials, { lineageEnabled: true }, provider);
+
+    const action = dataform.ExecutionAction.create({
+      target: { database: "proj", schema: "schema", name: "table" },
+      type: "table"
+    });
+    const startResult = dataform.ActionResult.create({
+      status: dataform.ActionResult.ExecutionStatus.RUNNING
+    });
+
+    emitter.emitForAction(action, startResult);
+    await emitter.drain();
+
+    expect(endpointsUsed).to.deep.equal([
+      "datalineage.us.rep.googleapis.com",
+      "datalineage.googleapis.com"
+    ]);
   });
 
   test("skip_reason=dry_run is logged once per run, not once per action", async () => {
@@ -257,6 +569,107 @@ suite("LineageEmitter", () => {
     expect(mockClient.processOpenLineageRunEventCalledWith.length).to.equal(0);
   });
 
+  test("skip_reason=api_disabled on PERMISSION_DENIED surfaces both IAM and API-enable hints", async () => {
+    // PERMISSION_DENIED is ambiguous on GCP — it fires for missing IAM roles
+    // AND for "API not enabled" (enablement checks often surface as code 7,
+    // not 9). The hint must cover both so users don't chase the wrong cause.
+    const mockClient = new MockLineageClient();
+    const stderr = new StderrCapture();
+    const permissionError: any = new Error("Permission Denied");
+    permissionError.code = 7;
+    mockClient.processOpenLineageRunEventError = permissionError;
+
+    const emitter = new LineageEmitter(
+      credentials,
+      { lineageEnabled: true },
+      () => mockClient as any,
+      stderr
+    );
+    const action = dataform.ExecutionAction.create({
+      target: { database: "target-proj", schema: "schema", name: "table" },
+      type: "table"
+    });
+    const startResult = dataform.ActionResult.create({
+      status: dataform.ActionResult.ExecutionStatus.RUNNING
+    });
+
+    emitter.emitForAction(action, startResult);
+    await emitter.drain();
+
+    const apiDisabledLines = stderr.writes.filter(w => w.includes("skip_reason=api_disabled"));
+    expect(apiDisabledLines.length).to.equal(1);
+    expect(apiDisabledLines[0]).to.contain(
+      "datalineage.googleapis.com/locations.processOpenLineageMessage"
+    );
+    expect(apiDisabledLines[0]).to.contain("gcloud services enable datalineage.googleapis.com");
+    expect(apiDisabledLines[0]).to.contain(" OR ");
+    expect(apiDisabledLines[0]).to.contain("target-proj");
+  });
+
+  test("skip_reason=api_disabled is logged when the API returns SERVICE_DISABLED", async () => {
+    const mockClient = new MockLineageClient();
+    const stderr = new StderrCapture();
+    const serviceDisabledError: any = new Error("SERVICE_DISABLED: Data Lineage API is disabled");
+    serviceDisabledError.code = 9;
+    mockClient.processOpenLineageRunEventError = serviceDisabledError;
+
+    const emitter = new LineageEmitter(
+      credentials,
+      { lineageEnabled: true },
+      () => mockClient as any,
+      stderr
+    );
+    const action = dataform.ExecutionAction.create({
+      target: { database: "target-proj", schema: "schema", name: "table" },
+      type: "table"
+    });
+    const startResult = dataform.ActionResult.create({
+      status: dataform.ActionResult.ExecutionStatus.RUNNING
+    });
+
+    emitter.emitForAction(action, startResult);
+    await emitter.drain();
+
+    const apiDisabledLines = stderr.writes.filter(w => w.includes("skip_reason=api_disabled"));
+    expect(apiDisabledLines.length).to.equal(1);
+    expect(apiDisabledLines[0]).to.contain("gcloud services enable datalineage.googleapis.com");
+    expect(apiDisabledLines[0]).to.contain("target-proj");
+  });
+
+  test("skip_reason=api_disabled is logged once when many in-flight calls all fail", async () => {
+    // Regression: when the first RPC has not yet returned before subsequent
+    // emit calls dispatch their own RPCs, the public-method guard cannot
+    // short-circuit them. All N rejections then hit the catch. Without a guard
+    // inside the catch, N stderr lines are printed. The guard must dedupe.
+    const mockClient = new MockLineageClient();
+    const stderr = new StderrCapture();
+    const permissionError: any = new Error("Permission Denied");
+    permissionError.code = 7;
+    mockClient.processOpenLineageRunEventError = permissionError;
+
+    const emitter = new LineageEmitter(
+      credentials,
+      { lineageEnabled: true },
+      () => mockClient as any,
+      stderr
+    );
+    const action = dataform.ExecutionAction.create({
+      target: { database: "proj", schema: "schema", name: "table" },
+      type: "table"
+    });
+    const startResult = dataform.ActionResult.create({
+      status: dataform.ActionResult.ExecutionStatus.RUNNING
+    });
+
+    for (let i = 0; i < 5; i++) {
+      emitter.emitForAction(action, startResult);
+    }
+    await emitter.drain();
+
+    const apiDisabledLines = stderr.writes.filter(w => w.includes("skip_reason=api_disabled"));
+    expect(apiDisabledLines.length).to.equal(1);
+  });
+
   test("sanitizes projectDir basename with special chars in workdirIdentifier", async () => {
     const mockClient = new MockLineageClient();
     const emitter = new LineageEmitter(
@@ -267,7 +680,8 @@ suite("LineageEmitter", () => {
 
     const action = dataform.ExecutionAction.create({
       target: { database: "target-project", schema: "s", name: "t" },
-      type: "table"
+      type: "table",
+      tasks: [{ statement: "SELECT 1" }]
     });
 
     emitter.emitForAction(action, dataform.ActionResult.create({
@@ -295,7 +709,8 @@ suite("LineageEmitter", () => {
 
     const action = dataform.ExecutionAction.create({
       target: { database: "target-project", schema: "s", name: "t" },
-      type: "table"
+      type: "table",
+      tasks: [{ statement: "SELECT 1" }]
     });
 
     emitter.emitForAction(action, dataform.ActionResult.create({
@@ -312,16 +727,92 @@ suite("LineageEmitter", () => {
     );
   });
 
+  test("REP endpoint falls back to global on HTTP 302 (region mismatch)", async () => {
+    // Symmetric to the DNS-unresolvable fallback: if a REP hostname is
+    // reachable but returns 302 (no backend route for the location), we
+    // should still fall through to the global endpoint rather than skip.
+    const mockClient = new MockLineageClient();
+    const redirectError: any = new Error("302:Found");
+    redirectError.code = 2;
+
+    let callCount = 0;
+    const endpointsUsed: string[] = [];
+    const provider = (projectId: string, endpoint: string) => {
+      endpointsUsed.push(endpoint);
+      callCount++;
+      mockClient.processOpenLineageRunEventError = callCount === 1 ? redirectError : null;
+      return mockClient as any;
+    };
+
+    const emitter = new LineageEmitter(credentials, { lineageEnabled: true }, provider);
+    const action = dataform.ExecutionAction.create({
+      target: { database: "proj", schema: "schema", name: "table" },
+      type: "table"
+    });
+    const startResult = dataform.ActionResult.create({
+      status: dataform.ActionResult.ExecutionStatus.RUNNING
+    });
+
+    emitter.emitForAction(action, startResult);
+    await emitter.drain();
+
+    expect(endpointsUsed).to.deep.equal([
+      "datalineage.us.rep.googleapis.com",
+      "datalineage.googleapis.com"
+    ]);
+    expect(mockClient.processOpenLineageRunEventCalledWith.length).to.equal(2);
+  });
+
+  test("Failed to emit line carries code name, endpoint, location, and message", async () => {
+    // Unhandled error kinds (anything other than DNS-unresolvable, 302,
+    // PERMISSION_DENIED, FAILED_PRECONDITION/SERVICE_DISABLED) reach the
+    // outer catch. That line is the diagnostic surface for the user — it
+    // must name the gRPC code, endpoint, and location so support can triage
+    // without asking for the transport log.
+    const mockClient = new MockLineageClient();
+    const stderr = new StderrCapture();
+    const invalidArgErr: any = new Error("bad request");
+    invalidArgErr.code = 3; // INVALID_ARGUMENT — not in any handled bucket
+    mockClient.processOpenLineageRunEventError = invalidArgErr;
+
+    const emitter = new LineageEmitter(
+      credentials,
+      { lineageEnabled: true },
+      () => mockClient as any,
+      stderr
+    );
+    const action = dataform.ExecutionAction.create({
+      target: { database: "proj", schema: "myschema", name: "mytable" },
+      type: "table"
+    });
+    const startResult = dataform.ActionResult.create({
+      status: dataform.ActionResult.ExecutionStatus.RUNNING
+    });
+
+    emitter.emitForAction(action, startResult);
+    await emitter.drain();
+
+    const failLines = stderr.writes.filter(w => w.includes("[lineage] Failed to emit"));
+    expect(failLines.length).to.equal(1);
+    expect(failLines[0]).to.contain("myschema.mytable");
+    expect(failLines[0]).to.contain("code=INVALID_ARGUMENT(3)");
+    expect(failLines[0]).to.contain("endpoint=datalineage.us.rep.googleapis.com");
+    expect(failLines[0]).to.contain("location=us");
+    expect(failLines[0]).to.contain("message=bad request");
+  });
+
   test("emit failures never surface as unhandled rejections", async () => {
     // Isolation contract: lineage errors must never propagate to the
-    // surrounding BQ executor.
+    // surrounding BQ executor. Regression guard so a future refactor of the
+    // .catch/.finally chain (or of drain()) can't silently break it. Uses a
+    // non-handled error kind so the promise chain has to catch it explicitly.
     const rejections: unknown[] = [];
     const onUnhandled = (r: unknown) => rejections.push(r);
     process.on("unhandledRejection", onUnhandled);
     try {
       const mockClient = new MockLineageClient();
       const genericError: any = new Error("something broke");
-      genericError.code = 13;
+      genericError.code = 13; // INTERNAL — handled by gax retry, then propagates
       mockClient.processOpenLineageRunEventError = genericError;
 
       const emitter = new LineageEmitter(
@@ -341,12 +832,130 @@ suite("LineageEmitter", () => {
         emitter.emitForAction(action, startResult);
       }
       await emitter.drain();
+      // Yield one more microtask cycle so any late rejections settle.
       await new Promise(r => setImmediate(r));
 
       expect(rejections).to.deep.equal([]);
     } finally {
       process.removeListener("unhandledRejection", onUnhandled);
     }
+  });
+
+  test("caches REP-unavailable decision after HTTP 302 fallback", async () => {
+    // Symmetric to the DNS-unresolvable cache test above: after a 302
+    // triggers REP -> global fallback, subsequent emits for the same
+    // location must skip REP entirely instead of re-probing it every time.
+    const mockClient = new MockLineageClient();
+    const redirectError: any = new Error("302:Found");
+    redirectError.code = 2;
+
+    let callCount = 0;
+    const endpointsUsed: string[] = [];
+    const provider = (projectId: string, endpoint: string) => {
+      endpointsUsed.push(endpoint);
+      callCount++;
+      mockClient.processOpenLineageRunEventError = callCount === 1 ? redirectError : null;
+      return mockClient as any;
+    };
+
+    const emitter = new LineageEmitter(credentials, { lineageEnabled: true }, provider);
+    const action = dataform.ExecutionAction.create({
+      target: { database: "proj", schema: "schema", name: "table" },
+      type: "table"
+    });
+    const startResult = dataform.ActionResult.create({
+      status: dataform.ActionResult.ExecutionStatus.RUNNING
+    });
+
+    emitter.emitForAction(action, startResult);
+    await emitter.drain();
+
+    emitter.emitForAction(action, startResult);
+    await emitter.drain();
+
+    expect(endpointsUsed).to.deep.equal([
+      "datalineage.us.rep.googleapis.com",
+      "datalineage.googleapis.com",
+      "datalineage.googleapis.com"
+    ]);
+  });
+
+  test("Failed to emit line names the global endpoint after REP fallback also fails", async () => {
+    // When REP -> global fallback is triggered but the global attempt also
+    // fails with an unhandled error, the structured error line must name
+    // the endpoint that was actually attempted last (global), not the
+    // original REP hostname. Regression guard: proves the per-attempt
+    // metadata on the error object is refreshed for the fallback attempt.
+    const mockClient = new MockLineageClient();
+    const stderr = new StderrCapture();
+    const dnsError: any = new Error(
+      "14 UNAVAILABLE: Name resolution failed for target dns:datalineage.us.rep.googleapis.com:443"
+    );
+    dnsError.code = 4;
+    const invalidArgErr: any = new Error("bad request");
+    invalidArgErr.code = 3;
+
+    let callCount = 0;
+    const provider = (projectId: string, endpoint: string) => {
+      callCount++;
+      mockClient.processOpenLineageRunEventError = callCount === 1 ? dnsError : invalidArgErr;
+      return mockClient as any;
+    };
+
+    const emitter = new LineageEmitter(
+      credentials,
+      { lineageEnabled: true },
+      provider,
+      stderr
+    );
+    const action = dataform.ExecutionAction.create({
+      target: { database: "proj", schema: "myschema", name: "mytable" },
+      type: "table"
+    });
+    const startResult = dataform.ActionResult.create({
+      status: dataform.ActionResult.ExecutionStatus.RUNNING
+    });
+
+    emitter.emitForAction(action, startResult);
+    await emitter.drain();
+
+    const failLines = stderr.writes.filter(w => w.includes("[lineage] Failed to emit"));
+    expect(failLines.length).to.equal(1);
+    expect(failLines[0]).to.contain("endpoint=datalineage.googleapis.com");
+    expect(failLines[0]).to.not.contain("endpoint=datalineage.us.rep.googleapis.com");
+    expect(failLines[0]).to.contain("code=INVALID_ARGUMENT(3)");
+  });
+
+  test("non-DNS / non-302 error from REP does not trigger fallback to global", async () => {
+    // Only two error shapes trigger REP -> global fallback: DNS-unresolvable
+    // and HTTP 302. An INTERNAL from REP means REP itself is reachable and
+    // serving; it should propagate to the structured error line without
+    // ever calling the global endpoint. Locks in that the fallback
+    // conditions can't quietly broaden.
+    const mockClient = new MockLineageClient();
+    const internalErr: any = new Error("upstream broke");
+    internalErr.code = 13;
+    mockClient.processOpenLineageRunEventError = internalErr;
+
+    const endpointsUsed: string[] = [];
+    const provider = (projectId: string, endpoint: string) => {
+      endpointsUsed.push(endpoint);
+      return mockClient as any;
+    };
+
+    const emitter = new LineageEmitter(credentials, { lineageEnabled: true }, provider);
+    const action = dataform.ExecutionAction.create({
+      target: { database: "proj", schema: "schema", name: "table" },
+      type: "table"
+    });
+    const startResult = dataform.ActionResult.create({
+      status: dataform.ActionResult.ExecutionStatus.RUNNING
+    });
+
+    emitter.emitForAction(action, startResult);
+    await emitter.drain();
+
+    expect(endpointsUsed).to.deep.equal(["datalineage.us.rep.googleapis.com"]);
   });
 });
 

--- a/cli/api/lineage/endpoint_router.ts
+++ b/cli/api/lineage/endpoint_router.ts
@@ -1,0 +1,28 @@
+export const GLOBAL_LINEAGE_ENDPOINT = "datalineage.googleapis.com";
+
+function regionalEndpointFor(location: string): string {
+  return `datalineage.${location}.rep.googleapis.com`;
+}
+
+/**
+ * Routes lineage RPCs to the correct endpoint for a given location.
+ *
+ * Default policy is REP-first (`datalineage.<loc>.rep.googleapis.com`) with
+ * fallback to global (`datalineage.googleapis.com`) once a location is marked
+ * unavailable via `markRepUnavailable`. Fallback is sticky for the lifetime
+ * of the router — subsequent emits in the same location skip the REP endpoint.
+ */
+export class LineageEndpointRouter {
+  private readonly repUnavailableForLocation = new Set<string>();
+
+  public endpointForLocation(location: string): string {
+    if (this.repUnavailableForLocation.has(location)) {
+      return GLOBAL_LINEAGE_ENDPOINT;
+    }
+    return regionalEndpointFor(location);
+  }
+
+  public markRepUnavailable(location: string): void {
+    this.repUnavailableForLocation.add(location);
+  }
+}

--- a/cli/api/lineage/endpoint_router_test.ts
+++ b/cli/api/lineage/endpoint_router_test.ts
@@ -1,0 +1,22 @@
+import { expect } from "chai";
+
+import {
+  GLOBAL_LINEAGE_ENDPOINT,
+  LineageEndpointRouter
+} from "df/cli/api/lineage/endpoint_router";
+import { suite, test } from "df/testing";
+
+suite("LineageEndpointRouter", () => {
+  test("returns REP endpoint by default", () => {
+    const router = new LineageEndpointRouter();
+    expect(router.endpointForLocation("us")).to.equal("datalineage.us.rep.googleapis.com");
+    expect(router.endpointForLocation("eu")).to.equal("datalineage.eu.rep.googleapis.com");
+  });
+
+  test("returns global endpoint after markRepUnavailable, for that location only", () => {
+    const router = new LineageEndpointRouter();
+    router.markRepUnavailable("us");
+    expect(router.endpointForLocation("us")).to.equal(GLOBAL_LINEAGE_ENDPOINT);
+    expect(router.endpointForLocation("eu")).to.equal("datalineage.eu.rep.googleapis.com");
+  });
+});

--- a/cli/api/lineage/lineage_integration_test.ts
+++ b/cli/api/lineage/lineage_integration_test.ts
@@ -194,10 +194,12 @@ suite("--emit-lineage integration", { parallel: true }, () => {
     expect(stderr.contains("skip_reason=invocation_override")).to.equal(true);
   });
 
-  test("Case 5 — lineage emit failure is fail-open (run exits SUCCESSFUL)", async () => {
+  test("Case 5 — lineage emit failure is fail-open (run exits SUCCESSFUL), skip_reason=api_disabled printed once", async () => {
     // Fail-open contract: any lineage emission failure — whatever the gRPC
     // code — must not affect the workflow status. The dataform run continues,
-    // dbadapter still executes every action.
+    // dbadapter still executes every action. When multiple in-flight emits
+    // hit the same PERMISSION_DENIED, the skip_reason line is dedup'd to a
+    // single stderr write via `emissionDisabledThisRun`.
     const recorder = new RecordingLineageClient();
     recorder.throwOnNextCallWith(7, "Permission Denied");
     const stderr = new StderrCapture();
@@ -214,6 +216,8 @@ suite("--emit-lineage integration", { parallel: true }, () => {
 
     expect(runResult.status).to.equal(dataform.RunResult.ExecutionStatus.SUCCESSFUL);
     expect(dbadapter.executed.length).to.equal(2);
+    const skipLines = stderr.writes.filter(w => w.includes("skip_reason=api_disabled"));
+    expect(skipLines.length).to.equal(1);
   });
 
   test("Case 6 — drain is bounded when the client hangs indefinitely", async () => {


### PR DESCRIPTION
feat(lineage): harden CLI lineage emission (endpoint routing, retry, structured errors)

PR 3 of 3. Adds production-hardening around the lineage emit path.

Endpoint routing (LineageEndpointRouter):
- REP-first policy: `datalineage.<loc>.rep.googleapis.com` by default.
- Per-location sticky fallback to `datalineage.googleapis.com` when the REP endpoint is DNS-unresolvable or returns HTTP 302 (region mismatch). Subsequent emits in the same location skip the REP endpoint.

Retry policy (LINEAGE_RETRY_CONFIG):
- Delegated to google-gax. Transient set follows AIP-194: DEADLINE_EXCEEDED, RESOURCE_EXHAUSTED, ABORTED, INTERNAL, UNAVAILABLE.
- Backoff 1s / 2s / 4s exponential, 2s per-attempt timeout, 15s total budget. Non-transient errors fall through immediately.

Structured error classification:
- On emit failure: single-line stderr `[lineage] Failed to emit ...: code=<NAME>(<n>) endpoint=<host> location=<loc> message=<err>` so telemetry can parse root cause without regex on prose.
- PERMISSION_DENIED / SERVICE_DISABLED / FAILED_PRECONDITION disable emission for the rest of the run and log a single `skip_reason=api_disabled` line with hints for both missing IAM and API-not-enabled (7 is ambiguous on Google Cloud). Dedup guard flips before the stderr write so concurrent in-flight failures collapse to one line.
- HTTP 302 region mismatch on a non-REP endpoint disables the run with `skip_reason=endpoint_region_mismatch`.

Client attribution:
- LineageClient receives `libName=dataform-cli` + `libVersion=<version>` so KC-side telemetry can attribute traffic to the Dataform CLI.

Test coverage:
- New `endpoint_router_test.ts`.
- `emitter_test.ts` expands with tests covering retry config shape, REP-fallback loop, PERMISSION_DENIED / SERVICE_DISABLED skip-and-dedup, non-DNS error propagation, and the structured `Failed to emit` line format.
- `lineage_integration_test.ts` extends Case 5 with the once-per-run `skip_reason=api_disabled` assertion.