### PR TITLE
Bump DF_VERSION from 3.0.67 to 3.0.68

### DIFF
--- a/version.bzl
+++ b/version.bzl
@@ -1,1 +1,1 @@
-DF_VERSION = "3.0.67"
+DF_VERSION = "3.0.68"


### PR DESCRIPTION
## Summary
Bumps the npm package version to release the PropertyGraph work landed since 3.0.67 (#2258 ref/DAG dependencies, #2271 ref/resolve error attribution, #2268 CLI runtime + E2E) together with the `tags` support in #2275.