### PR TITLE
Fix plumb filename

### DIFF
--- a/core/main_test.ts
+++ b/core/main_test.ts
@@ -172,6 +172,32 @@ SELECT 1`);
       ).deep.equals(`Could not resolve "e"`);
     });
 
+    test("failed ref attributes the compilation error to the source sqlx file", () => {
+      // Regression test: after the vm2 3.11.3 upgrade, V8 CallSite objects
+      // inside the sandbox lose their file paths, so utils.getCallerFile
+      // cannot recover the caller during a callback invocation. Errors from
+      // Session.resolve were therefore attributed to the sandbox entry
+      // ("index.js") instead of the action's source file. This test locks
+      // the fileName on the emitted CompilationError to the sqlx file.
+      const projectDir = tmpDirFixture.createNewTmpDir();
+      fs.writeFileSync(
+        path.join(projectDir, "workflow_settings.yaml"),
+        VALID_WORKFLOW_SETTINGS_YAML
+      );
+      fs.mkdirSync(path.join(projectDir, "definitions"));
+      fs.writeFileSync(
+        path.join(projectDir, "definitions/mytable.sqlx"),
+        `config { type: "view" }\nSELECT 1 FROM \${ref("FOO")}`
+      );
+
+      const result = runMainInVm(coreExecutionRequestFromPath(projectDir));
+
+      const errors = result.compile.compiledGraph.graphErrors.compilationErrors;
+      const resolveError = errors.find(e => e.message === `Could not resolve "FOO"`);
+      expect(resolveError, "expected a 'Could not resolve' error").to.not.equal(undefined);
+      expect(resolveError.fileName).equals("definitions/mytable.sqlx");
+    });
+
     test("fails when ambiguous resolve", () => {
       const projectDir = tmpDirFixture.createNewTmpDir();
       fs.writeFileSync(

--- a/core/session.ts
+++ b/core/session.ts
@@ -66,6 +66,12 @@ export class Session {
   // jit_context.data, avilable at jit stage.
   public jitContextData: google.protobuf.Struct | undefined;
 
+  // The file of the action currently being compiled by compileGraphChunk.
+  // Populated only while an action's callback is running so that errors raised
+  // from user code (e.g. failed refs) can be attributed without relying on
+  // getCallerFile(), which is unreliable under vm2's sandbox stack stripping.
+  private currentActionFile: string | undefined;
+
   constructor(
     rootDir?: string,
     projectConfig?: dataform.ProjectConfig,
@@ -467,7 +473,8 @@ export class Session {
 
   }
   public compileError(err: Error | string, path?: string, actionTarget?: dataform.ITarget) {
-    const fileName = path || utils.getCallerFile(this.rootDir) || __filename;
+    const fileName =
+      path || this.currentActionFile || utils.getCallerFile(this.rootDir) || __filename;
 
     const compileError = dataform.CompilationError.create({
       fileName,
@@ -616,11 +623,17 @@ export class Session {
     const compiledChunks: T[] = [];
 
     actions.forEach(action => {
+      // Track the action's file so that compileError() called synchronously
+      // from within the action's callback (e.g. Session.resolve) can attribute
+      // the error without depending on getCallerFile / the vm2 sandbox stack.
+      this.currentActionFile = action.getFileName() || undefined;
       try {
         const compiledChunk = action.compile();
         compiledChunks.push(compiledChunk as any);
       } catch (e) {
-        this.compileError(e, action.getFileName(), action.getTarget());
+        this.compileError(e, this.currentActionFile, action.getTarget());
+      } finally {
+        this.currentActionFile = undefined;
       }
     });
 


### PR DESCRIPTION
Session.resolve raises compileError() with no explicit file path, so it falls through to utils.getCallerFile(). Under vm2 >= 3.11.3, V8 CallSite objects inside the sandbox no longer carry file paths, and the global.__dataform_current_file fallback installed by the CLI wrapper is scoped to module load -- by the time a sqlx action's callback executes (during Session.compile), that global has been restored to the outer "index.js" sandbox entry. Every ref/resolve failure was consequently blamed on "index.js" instead of the sqlx file (see #2266).

Track the current action's file on the Session while its callback is being compiled, and let compileError() prefer it over the caller-file fallback. No behavior change when compileError is called with an explicit path.