### PR TITLE
Fix LegacyConfigConverter mutating caller-shared configs

### DIFF
--- a/core/actions/index.ts
+++ b/core/actions/index.ts
@@ -419,6 +419,8 @@ export class LegacyConfigConverter {
     // Type `any` is used here to facilitate the type hacking for legacy compatibility.
     const legacyConfig: any = unverifiedConfig;
     if (legacyConfig?.assertions) {
+      // Shallow-clone before in-place coercions so we don't mutate a caller-shared object.
+      legacyConfig.assertions = { ...legacyConfig.assertions };
       if (typeof legacyConfig.assertions?.uniqueKey === "string") {
         legacyConfig.assertions.uniqueKey = [legacyConfig.assertions.uniqueKey];
       }
@@ -444,6 +446,8 @@ export class LegacyConfigConverter {
     if (!legacyConfig?.bigquery) {
       return legacyConfig;
     }
+    // Shallow-clone before the delete-loop below so we don't mutate a caller-shared object.
+    legacyConfig.bigquery = { ...legacyConfig.bigquery };
     if (!!legacyConfig.bigquery.partitionBy) {
       legacyConfig.partitionBy = legacyConfig.bigquery.partitionBy;
       delete legacyConfig.bigquery.partitionBy;

--- a/core/actions/table_test.ts
+++ b/core/actions/table_test.ts
@@ -1138,4 +1138,50 @@ SELECT 1`
       });
     });
   });
+
+  suite("shared config", () => {
+    test("a shared config object can be reused across publish() calls without losing fields", () => {
+      const projectDir = tmpDirFixture.createNewTmpDir();
+      fs.writeFileSync(
+        path.join(projectDir, "workflow_settings.yaml"),
+        VALID_WORKFLOW_SETTINGS_YAML
+      );
+      fs.mkdirSync(path.join(projectDir, "definitions"));
+      fs.writeFileSync(
+        path.join(projectDir, "definitions/shared.js"),
+        `
+const shared = {
+  type: "table",
+  bigquery: { partitionBy: "event_date", clusterBy: ["user_id"] },
+  assertions: { uniqueKey: "id", nonNull: "id" }
+};
+publish("t1", shared).query(_ => "SELECT 1 AS id, DATE '2024-01-01' AS event_date, 'u1' AS user_id");
+publish("t2", shared).query(_ => "SELECT 2 AS id, DATE '2024-01-01' AS event_date, 'u2' AS user_id");
+publish("t3", shared).query(_ => "SELECT 3 AS id, DATE '2024-01-01' AS event_date, 'u3' AS user_id");
+`
+      );
+
+      const result = runMainInVm(coreExecutionRequestFromPath(projectDir));
+
+      expect(result.compile.compiledGraph.graphErrors.compilationErrors).deep.equals([]);
+
+      const bigqueryBlocks = result.compile.compiledGraph.tables.map(t =>
+        asPlainObject(t.bigquery)
+      );
+      const expectedBigquery = { partitionBy: "event_date", clusterBy: ["user_id"] };
+      expect(bigqueryBlocks).deep.equals([expectedBigquery, expectedBigquery, expectedBigquery]);
+
+      const assertionNames = result.compile.compiledGraph.assertions
+        .map(a => a.target.name)
+        .sort();
+      expect(assertionNames).deep.equals([
+        "defaultDataset_t1_assertions_rowConditions",
+        "defaultDataset_t1_assertions_uniqueKey_0",
+        "defaultDataset_t2_assertions_rowConditions",
+        "defaultDataset_t2_assertions_uniqueKey_0",
+        "defaultDataset_t3_assertions_rowConditions",
+        "defaultDataset_t3_assertions_uniqueKey_0"
+      ]);
+    });
+  });
 });


### PR DESCRIPTION
Shallow-clone .bigquery and .assertions before in-place coercions so `publish("t1", shared); publish("t2", shared);` no longer leaves t2/t3 with an empty bigquery block. Regression from #1780 (3.0.10).

core/actions/index.ts