### PR TITLE
Fix View.verifyConfig mutating caller-shared bigquery configs

### DIFF
--- a/core/actions/view.ts
+++ b/core/actions/view.ts
@@ -635,6 +635,8 @@ export class View extends ActionBuilder<dataform.Table> {
           strictKeysOf<ILegacyViewBigqueryConfig>()(["labels", "additionalOptions", "partitionBy", "clusterBy",]),
           "BigQuery view config"
         );
+        // Shallow-clone before the delete-loop below so we don't mutate a caller-shared object.
+        unverifiedConfig.bigquery = { ...unverifiedConfig.bigquery };
         if (!!unverifiedConfig.bigquery.labels) {
           unverifiedConfig.labels = unverifiedConfig.bigquery.labels;
           delete unverifiedConfig.bigquery.labels;

--- a/core/actions/view_test.ts
+++ b/core/actions/view_test.ts
@@ -441,4 +441,38 @@ ${exampleBuiltInAssertionsAsYaml.inputActionConfigBlock}
       expect(result.compile.compiledGraph.graphErrors.compilationErrors.some(e => e.message.includes("Cannot mix AoT and JiT compilation"))).equals(true);
     });
   });
+
+  suite("shared config", () => {
+    test("a shared config object can be reused across publish() calls without losing fields", () => {
+      const projectDir = tmpDirFixture.createNewTmpDir();
+      fs.writeFileSync(
+        path.join(projectDir, "workflow_settings.yaml"),
+        VALID_WORKFLOW_SETTINGS_YAML
+      );
+      fs.mkdirSync(path.join(projectDir, "definitions"));
+      fs.writeFileSync(
+        path.join(projectDir, "definitions/shared.js"),
+        `
+const shared = {
+  type: "view",
+  materialized: true,
+  bigquery: { partitionBy: "event_date", clusterBy: ["user_id"] }
+};
+publish("v1", shared).query(_ => "SELECT 1 AS id, DATE '2024-01-01' AS event_date, 'u1' AS user_id");
+publish("v2", shared).query(_ => "SELECT 2 AS id, DATE '2024-01-01' AS event_date, 'u2' AS user_id");
+publish("v3", shared).query(_ => "SELECT 3 AS id, DATE '2024-01-01' AS event_date, 'u3' AS user_id");
+`
+      );
+
+      const result = runMainInVm(coreExecutionRequestFromPath(projectDir));
+
+      expect(result.compile.compiledGraph.graphErrors.compilationErrors).deep.equals([]);
+
+      const bigqueryBlocks = result.compile.compiledGraph.tables.map(t =>
+        asPlainObject(t.bigquery)
+      );
+      const expectedBigquery = { partitionBy: "event_date", clusterBy: ["user_id"] };
+      expect(bigqueryBlocks).deep.equals([expectedBigquery, expectedBigquery, expectedBigquery]);
+    });
+  });
 });


### PR DESCRIPTION
Shallow-clone unverifiedConfig.bigquery before the hoist-then-delete loop so a shared `bigquery` object is not stripped across successive publish() calls. View.verifyConfig has its own hoist-then-delete loop outside LegacyConfigConverter; #2260 fixed the converter, which covers Table and IncrementalTable but not View.

Fixes #2267.