### PR TITLE
Port PropertyGraph PRs #2258 and #2268 to dataproc-poc

### DIFF
--- a/cli/api/BUILD
+++ b/cli/api/BUILD
@@ -59,6 +59,7 @@ ts_test_suite(
     name = "tests",
     srcs = [
         "commands/jit/rpc_test.ts",
+        "commands/prune_test.ts",
         "dbadapters/bigquery_test.ts",
         "execution_sql_test.ts",
         "utils_test.ts",

--- a/cli/api/commands/prune.ts
+++ b/cli/api/commands/prune.ts
@@ -2,7 +2,11 @@ import { targetAsReadableString } from "df/core/targets";
 import * as utils from "df/core/utils";
 import { dataform } from "df/protos/ts";
 
-type CompileAction = dataform.ITable | dataform.IOperation | dataform.IAssertion;
+type CompileAction =
+  | dataform.ITable
+  | dataform.IOperation
+  | dataform.IAssertion
+  | dataform.IPropertyGraph;
 
 export function prune(
   compiledGraph: dataform.ICompiledGraph,
@@ -20,6 +24,14 @@ export function prune(
     ),
     operations: compiledGraph.operations.filter(action =>
       includedActionNames.has(targetAsReadableString(action.target))
+    ),
+    propertyGraphs: compiledGraph.propertyGraphs?.filter(action =>
+      includedActionNames.has(targetAsReadableString(action.target))
+    ),
+    // `targets` is declarative output only (nothing downstream reads it), but
+    // `compile` prints it, so it has to agree with the filtered action lists.
+    targets: compiledGraph.targets?.filter(target =>
+      includedActionNames.has(targetAsReadableString(target))
     )
   };
 }
@@ -28,11 +40,12 @@ function computeIncludedActionNames(
   compiledGraph: dataform.ICompiledGraph,
   runConfig: dataform.IRunConfig
 ): Set<string> {
-  // Union all tables, operations, assertions.
+  // Union all tables, operations, assertions, property graphs.
   const allActions: CompileAction[] = [].concat(
     compiledGraph.tables,
     compiledGraph.operations,
-    compiledGraph.assertions
+    compiledGraph.assertions,
+    compiledGraph.propertyGraphs
   );
 
   const allActionNames = new Set<string>(
@@ -62,7 +75,7 @@ function computeIncludedActionNames(
   // Determine actions selected with --tag option and update applicable actions
   if (hasTagSelector) {
     allActions
-      .filter(action => action.tags.some(tag => runConfig.tags.includes(tag)))
+      .filter(action => "tags" in action && action.tags?.some(tag => runConfig.tags.includes(tag)))
       .forEach(action => includedActionNames.add(targetAsReadableString(action.target)));
   }
 

--- a/cli/api/commands/prune_test.ts
+++ b/cli/api/commands/prune_test.ts
@@ -1,0 +1,135 @@
+import { expect } from "chai";
+
+import { prune } from "df/cli/api/commands/prune";
+import { dataform } from "df/protos/ts";
+import { asPlainObject, suite, test } from "df/testing";
+
+const TABLE_TARGET: dataform.ITarget = { database: "p", schema: "d", name: "books" };
+const GRAPH_TARGET: dataform.ITarget = { database: "p", schema: "d", name: "LibraryGraph" };
+
+const TABLE_ACTION: dataform.ITable = {
+  type: "table",
+  enumType: dataform.TableType.TABLE,
+  target: TABLE_TARGET,
+  canonicalTarget: TABLE_TARGET,
+  query: "select 1 as id",
+  tags: ["daily"],
+  dependencyTargets: []
+};
+
+const GRAPH_ACTION: dataform.IPropertyGraph = {
+  target: GRAPH_TARGET,
+  canonicalTarget: GRAPH_TARGET,
+  entities: [
+    {
+      name: "Book",
+      dataSource: TABLE_TARGET,
+      keys: ["id"]
+    }
+  ],
+  relationships: [],
+  dependencyTargets: [TABLE_TARGET],
+  graphBody: "NODE TABLES (`p.d.books` KEY (id))"
+};
+
+function makeCompiledGraph(): dataform.ICompiledGraph {
+  return {
+    tables: [TABLE_ACTION],
+    operations: [],
+    assertions: [],
+    propertyGraphs: [GRAPH_ACTION],
+    targets: [TABLE_TARGET, GRAPH_TARGET]
+  };
+}
+
+suite("prune", () => {
+  test("no selectors returns all actions including property graphs", () => {
+    expect(asPlainObject(prune(makeCompiledGraph(), {}))).deep.equals(
+      asPlainObject({
+        tables: [TABLE_ACTION],
+        operations: [],
+        assertions: [],
+        propertyGraphs: [GRAPH_ACTION],
+        targets: [TABLE_TARGET, GRAPH_TARGET]
+      })
+    );
+  });
+
+  test("--actions=<graph_name> selects only the graph", () => {
+    expect(
+      asPlainObject(prune(makeCompiledGraph(), { actions: ["LibraryGraph"] }))
+    ).deep.equals(
+      asPlainObject({
+        tables: [],
+        operations: [],
+        assertions: [],
+        propertyGraphs: [GRAPH_ACTION],
+        targets: [GRAPH_TARGET]
+      })
+    );
+  });
+
+  test("--actions=<graph_name> with includeDependencies pulls in the ref target", () => {
+    expect(
+      asPlainObject(
+        prune(makeCompiledGraph(), {
+          actions: ["LibraryGraph"],
+          includeDependencies: true
+        })
+      )
+    ).deep.equals(
+      asPlainObject({
+        tables: [TABLE_ACTION],
+        operations: [],
+        assertions: [],
+        propertyGraphs: [GRAPH_ACTION],
+        targets: [TABLE_TARGET, GRAPH_TARGET]
+      })
+    );
+  });
+
+  test("--actions=<table_name> with includeDependents pulls in the graph", () => {
+    expect(
+      asPlainObject(
+        prune(makeCompiledGraph(), {
+          actions: ["books"],
+          includeDependents: true
+        })
+      )
+    ).deep.equals(
+      asPlainObject({
+        tables: [TABLE_ACTION],
+        operations: [],
+        assertions: [],
+        propertyGraphs: [GRAPH_ACTION],
+        targets: [TABLE_TARGET, GRAPH_TARGET]
+      })
+    );
+  });
+
+  test("--tags matches tagged tables but never property graphs", () => {
+    expect(asPlainObject(prune(makeCompiledGraph(), { tags: ["daily"] }))).deep.equals(
+      asPlainObject({
+        tables: [TABLE_ACTION],
+        operations: [],
+        assertions: [],
+        propertyGraphs: [],
+        targets: [TABLE_TARGET]
+      })
+    );
+  });
+
+  test("--actions=<pattern> matches graph by readable target string", () => {
+    expect(
+      asPlainObject(prune(makeCompiledGraph(), { actions: ["p.d.LibraryGraph"] }))
+    ).deep.equals(
+      asPlainObject({
+        tables: [],
+        operations: [],
+        assertions: [],
+        propertyGraphs: [GRAPH_ACTION],
+        targets: [GRAPH_TARGET]
+      })
+    );
+  });
+});

--- a/cli/api/utils/graphs.ts
+++ b/cli/api/utils/graphs.ts
@@ -6,7 +6,8 @@ type CoreProtoActionTypes =
   | dataform.IOperation
   | dataform.IAssertion
   | dataform.IDeclaration
-  | dataform.IDataPreparation;
+  | dataform.IDataPreparation
+  | dataform.IPropertyGraph;
 
 function combineAllActions(graph: dataform.ICompiledGraph) {
   return ([] as CoreProtoActionTypes[]).concat(
@@ -14,7 +15,8 @@ function combineAllActions(graph: dataform.ICompiledGraph) {
     graph.operations || ([] as dataform.IOperation[]),
     graph.assertions || ([] as dataform.IAssertion[]),
     graph.declarations || ([] as dataform.IDeclaration[]),
-    graph.dataPreparations || ([] as dataform.IDataPreparation[])
+    graph.dataPreparations || ([] as dataform.IDataPreparation[]),
+    graph.propertyGraphs || ([] as dataform.IPropertyGraph[])
   );
 }
 

--- a/cli/console.ts
+++ b/cli/console.ts
@@ -200,7 +200,8 @@ export function printCompiledGraph(graph: dataform.ICompiledGraph, outputType: c
       0 +
       (graph.tables ? graph.tables.length : 0) +
       (graph.assertions ? graph.assertions.length : 0) +
-      (graph.operations ? graph.operations.length : 0);
+      (graph.operations ? graph.operations.length : 0) +
+      (graph.propertyGraphs ? graph.propertyGraphs.length : 0);
     writeStdOut(successOutput(`Compiled ${actionCount} action(s).`));
     if (graph.tables && graph.tables.length) {
       graph.tables.forEach(setOrValidateTableEnumType);
@@ -231,6 +232,16 @@ export function printCompiledGraph(graph: dataform.ICompiledGraph, outputType: c
       if(!quietCompilation){
           graph.operations.forEach(operation => {
             writeStdOut(operationString(operation.target, operation.disabled), 1);
+          });
+      }
+    }
+    if (graph.propertyGraphs && graph.propertyGraphs.length) {
+      writeStdOut(
+        `${graph.propertyGraphs.length} property graph(s)${quietCompilation ? "." : ":"}`
+      );
+      if(!quietCompilation){
+          graph.propertyGraphs.forEach(propertyGraph => {
+            writeStdOut(propertyGraphString(propertyGraph.target, false), 1);
           });
       }
     }
@@ -283,11 +294,17 @@ export function printExecutionGraph(executionGraph: dataform.ExecutionGraph, asJ
     const actionsByType = {
       table: [] as dataform.IExecutionAction[],
       assertion: [] as dataform.IExecutionAction[],
-      operation: [] as dataform.IExecutionAction[]
+      operation: [] as dataform.IExecutionAction[],
+      propertyGraph: [] as dataform.IExecutionAction[]
     };
     executionGraph.actions.forEach(action => {
       if (
-        !(action.type === "table" || action.type === "assertion" || action.type === "operation")
+        !(
+          action.type === "table" ||
+          action.type === "assertion" ||
+          action.type === "operation" ||
+          action.type === "propertyGraph"
+        )
       ) {
         throw new Error(`Unrecognized action type: ${action.type}`);
       }
@@ -315,6 +332,19 @@ export function printExecutionGraph(executionGraph: dataform.ExecutionGraph, asJ
       writeStdOut(`${operationActions.length} operation(s):`);
       operationActions.forEach(operationAction =>
         writeStdOut(operationString(operationAction.target, operationAction.tasks.length === 0), 1)
+      );
+    }
+    const propertyGraphActions = actionsByType.propertyGraph;
+    if (propertyGraphActions && propertyGraphActions.length) {
+      writeStdOut(`${propertyGraphActions.length} property graph(s):`);
+      propertyGraphActions.forEach(propertyGraphAction =>
+        writeStdOut(
+          propertyGraphString(
+            propertyGraphAction.target,
+            propertyGraphAction.tasks.length === 0
+          ),
+          1
+        )
       );
     }
   }
@@ -372,13 +402,26 @@ export function printExecutedAction(
           );
           return;
         }
+        case "propertyGraph": {
+          writeStdOut(
+            `${successOutput(
+              `Property graph ${dryRun ? "dry run success" : "created"}: `
+            )} ${propertyGraphString(
+              executionAction.target,
+              executionAction.tasks.length === 0
+            )}${executionSuffix}`
+          );
+          return;
+        }
       }
     }
     case dataform.ActionResult.ExecutionStatus.FAILED: {
       switch (executionAction.type) {
         case "table": {
           writeStdErr(
-            `${errorOutput("Dataset creation failed: ")} ${datasetString(
+            `${errorOutput(
+              `Dataset ${dryRun ? "dry run" : "creation"} failed: `
+            )} ${datasetString(
               executionAction.target,
               executionAction.tableType,
               executionAction.tasks.length === 0
@@ -388,7 +431,9 @@ export function printExecutedAction(
         }
         case "assertion": {
           writeStdErr(
-            `${errorOutput("Assertion failed: ")} ${assertionString(
+            `${errorOutput(
+              `Assertion ${dryRun ? "dry run " : ""}failed: `
+            )} ${assertionString(
               executionAction.target,
               executionAction.tasks.length === 0
             )}${executionSuffix}`
@@ -397,7 +442,20 @@ export function printExecutedAction(
         }
         case "operation": {
           writeStdErr(
-            `${errorOutput("Operation failed: ")} ${operationString(
+            `${errorOutput(
+              `Operation ${dryRun ? "dry run " : ""}failed: `
+            )} ${operationString(
+              executionAction.target,
+              executionAction.tasks.length === 0
+            )}${executionSuffix}`
+          );
+          break;
+        }
+        case "propertyGraph": {
+          writeStdErr(
+            `${errorOutput(
+              `Property graph ${dryRun ? "dry run" : "creation"} failed: `
+            )} ${propertyGraphString(
               executionAction.target,
               executionAction.tasks.length === 0
             )}${executionSuffix}`
@@ -438,6 +496,19 @@ export function printExecutedAction(
           );
           return;
         }
+        case "propertyGraph": {
+          writeStdOut(
+            `${warningOutput(
+              dryRun
+                ? "Property graph dry run skipped (upstream tables not materialised): "
+                : "Skipping property graph creation: "
+            )} ${propertyGraphString(
+              executionAction.target,
+              executionAction.tasks.length === 0
+            )}`
+          );
+          return;
+        }
       }
       return;
     }
@@ -465,6 +536,15 @@ export function printExecutedAction(
         case "operation": {
           writeStdOut(
             `${warningOutput(`Operation execution disabled: `)} ${operationString(
+              executionAction.target,
+              executionAction.tasks.length === 0
+            )}`
+          );
+          return;
+        }
+        case "propertyGraph": {
+          writeStdOut(
+            `${warningOutput(`Property graph creation disabled: `)} ${propertyGraphString(
               executionAction.target,
               executionAction.tasks.length === 0
             )}`
@@ -516,6 +596,10 @@ function assertionString(target: dataform.ITarget, disabled: boolean) {
 }
 
 function operationString(target: dataform.ITarget, disabled: boolean) {
+  return `${targetString(target)}${disabled ? " [disabled]" : ""}`;
+}
+
+function propertyGraphString(target: dataform.ITarget, disabled: boolean) {
   return `${targetString(target)}${disabled ? " [disabled]" : ""}`;
 }
 

--- a/core/actions/property_graph.ts
+++ b/core/actions/property_graph.ts
@@ -1,15 +1,31 @@
 import { verifyObjectMatchesProto, VerifyProtoErrorBehaviour } from "df/common/protos";
 import { ActionBuilder } from "df/core/actions";
 import { Session } from "df/core/session";
+import { checkAssertionsForDependency } from "df/core/utils";
 import { dataform } from "df/protos/ts";
 
 const CATALOG_NOT_SUPPORTED_MESSAGE =
   "Catalog-based data sources (BigLake/Iceberg/external catalogs) are not yet supported.";
 
+function entityRefKey(name: string): string {
+  return `entity:${name}`;
+}
+
+function relationshipRefKey(name: string): string {
+  return `relationship:${name}`;
+}
+
 export class PropertyGraph extends ActionBuilder<dataform.PropertyGraph> {
   public session: Session;
+  public dependOnDependencyAssertions: boolean = false;
 
   private proto = dataform.PropertyGraph.create({ description: "", disabled: false });
+  // Populated during construction for entity/relationship configs that use a ref-style
+  // dataSource; drained in finalize() once all actions are indexed, since the target
+  // schema/database of a ref cannot be resolved until every action is known.
+  // Keys are produced by entityRefKey / relationshipRefKey.
+  private pendingRefs = new Map<string, dataform.ITarget>();
+  private dependencyKeys = new Set<string>();
 
   constructor(session?: Session, unverifiedConfig?: any, filename?: string) {
     super(session);
@@ -50,6 +66,9 @@ export class PropertyGraph extends ActionBuilder<dataform.PropertyGraph> {
     if (config.disabled) {
       this.proto.disabled = config.disabled;
     }
+    if (config.dependOnDependencyAssertions) {
+      this.dependOnDependencyAssertions = config.dependOnDependencyAssertions;
+    }
 
     this.proto.entities = config.entities.map(entityConfig =>
       this.buildEntity(entityConfig, config.name)
@@ -61,8 +80,6 @@ export class PropertyGraph extends ActionBuilder<dataform.PropertyGraph> {
     this.validateUniqueNames(config.name);
     this.resolveEndpointDefaults();
     this.validateEndpointReferences(config.name);
-
-    this.proto.graphBody = this.emitGraphBody();
   }
 
   public getFileName() {
@@ -74,20 +91,56 @@ export class PropertyGraph extends ActionBuilder<dataform.PropertyGraph> {
   }
 
   public compile() {
-    return verifyObjectMatchesProto(
+    this.proto = verifyObjectMatchesProto(
       dataform.PropertyGraph,
       this.proto,
       VerifyProtoErrorBehaviour.SUGGEST_REPORTING_TO_DATAFORM_TEAM
     );
+    return this.proto;
+  }
+
+  public finalize() {
+    let allResolved = true;
+    for (const entity of this.proto.entities) {
+      if (!this.resolveRefIntoDataSource(entity, entityRefKey(entity.name))) {
+        allResolved = false;
+      }
+    }
+    for (const rel of this.proto.relationships) {
+      if (!this.resolveRefIntoDataSource(rel, relationshipRefKey(rel.name))) {
+        allResolved = false;
+      }
+    }
+    if (allResolved) {
+      this.proto.graphBody = this.emitGraphBody();
+    }
+  }
+
+  private resolveRefIntoDataSource(
+    entityOrRel: dataform.IGraphEntity | dataform.IGraphRelationship,
+    key: string
+  ): boolean {
+    const rawRef = this.pendingRefs.get(key);
+    if (!rawRef) {
+      return true;
+    }
+    const target = this.session.resolveTarget(rawRef);
+    if (!target) {
+      return false;
+    }
+    entityOrRel.dataSource = dataform.Target.create(target);
+    return true;
   }
 
   private normalizeEntitiesAndRelationships(unverifiedConfig: any) {
     for (const entity of unverifiedConfig.entities || []) {
+      normalizeRef(entity);
       normalizeKeys(entity);
       normalizeFields(entity);
       normalizeFieldsOnLabels(entity);
     }
     for (const relationship of unverifiedConfig.relationships || []) {
+      normalizeRef(relationship);
       normalizeKeys(relationship);
       normalizeFields(relationship);
       normalizeFieldsOnLabels(relationship);
@@ -113,7 +166,7 @@ export class PropertyGraph extends ActionBuilder<dataform.PropertyGraph> {
     }
     const entityName = entityConfig.name;
     const where = `Property graph '${graphName}': entity '${entityName}'`;
-    const dataSource = this.resolveDataSource(entityConfig, where);
+    const dataSource = this.resolveDataSource(entityConfig, entityRefKey(entityName), where);
     if (!entityConfig.keys || entityConfig.keys.length === 0) {
       throw new Error(`${where} must declare 'keys'.`);
     }
@@ -137,7 +190,7 @@ export class PropertyGraph extends ActionBuilder<dataform.PropertyGraph> {
     }
     const relName = relConfig.name;
     const where = `Property graph '${graphName}': relationship '${relName}'`;
-    const dataSource = this.resolveDataSource(relConfig, where);
+    const dataSource = this.resolveDataSource(relConfig, relationshipRefKey(relName), where);
 
     if (!relConfig.source) {
       throw new Error(`${where} must declare 'source'.`);
@@ -163,6 +216,7 @@ export class PropertyGraph extends ActionBuilder<dataform.PropertyGraph> {
 
   private resolveDataSource(
     entityOrRel: dataform.IGraphEntityConfig | dataform.IGraphRelationshipConfig,
+    pendingKey: string,
     where: string
   ): dataform.Target {
     if (entityOrRel.dataSourceCatalog) {
@@ -186,6 +240,32 @@ export class PropertyGraph extends ActionBuilder<dataform.PropertyGraph> {
         );
       }
       return dataform.Target.create({ name: ds.table, schema: dataset, database: project });
+    }
+    if (entityOrRel.dataSourceRef) {
+      const ref = entityOrRel.dataSourceRef;
+      if (!ref.name) {
+        throw new Error(`${where}: 'ref' must include a 'name'.`);
+      }
+      const rawRef: dataform.ITarget = { name: ref.name };
+      if (ref.schema) {
+        rawRef.schema = ref.schema;
+      }
+      if (ref.database) {
+        rawRef.database = ref.database;
+      }
+      if (ref.includeDependentAssertions) {
+        rawRef.includeDependentAssertions = ref.includeDependentAssertions;
+      }
+      this.pendingRefs.set(pendingKey, rawRef);
+      const depKey = `${rawRef.database || ""}.${rawRef.schema || ""}.${rawRef.name}`;
+      if (!this.dependencyKeys.has(depKey)) {
+        this.dependencyKeys.add(depKey);
+        const depTarget = checkAssertionsForDependency(this, rawRef);
+        if (depTarget) {
+          this.proto.dependencyTargets.push(depTarget);
+        }
+      }
+      return undefined;
     }
     throw new Error(`${where}: must declare a data source.`);
   }
@@ -265,6 +345,21 @@ export class PropertyGraph extends ActionBuilder<dataform.PropertyGraph> {
       parts.push(`EDGE TABLES (\n  ${edgeEntries.join(",\n  ")}\n)`);
     }
     return parts.join("\n");
+  }
+}
+
+function normalizeRef(entityOrRel: any) {
+  if (entityOrRel.ref === undefined || entityOrRel.ref === null) {
+    return;
+  }
+  if (typeof entityOrRel.ref === "string") {
+    entityOrRel.dataSourceRef = { name: entityOrRel.ref };
+    delete entityOrRel.ref;
+    return;
+  }
+  if (typeof entityOrRel.ref === "object") {
+    entityOrRel.dataSourceRef = entityOrRel.ref;
+    delete entityOrRel.ref;
   }
 }
 

--- a/core/actions/property_graph_test.ts
+++ b/core/actions/property_graph_test.ts
@@ -16,7 +16,14 @@ function makeSession(): Session {
 }
 
 function compile(config: any, filename = "definitions/graph.yaml"): dataform.PropertyGraph {
-  return new PropertyGraph(makeSession(), config, filename).compile();
+  const action = new PropertyGraph(makeSession(), config, filename);
+  const compiled = action.compile();
+  action.finalize();
+  return compiled;
+}
+
+function build(config: any, filename = "definitions/graph.yaml"): PropertyGraph {
+  return new PropertyGraph(makeSession(), config, filename);
 }
 
 const graphTarget = (name: string) => ({
@@ -1351,5 +1358,190 @@ suite("property_graph", () => {
         graphBody: "NODE TABLES (\n  `p.d.A` AS A KEY (id)\n)"
       })
     );
+  });
+
+  test("scalar ref normalizes to dataSourceRef and populates dependencyTargets", () => {
+    const compiled = build({
+      name: "G",
+      entities: [
+        {
+          name: "A",
+          ref: "books",
+          keys: ["id"]
+        }
+      ]
+    }).compile();
+
+    expect(asPlainObject(compiled)).deep.equals(
+      asPlainObject({
+        target: graphTarget("G"),
+        canonicalTarget: graphTarget("G"),
+        dependencyTargets: [{ name: "books", includeDependentAssertions: false }],
+        fileName: "definitions/graph.yaml",
+        description: "",
+        disabled: false,
+        entities: [{ name: "A", keys: ["id"] }]
+      })
+    );
+  });
+
+  test("object ref preserves schema and database in dependencyTargets", () => {
+    const compiled = build({
+      name: "G",
+      entities: [
+        {
+          name: "A",
+          ref: { name: "books", schema: "analytics", database: "proj" },
+          keys: ["id"]
+        }
+      ]
+    }).compile();
+
+    expect(asPlainObject(compiled)).deep.equals(
+      asPlainObject({
+        target: graphTarget("G"),
+        canonicalTarget: graphTarget("G"),
+        dependencyTargets: [
+          { database: "proj", schema: "analytics", name: "books", includeDependentAssertions: false }
+        ],
+        fileName: "definitions/graph.yaml",
+        description: "",
+        disabled: false,
+        entities: [{ name: "A", keys: ["id"] }]
+      })
+    );
+  });
+
+  test("duplicate refs across entities dedupe in dependencyTargets", () => {
+    const compiled = build({
+      name: "G",
+      entities: [
+        { name: "A", ref: "books", keys: ["id"] },
+        { name: "B", ref: "books", keys: ["id"] }
+      ]
+    }).compile();
+
+    expect(asPlainObject(compiled)).deep.equals(
+      asPlainObject({
+        target: graphTarget("G"),
+        canonicalTarget: graphTarget("G"),
+        dependencyTargets: [{ name: "books", includeDependentAssertions: false }],
+        fileName: "definitions/graph.yaml",
+        description: "",
+        disabled: false,
+        entities: [
+          { name: "A", keys: ["id"] },
+          { name: "B", keys: ["id"] }
+        ]
+      })
+    );
+  });
+
+  test("graph-level dependOnDependencyAssertions propagates to every ref dependency", () => {
+    const compiled = build({
+      name: "G",
+      dependOnDependencyAssertions: true,
+      entities: [
+        { name: "A", ref: "books", keys: ["id"] },
+        { name: "B", ref: "authors", keys: ["id"] }
+      ]
+    }).compile();
+
+    expect(asPlainObject(compiled)).deep.equals(
+      asPlainObject({
+        target: graphTarget("G"),
+        canonicalTarget: graphTarget("G"),
+        dependencyTargets: [
+          { name: "books", includeDependentAssertions: true },
+          { name: "authors", includeDependentAssertions: true }
+        ],
+        fileName: "definitions/graph.yaml",
+        description: "",
+        disabled: false,
+        entities: [{ name: "A", keys: ["id"] }, { name: "B", keys: ["id"] }]
+      })
+    );
+  });
+
+  test("ref-level includeDependentAssertions propagates to that dependency only", () => {
+    const compiled = build({
+      name: "G",
+      entities: [
+        { name: "A", ref: { name: "books", includeDependentAssertions: true }, keys: ["id"] },
+        { name: "B", ref: "authors", keys: ["id"] }
+      ]
+    }).compile();
+
+    expect(asPlainObject(compiled)).deep.equals(
+      asPlainObject({
+        target: graphTarget("G"),
+        canonicalTarget: graphTarget("G"),
+        dependencyTargets: [
+          { name: "books", includeDependentAssertions: true },
+          { name: "authors", includeDependentAssertions: false }
+        ],
+        fileName: "definitions/graph.yaml",
+        description: "",
+        disabled: false,
+        entities: [{ name: "A", keys: ["id"] }, { name: "B", keys: ["id"] }]
+      })
+    );
+  });
+
+  test("ref on relationship also normalizes and populates dependencyTargets", () => {
+    const compiled = build({
+      name: "G",
+      entities: [
+        { name: "A", dataSourceString: "p.d.A", keys: ["id"] },
+        { name: "B", dataSourceString: "p.d.B", keys: ["id"] }
+      ],
+      relationships: [
+        {
+          name: "R",
+          ref: "wrote",
+          keys: ["a_id", "b_id"],
+          source: { entity: "A", joinKeys: ["a_id"] },
+          destination: { entity: "B", joinKeys: ["b_id"] }
+        }
+      ]
+    }).compile();
+
+    expect(asPlainObject(compiled)).deep.equals(
+      asPlainObject({
+        target: graphTarget("G"),
+        canonicalTarget: graphTarget("G"),
+        dependencyTargets: [{ name: "wrote", includeDependentAssertions: false }],
+        fileName: "definitions/graph.yaml",
+        description: "",
+        disabled: false,
+        entities: [
+          { name: "A", dataSource: { database: "p", schema: "d", name: "A" }, keys: ["id"] },
+          { name: "B", dataSource: { database: "p", schema: "d", name: "B" }, keys: ["id"] }
+        ],
+        relationships: [
+          {
+            name: "R",
+            keys: ["a_id", "b_id"],
+            source: { entity: "A", relationshipColumns: ["a_id"], entityColumns: ["id"] },
+            destination: { entity: "B", relationshipColumns: ["b_id"], entityColumns: ["id"] }
+          }
+        ]
+      })
+    );
+  });
+
+  test("errors when ref has no name", () => {
+    expect(() =>
+      compile({
+        name: "G",
+        entities: [
+          {
+            name: "A",
+            ref: { schema: "s" },
+            keys: ["id"]
+          }
+        ]
+      })
+    ).to.throw("'ref' must include a 'name'");
   });
 });

--- a/core/main_test.ts
+++ b/core/main_test.ts
@@ -2528,12 +2528,12 @@ actions:
       expect(tables.length).equals(2);
 
       const topEnPages = tables.find(t => t.target.name === "top_en_pages");
-      expect(topEnPages).to.not.be.undefined;
+      expect(topEnPages).to.not.equal(undefined);
       expect(topEnPages.target.database).equals("swalk-composer-1");
       expect(topEnPages.target.schema).equals("my_dataset");
 
       const sharedTopPages = tables.find(t => t.target.name === "shared_top_pages");
-      expect(sharedTopPages).to.not.be.undefined;
+      expect(sharedTopPages).to.not.equal(undefined);
       expect(sharedTopPages.target.database).equals("swalk-composer-1");
       expect(sharedTopPages.target.schema).equals("my_dataset");
       expect(asPlainObject(sharedTopPages.dependencyTargets)).deep.equals([
@@ -2995,7 +2995,7 @@ actions:
           }
         }
       }
-      expect(foundDagFile).to.be.true;
+      expect(foundDagFile).to.equal(true);
     });
 
     test("op-to-dataform transpiles airflowOperator actions with runner 'dataform-notebook-cloud-run-service'", () => {
@@ -3059,7 +3059,7 @@ actions:
           }
         }
       }
-      expect(foundDagFile).to.be.true;
+      expect(foundDagFile).to.equal(true);
     });
 
     test("op-to-dataform transpiles airflowOperator actions with runner 'dataform-notebook-cloud-run-job'", () => {
@@ -3163,7 +3163,7 @@ actions:
           }
         }
       }
-      expect(foundDagFileOne).to.be.true;
+      expect(foundDagFileOne).to.equal(true);
 
       // Verify action_two notebook contains GCSDeleteBucketOperator
       const notebookTwoContents = JSON.parse(notebooks.find(n => n.target.name === "action_two").notebookContents);
@@ -3182,7 +3182,7 @@ actions:
           }
         }
       }
-      expect(foundDagFileTwo).to.be.true;
+      expect(foundDagFileTwo).to.equal(true);
     });
 
     test("op-to-dataform supports stagingBucket in defaults", () => {

--- a/core/main_test.ts
+++ b/core/main_test.ts
@@ -3893,6 +3893,961 @@ relationships:
       }));
     });
 
+    test("ref to declaration resolves entity dataSource and renders graphBody", () => {
+      const projectDir = tmpDirFixture.createNewTmpDir();
+      fs.writeFileSync(
+        path.join(projectDir, "workflow_settings.yaml"),
+        VALID_WORKFLOW_SETTINGS_YAML
+      );
+      fs.mkdirSync(path.join(projectDir, "definitions"));
+      fs.writeFileSync(
+        path.join(projectDir, "definitions/actions.yaml"),
+        `
+actions:
+- declaration:
+    name: books
+`
+      );
+      fs.writeFileSync(
+        path.join(projectDir, "definitions/graph.yaml"),
+        `
+name: RefGraph
+entities:
+- name: Book
+  ref: books
+  keys:
+  - id
+`
+      );
+
+      const result = runMainInVm(coreExecutionRequestFromPath(projectDir));
+
+      expect(result.compile.compiledGraph.graphErrors.compilationErrors).deep.equals([]);
+      expect(asPlainObject(result.compile.compiledGraph.propertyGraphs)).deep.equals(
+        asPlainObject([
+          {
+            target: {
+              schema: "defaultDataset",
+              name: "RefGraph",
+              database: "defaultProject"
+            },
+            canonicalTarget: {
+              schema: "defaultDataset",
+              name: "RefGraph",
+              database: "defaultProject"
+            },
+            dependencyTargets: [
+              {
+                database: "defaultProject",
+                schema: "defaultDataset",
+                name: "books"
+              }
+            ],
+            fileName: "definitions/graph.yaml",
+            description: "",
+            disabled: false,
+            entities: [
+              {
+                name: "Book",
+                dataSource: {
+                  schema: "defaultDataset",
+                  name: "books",
+                  database: "defaultProject"
+                },
+                keys: ["id"]
+              }
+            ],
+            graphBody:
+              "NODE TABLES (\n" +
+              "  `defaultProject.defaultDataset.books` AS Book KEY (id)\n" +
+              ")"
+          }
+        ])
+      );
+    });
+
+    test("ref with schema override resolves the matching declaration", () => {
+      const projectDir = tmpDirFixture.createNewTmpDir();
+      fs.writeFileSync(
+        path.join(projectDir, "workflow_settings.yaml"),
+        VALID_WORKFLOW_SETTINGS_YAML
+      );
+      fs.mkdirSync(path.join(projectDir, "definitions"));
+      fs.writeFileSync(
+        path.join(projectDir, "definitions/actions.yaml"),
+        `
+actions:
+- declaration:
+    name: books
+    dataset: alt
+- declaration:
+    name: books
+`
+      );
+      fs.writeFileSync(
+        path.join(projectDir, "definitions/graph.yaml"),
+        `
+name: RefWithSchemaGraph
+entities:
+- name: Book
+  ref:
+    name: books
+    schema: alt
+  keys:
+  - id
+`
+      );
+
+      const result = runMainInVm(coreExecutionRequestFromPath(projectDir));
+
+      expect(result.compile.compiledGraph.graphErrors.compilationErrors).deep.equals([]);
+      expect(asPlainObject(result.compile.compiledGraph.propertyGraphs)).deep.equals(
+        asPlainObject([
+          {
+            target: {
+              schema: "defaultDataset",
+              name: "RefWithSchemaGraph",
+              database: "defaultProject"
+            },
+            canonicalTarget: {
+              schema: "defaultDataset",
+              name: "RefWithSchemaGraph",
+              database: "defaultProject"
+            },
+            dependencyTargets: [
+              {
+                database: "defaultProject",
+                schema: "alt",
+                name: "books"
+              }
+            ],
+            fileName: "definitions/graph.yaml",
+            description: "",
+            disabled: false,
+            entities: [
+              {
+                name: "Book",
+                dataSource: {
+                  schema: "alt",
+                  name: "books",
+                  database: "defaultProject"
+                },
+                keys: ["id"]
+              }
+            ],
+            graphBody:
+              "NODE TABLES (\n" +
+              "  `defaultProject.alt.books` AS Book KEY (id)\n" +
+              ")"
+          }
+        ])
+      );
+    });
+
+    test("ref with includeDependentAssertions pulls the dependency's assertions", () => {
+      const projectDir = tmpDirFixture.createNewTmpDir();
+      fs.writeFileSync(
+        path.join(projectDir, "workflow_settings.yaml"),
+        VALID_WORKFLOW_SETTINGS_YAML
+      );
+      fs.mkdirSync(path.join(projectDir, "definitions"));
+      fs.writeFileSync(
+        path.join(projectDir, "definitions/books.sqlx"),
+        `config {
+  type: "table",
+  assertions: { rowConditions: ["id > 0"] }
+}
+select 1 as id`
+      );
+      fs.writeFileSync(
+        path.join(projectDir, "definitions/graph.yaml"),
+        `
+name: AssertRefGraph
+entities:
+- name: Book
+  ref:
+    name: books
+    includeDependentAssertions: true
+  keys:
+  - id
+`
+      );
+
+      const result = runMainInVm(coreExecutionRequestFromPath(projectDir));
+
+      expect(result.compile.compiledGraph.graphErrors.compilationErrors).deep.equals([]);
+      expect(asPlainObject(result.compile.compiledGraph.propertyGraphs)).deep.equals(
+        asPlainObject([
+          {
+            target: {
+              schema: "defaultDataset",
+              name: "AssertRefGraph",
+              database: "defaultProject"
+            },
+            canonicalTarget: {
+              schema: "defaultDataset",
+              name: "AssertRefGraph",
+              database: "defaultProject"
+            },
+            dependencyTargets: [
+              {
+                database: "defaultProject",
+                schema: "defaultDataset",
+                name: "books"
+              },
+              {
+                database: "defaultProject",
+                schema: "defaultDataset",
+                name: "defaultDataset_books_assertions_rowConditions"
+              }
+            ],
+            fileName: "definitions/graph.yaml",
+            description: "",
+            disabled: false,
+            entities: [
+              {
+                name: "Book",
+                dataSource: {
+                  schema: "defaultDataset",
+                  name: "books",
+                  database: "defaultProject"
+                },
+                keys: ["id"]
+              }
+            ],
+            graphBody:
+              "NODE TABLES (\n" +
+              "  `defaultProject.defaultDataset.books` AS Book KEY (id)\n" +
+              ")"
+          }
+        ])
+      );
+    });
+
+    test("graph-level dependOnDependencyAssertions pulls every ref's assertions", () => {
+      const projectDir = tmpDirFixture.createNewTmpDir();
+      fs.writeFileSync(
+        path.join(projectDir, "workflow_settings.yaml"),
+        VALID_WORKFLOW_SETTINGS_YAML
+      );
+      fs.mkdirSync(path.join(projectDir, "definitions"));
+      fs.writeFileSync(
+        path.join(projectDir, "definitions/books.sqlx"),
+        `config {
+  type: "table",
+  assertions: { rowConditions: ["id > 0"] }
+}
+select 1 as id`
+      );
+      fs.writeFileSync(
+        path.join(projectDir, "definitions/graph.yaml"),
+        `
+name: GraphAssertDefaultGraph
+dependOnDependencyAssertions: true
+entities:
+- name: Book
+  ref: books
+  keys:
+  - id
+`
+      );
+
+      const result = runMainInVm(coreExecutionRequestFromPath(projectDir));
+
+      expect(result.compile.compiledGraph.graphErrors.compilationErrors).deep.equals([]);
+      expect(asPlainObject(result.compile.compiledGraph.propertyGraphs)).deep.equals(
+        asPlainObject([
+          {
+            target: {
+              schema: "defaultDataset",
+              name: "GraphAssertDefaultGraph",
+              database: "defaultProject"
+            },
+            canonicalTarget: {
+              schema: "defaultDataset",
+              name: "GraphAssertDefaultGraph",
+              database: "defaultProject"
+            },
+            dependencyTargets: [
+              {
+                database: "defaultProject",
+                schema: "defaultDataset",
+                name: "books"
+              },
+              {
+                database: "defaultProject",
+                schema: "defaultDataset",
+                name: "defaultDataset_books_assertions_rowConditions"
+              }
+            ],
+            fileName: "definitions/graph.yaml",
+            description: "",
+            disabled: false,
+            entities: [
+              {
+                name: "Book",
+                dataSource: {
+                  schema: "defaultDataset",
+                  name: "books",
+                  database: "defaultProject"
+                },
+                keys: ["id"]
+              }
+            ],
+            graphBody:
+              "NODE TABLES (\n" +
+              "  `defaultProject.defaultDataset.books` AS Book KEY (id)\n" +
+              ")"
+          }
+        ])
+      );
+    });
+
+    test("missing ref emits a compilation error and leaves graphBody empty", () => {
+      const projectDir = tmpDirFixture.createNewTmpDir();
+      fs.writeFileSync(
+        path.join(projectDir, "workflow_settings.yaml"),
+        VALID_WORKFLOW_SETTINGS_YAML
+      );
+      fs.mkdirSync(path.join(projectDir, "definitions"));
+      fs.writeFileSync(
+        path.join(projectDir, "definitions/graph.yaml"),
+        `
+name: MissingRefGraph
+entities:
+- name: Book
+  ref: nonexistent
+  keys:
+  - id
+`
+      );
+
+      const result = runMainInVm(coreExecutionRequestFromPath(projectDir));
+
+      const missingRefTarget = {
+        schema: "defaultDataset",
+        name: "MissingRefGraph",
+        database: "defaultProject"
+      };
+      expect(asPlainObject(result.compile.compiledGraph)).deep.equals(asPlainObject({
+        projectConfig: graphProjectConfig,
+        graphErrors: {
+          compilationErrors: [
+            graphError(
+              "definitions/graph.yaml",
+              "Missing dependency detected: Action " +
+                "\"defaultProject.defaultDataset.MissingRefGraph\" depends on " +
+                "\"{\"name\":\"nonexistent\",\"includeDependentAssertions\":false}\" " +
+                "which does not exist",
+              {
+                actionName: "defaultProject.defaultDataset.MissingRefGraph",
+                actionTarget: missingRefTarget
+              }
+            )
+          ]
+        },
+        dataformCoreVersion: version,
+        targets: [missingRefTarget],
+        jitData: {},
+        propertyGraphs: [
+          {
+            target: missingRefTarget,
+            canonicalTarget: missingRefTarget,
+            fileName: "definitions/graph.yaml",
+            description: "",
+            disabled: false,
+            entities: [
+              {
+                name: "Book",
+                keys: ["id"]
+              }
+            ]
+          }
+        ]
+      }));
+    });
+
+    test("ref to a table respects datasetSuffix on the resolved dependency", () => {
+      const projectDir = tmpDirFixture.createNewTmpDir();
+      fs.writeFileSync(
+        path.join(projectDir, "workflow_settings.yaml"),
+        `
+defaultProject: defaultProject
+defaultDataset: defaultDataset
+defaultLocation: US
+datasetSuffix: dev
+`
+      );
+      fs.mkdirSync(path.join(projectDir, "definitions"));
+      fs.writeFileSync(
+        path.join(projectDir, "definitions/books.sqlx"),
+        `config {type: "table"}
+select 1 as id`
+      );
+      fs.writeFileSync(
+        path.join(projectDir, "definitions/graph.yaml"),
+        `
+name: SuffixRefGraph
+entities:
+- name: Book
+  ref: books
+  keys:
+  - id
+`
+      );
+
+      const result = runMainInVm(coreExecutionRequestFromPath(projectDir));
+
+      expect(result.compile.compiledGraph.graphErrors.compilationErrors).deep.equals([]);
+      expect(asPlainObject(result.compile.compiledGraph.propertyGraphs)).deep.equals(
+        asPlainObject([
+          {
+            target: {
+              schema: "defaultDataset_dev",
+              name: "SuffixRefGraph",
+              database: "defaultProject"
+            },
+            canonicalTarget: {
+              schema: "defaultDataset",
+              name: "SuffixRefGraph",
+              database: "defaultProject"
+            },
+            dependencyTargets: [
+              {
+                schema: "defaultDataset_dev",
+                name: "books",
+                database: "defaultProject"
+              }
+            ],
+            fileName: "definitions/graph.yaml",
+            description: "",
+            disabled: false,
+            entities: [
+              {
+                name: "Book",
+                dataSource: {
+                  schema: "defaultDataset_dev",
+                  name: "books",
+                  database: "defaultProject"
+                },
+                keys: ["id"]
+              }
+            ],
+            graphBody:
+              "NODE TABLES (\n" +
+              "  `defaultProject.defaultDataset_dev.books` AS Book KEY (id)\n" +
+              ")"
+          }
+        ])
+      );
+    });
+
+    test("ref with database override resolves the matching declaration", () => {
+      const projectDir = tmpDirFixture.createNewTmpDir();
+      fs.writeFileSync(
+        path.join(projectDir, "workflow_settings.yaml"),
+        VALID_WORKFLOW_SETTINGS_YAML
+      );
+      fs.mkdirSync(path.join(projectDir, "definitions"));
+      fs.writeFileSync(
+        path.join(projectDir, "definitions/actions.yaml"),
+        `
+actions:
+- declaration:
+    name: books
+    project: otherProject
+- declaration:
+    name: books
+`
+      );
+      fs.writeFileSync(
+        path.join(projectDir, "definitions/graph.yaml"),
+        `
+name: RefWithDatabaseGraph
+entities:
+- name: Book
+  ref:
+    name: books
+    database: otherProject
+  keys:
+  - id
+`
+      );
+
+      const result = runMainInVm(coreExecutionRequestFromPath(projectDir));
+
+      expect(result.compile.compiledGraph.graphErrors.compilationErrors).deep.equals([]);
+      expect(asPlainObject(result.compile.compiledGraph.propertyGraphs)).deep.equals(
+        asPlainObject([
+          {
+            target: {
+              schema: "defaultDataset",
+              name: "RefWithDatabaseGraph",
+              database: "defaultProject"
+            },
+            canonicalTarget: {
+              schema: "defaultDataset",
+              name: "RefWithDatabaseGraph",
+              database: "defaultProject"
+            },
+            dependencyTargets: [
+              {
+                database: "otherProject",
+                schema: "defaultDataset",
+                name: "books"
+              }
+            ],
+            fileName: "definitions/graph.yaml",
+            description: "",
+            disabled: false,
+            entities: [
+              {
+                name: "Book",
+                dataSource: {
+                  database: "otherProject",
+                  schema: "defaultDataset",
+                  name: "books"
+                },
+                keys: ["id"]
+              }
+            ],
+            graphBody:
+              "NODE TABLES (\n" +
+              "  `otherProject.defaultDataset.books` AS Book KEY (id)\n" +
+              ")"
+          }
+        ])
+      );
+    });
+
+    test("relationship ref resolves through the full pipeline", () => {
+      const projectDir = tmpDirFixture.createNewTmpDir();
+      fs.writeFileSync(
+        path.join(projectDir, "workflow_settings.yaml"),
+        VALID_WORKFLOW_SETTINGS_YAML
+      );
+      fs.mkdirSync(path.join(projectDir, "definitions"));
+      fs.writeFileSync(
+        path.join(projectDir, "definitions/actions.yaml"),
+        `
+actions:
+- declaration:
+    name: wrote
+`
+      );
+      fs.writeFileSync(
+        path.join(projectDir, "definitions/graph.yaml"),
+        `
+name: RelationshipRefGraph
+entities:
+- name: Book
+  dataSourceString: defaultProject.defaultDataset.books
+  keys:
+  - id
+- name: Author
+  dataSourceString: defaultProject.defaultDataset.authors
+  keys:
+  - id
+relationships:
+- name: WrittenBy
+  ref: wrote
+  keys:
+  - author_id
+  - book_id
+  source:
+    entity: Book
+    joinKeys:
+    - book_id
+  destination:
+    entity: Author
+    joinKeys:
+    - author_id
+`
+      );
+
+      const result = runMainInVm(coreExecutionRequestFromPath(projectDir));
+
+      expect(result.compile.compiledGraph.graphErrors.compilationErrors).deep.equals([]);
+      expect(asPlainObject(result.compile.compiledGraph.propertyGraphs)).deep.equals(
+        asPlainObject([
+          {
+            target: {
+              schema: "defaultDataset",
+              name: "RelationshipRefGraph",
+              database: "defaultProject"
+            },
+            canonicalTarget: {
+              schema: "defaultDataset",
+              name: "RelationshipRefGraph",
+              database: "defaultProject"
+            },
+            dependencyTargets: [
+              {
+                database: "defaultProject",
+                schema: "defaultDataset",
+                name: "wrote"
+              }
+            ],
+            fileName: "definitions/graph.yaml",
+            description: "",
+            disabled: false,
+            entities: [
+              {
+                name: "Book",
+                dataSource: {
+                  database: "defaultProject",
+                  schema: "defaultDataset",
+                  name: "books"
+                },
+                keys: ["id"]
+              },
+              {
+                name: "Author",
+                dataSource: {
+                  database: "defaultProject",
+                  schema: "defaultDataset",
+                  name: "authors"
+                },
+                keys: ["id"]
+              }
+            ],
+            relationships: [
+              {
+                name: "WrittenBy",
+                dataSource: {
+                  database: "defaultProject",
+                  schema: "defaultDataset",
+                  name: "wrote"
+                },
+                keys: ["author_id", "book_id"],
+                source: {
+                  entity: "Book",
+                  relationshipColumns: ["book_id"],
+                  entityColumns: ["id"]
+                },
+                destination: {
+                  entity: "Author",
+                  relationshipColumns: ["author_id"],
+                  entityColumns: ["id"]
+                }
+              }
+            ],
+            graphBody:
+              "NODE TABLES (\n" +
+              "  `defaultProject.defaultDataset.books` AS Book KEY (id),\n" +
+              "  `defaultProject.defaultDataset.authors` AS Author KEY (id)\n" +
+              ")\n" +
+              "EDGE TABLES (\n" +
+              "  `defaultProject.defaultDataset.wrote` AS WrittenBy " +
+              "KEY (author_id, book_id) " +
+              "SOURCE KEY (book_id) REFERENCES Book (id) " +
+              "DESTINATION KEY (author_id) REFERENCES Author (id)\n" +
+              ")"
+          }
+        ])
+      );
+    });
+
+    test("ref to a view resolves and picks up datasetSuffix", () => {
+      const projectDir = tmpDirFixture.createNewTmpDir();
+      fs.writeFileSync(
+        path.join(projectDir, "workflow_settings.yaml"),
+        `
+defaultProject: defaultProject
+defaultDataset: defaultDataset
+defaultLocation: US
+datasetSuffix: dev
+`
+      );
+      fs.mkdirSync(path.join(projectDir, "definitions"));
+      fs.writeFileSync(
+        path.join(projectDir, "definitions/books.sqlx"),
+        `config {type: "view"}
+select 1 as id`
+      );
+      fs.writeFileSync(
+        path.join(projectDir, "definitions/graph.yaml"),
+        `
+name: ViewRefGraph
+entities:
+- name: Book
+  ref: books
+  keys:
+  - id
+`
+      );
+
+      const result = runMainInVm(coreExecutionRequestFromPath(projectDir));
+
+      expect(result.compile.compiledGraph.graphErrors.compilationErrors).deep.equals([]);
+      expect(asPlainObject(result.compile.compiledGraph.propertyGraphs)).deep.equals(
+        asPlainObject([
+          {
+            target: {
+              schema: "defaultDataset_dev",
+              name: "ViewRefGraph",
+              database: "defaultProject"
+            },
+            canonicalTarget: {
+              schema: "defaultDataset",
+              name: "ViewRefGraph",
+              database: "defaultProject"
+            },
+            dependencyTargets: [
+              {
+                database: "defaultProject",
+                schema: "defaultDataset_dev",
+                name: "books"
+              }
+            ],
+            fileName: "definitions/graph.yaml",
+            description: "",
+            disabled: false,
+            entities: [
+              {
+                name: "Book",
+                dataSource: {
+                  database: "defaultProject",
+                  schema: "defaultDataset_dev",
+                  name: "books"
+                },
+                keys: ["id"]
+              }
+            ],
+            graphBody:
+              "NODE TABLES (\n" +
+              "  `defaultProject.defaultDataset_dev.books` AS Book KEY (id)\n" +
+              ")"
+          }
+        ])
+      );
+    });
+
+    test("ambiguous ref emits a compilation error", () => {
+      const projectDir = tmpDirFixture.createNewTmpDir();
+      fs.writeFileSync(
+        path.join(projectDir, "workflow_settings.yaml"),
+        VALID_WORKFLOW_SETTINGS_YAML
+      );
+      fs.mkdirSync(path.join(projectDir, "definitions"));
+      fs.writeFileSync(
+        path.join(projectDir, "definitions/actions.yaml"),
+        `
+actions:
+- declaration:
+    name: books
+    dataset: one
+- declaration:
+    name: books
+    dataset: two
+`
+      );
+      fs.writeFileSync(
+        path.join(projectDir, "definitions/graph.yaml"),
+        `
+name: AmbiguousRefGraph
+entities:
+- name: Book
+  ref: books
+  keys:
+  - id
+`
+      );
+
+      const result = runMainInVm(coreExecutionRequestFromPath(projectDir));
+
+      const declOneTarget = { schema: "one", name: "books", database: "defaultProject" };
+      const declTwoTarget = { schema: "two", name: "books", database: "defaultProject" };
+      const graphTarget = {
+        schema: "defaultDataset",
+        name: "AmbiguousRefGraph",
+        database: "defaultProject"
+      };
+      expect(asPlainObject(result.compile.compiledGraph)).deep.equals(asPlainObject({
+        projectConfig: graphProjectConfig,
+        graphErrors: {
+          compilationErrors: [
+            graphError(
+              "definitions/graph.yaml",
+              `Ambiguous Action name: {"name":"books","includeDependentAssertions":false}. ` +
+                "Did you mean one of: one.books, two.books.",
+              {
+                actionName: "defaultProject.defaultDataset.AmbiguousRefGraph",
+                actionTarget: graphTarget
+              }
+            )
+          ]
+        },
+        dataformCoreVersion: version,
+        targets: [declOneTarget, declTwoTarget, graphTarget],
+        jitData: {},
+        declarations: [
+          { target: declOneTarget, canonicalTarget: declOneTarget },
+          { target: declTwoTarget, canonicalTarget: declTwoTarget }
+        ],
+        propertyGraphs: [
+          {
+            target: graphTarget,
+            canonicalTarget: graphTarget,
+            fileName: "definitions/graph.yaml",
+            description: "",
+            disabled: false,
+            entities: [{ name: "Book", keys: ["id"] }]
+          }
+        ]
+      }));
+    });
+
+    test("ref to a table respects projectSuffix on the resolved dependency", () => {
+      const projectDir = tmpDirFixture.createNewTmpDir();
+      fs.writeFileSync(
+        path.join(projectDir, "workflow_settings.yaml"),
+        `
+defaultProject: defaultProject
+defaultDataset: defaultDataset
+defaultLocation: US
+projectSuffix: dev
+`
+      );
+      fs.mkdirSync(path.join(projectDir, "definitions"));
+      fs.writeFileSync(
+        path.join(projectDir, "definitions/books.sqlx"),
+        `config {type: "table"}
+select 1 as id`
+      );
+      fs.writeFileSync(
+        path.join(projectDir, "definitions/graph.yaml"),
+        `
+name: ProjectSuffixRefGraph
+entities:
+- name: Book
+  ref: books
+  keys:
+  - id
+`
+      );
+
+      const result = runMainInVm(coreExecutionRequestFromPath(projectDir));
+
+      expect(result.compile.compiledGraph.graphErrors.compilationErrors).deep.equals([]);
+      expect(asPlainObject(result.compile.compiledGraph.propertyGraphs)).deep.equals(
+        asPlainObject([
+          {
+            target: {
+              schema: "defaultDataset",
+              name: "ProjectSuffixRefGraph",
+              database: "defaultProject_dev"
+            },
+            canonicalTarget: {
+              schema: "defaultDataset",
+              name: "ProjectSuffixRefGraph",
+              database: "defaultProject"
+            },
+            dependencyTargets: [
+              {
+                schema: "defaultDataset",
+                name: "books",
+                database: "defaultProject_dev"
+              }
+            ],
+            fileName: "definitions/graph.yaml",
+            description: "",
+            disabled: false,
+            entities: [
+              {
+                name: "Book",
+                dataSource: {
+                  schema: "defaultDataset",
+                  name: "books",
+                  database: "defaultProject_dev"
+                },
+                keys: ["id"]
+              }
+            ],
+            graphBody:
+              "NODE TABLES (\n" +
+              "  `defaultProject_dev.defaultDataset.books` AS Book KEY (id)\n" +
+              ")"
+          }
+        ])
+      );
+    });
+
+    test("ref to a table respects namePrefix on the resolved dependency", () => {
+      const projectDir = tmpDirFixture.createNewTmpDir();
+      fs.writeFileSync(
+        path.join(projectDir, "workflow_settings.yaml"),
+        `
+defaultProject: defaultProject
+defaultDataset: defaultDataset
+defaultLocation: US
+namePrefix: pfx
+`
+      );
+      fs.mkdirSync(path.join(projectDir, "definitions"));
+      fs.writeFileSync(
+        path.join(projectDir, "definitions/books.sqlx"),
+        `config {type: "table"}
+select 1 as id`
+      );
+      fs.writeFileSync(
+        path.join(projectDir, "definitions/graph.yaml"),
+        `
+name: NamePrefixRefGraph
+entities:
+- name: Book
+  ref: books
+  keys:
+  - id
+`
+      );
+
+      const result = runMainInVm(coreExecutionRequestFromPath(projectDir));
+
+      expect(result.compile.compiledGraph.graphErrors.compilationErrors).deep.equals([]);
+      expect(asPlainObject(result.compile.compiledGraph.propertyGraphs)).deep.equals(
+        asPlainObject([
+          {
+            target: {
+              schema: "defaultDataset",
+              name: "pfx_NamePrefixRefGraph",
+              database: "defaultProject"
+            },
+            canonicalTarget: {
+              schema: "defaultDataset",
+              name: "NamePrefixRefGraph",
+              database: "defaultProject"
+            },
+            dependencyTargets: [
+              {
+                schema: "defaultDataset",
+                name: "pfx_books",
+                database: "defaultProject"
+              }
+            ],
+            fileName: "definitions/graph.yaml",
+            description: "",
+            disabled: false,
+            entities: [
+              {
+                name: "Book",
+                dataSource: {
+                  schema: "defaultDataset",
+                  name: "pfx_books",
+                  database: "defaultProject"
+                },
+                keys: ["id"]
+              }
+            ],
+            graphBody:
+              "NODE TABLES (\n" +
+              "  `defaultProject.defaultDataset.pfx_books` AS Book KEY (id)\n" +
+              ")"
+          }
+        ])
+      );
+    });
+
     test("graph target colliding with a table target is flagged as duplicate", () => {
       const projectDir = tmpDirFixture.createNewTmpDir();
       fs.writeFileSync(
@@ -4080,6 +5035,91 @@ relationships:
           }
         ]
       }));
+    });
+
+    test("mixed ref and dataSourceString: only ref target appears in dependencyTargets", () => {
+      const projectDir = tmpDirFixture.createNewTmpDir();
+      fs.writeFileSync(
+        path.join(projectDir, "workflow_settings.yaml"),
+        VALID_WORKFLOW_SETTINGS_YAML
+      );
+      fs.mkdirSync(path.join(projectDir, "definitions"));
+      fs.writeFileSync(
+        path.join(projectDir, "definitions/books.sqlx"),
+        `config {type: "table"}
+select 1 as id`
+      );
+      fs.writeFileSync(
+        path.join(projectDir, "definitions/authors.sqlx"),
+        `config {type: "table"}
+select 1 as id`
+      );
+      fs.writeFileSync(
+        path.join(projectDir, "definitions/graph.yaml"),
+        `
+name: MixedRefStringGraph
+entities:
+- name: Book
+  ref: books
+  keys:
+  - id
+- name: Author
+  dataSourceString: defaultProject.defaultDataset.authors
+  keys:
+  - id
+`
+      );
+
+      const result = runMainInVm(coreExecutionRequestFromPath(projectDir));
+
+      expect(result.compile.compiledGraph.graphErrors.compilationErrors).deep.equals([]);
+      expect(asPlainObject(result.compile.compiledGraph.propertyGraphs)).deep.equals(
+        asPlainObject([
+          {
+            target: {
+              schema: "defaultDataset",
+              name: "MixedRefStringGraph",
+              database: "defaultProject"
+            },
+            canonicalTarget: {
+              schema: "defaultDataset",
+              name: "MixedRefStringGraph",
+              database: "defaultProject"
+            },
+            dependencyTargets: [
+              { database: "defaultProject", schema: "defaultDataset", name: "books" }
+            ],
+            fileName: "definitions/graph.yaml",
+            description: "",
+            disabled: false,
+            entities: [
+              {
+                name: "Book",
+                dataSource: {
+                  schema: "defaultDataset",
+                  name: "books",
+                  database: "defaultProject"
+                },
+                keys: ["id"]
+              },
+              {
+                name: "Author",
+                dataSource: {
+                  schema: "defaultDataset",
+                  name: "authors",
+                  database: "defaultProject"
+                },
+                keys: ["id"]
+              }
+            ],
+            graphBody:
+              "NODE TABLES (\n" +
+              "  `defaultProject.defaultDataset.books` AS Book KEY (id),\n" +
+              "  `defaultProject.defaultDataset.authors` AS Author KEY (id)\n" +
+              ")"
+          }
+        ])
+      );
     });
   });
 });

--- a/core/session.ts
+++ b/core/session.ts
@@ -263,21 +263,37 @@ export class Session {
       return "";
     }
 
-    if (resolved) {
-      if (resolved instanceof Declaration) {
-        return this.compilationSql().resolveTarget(resolved.getTarget());
-      }
-      return this.compilationSql().resolveTarget({
-        ...resolved.getTarget(),
-        database:
-          resolved.getTarget().database && this.finalizeDatabase(resolved.getTarget().database),
-        schema: this.finalizeSchema(resolved.getTarget().schema),
-        name: this.finalizeName(resolved.getTarget().name)
-      });
+    const target = this.resolveTarget(ref);
+    if (!target) {
+      this.compileError(new Error(`Could not resolve ${JSON.stringify(ref)}`));
+      return "";
     }
+    return this.compilationSql().resolveTarget(target);
+  }
 
-    this.compileError(new Error(`Could not resolve ${JSON.stringify(ref)}`));
-    return "";
+  public resolveTarget(
+    ref: Resolvable | string[],
+    ...rest: string[]
+  ): dataform.ITarget | undefined {
+    ref = toResolvable(ref, rest);
+    const allResolved = this.indexedActions.find(utils.resolvableAsTarget(ref));
+    if (allResolved.length !== 1) {
+      return undefined;
+    }
+    const resolved = allResolved[0];
+    if (resolved instanceof Operation && !resolved.getHasOutput()) {
+      return undefined;
+    }
+    if (resolved instanceof Declaration) {
+      return resolved.getTarget();
+    }
+    const target = resolved.getTarget();
+    return {
+      ...target,
+      database: target.database && this.finalizeDatabase(target.database),
+      schema: this.finalizeSchema(target.schema),
+      name: this.finalizeName(target.name)
+    };
   }
 
   public pushAction(action: Action) {
@@ -557,6 +573,8 @@ export class Session {
 
     this.removeNonUniqueActionsFromCompiledGraph(compiledGraph);
 
+    this.finalizePropertyGraphs();
+
     this.checkTestNameUniqueness(compiledGraph.tests);
 
     this.checkCircularity(
@@ -783,6 +801,14 @@ export class Session {
           .map(action => action as Table | View)
           .forEach(tableOrViewAction => tableOrViewAction.dependencies(utils.resolvableAsTarget(currentTest.getTarget())));
       });
+  }
+
+  private finalizePropertyGraphs() {
+    for (const action of this.actions) {
+      if (action instanceof PropertyGraph) {
+        action.finalize();
+      }
+    }
   }
 
   private removeNonUniqueActionsFromCompiledGraph(compiledGraph: dataform.CompiledGraph) {

--- a/core/utils.ts
+++ b/core/utils.ts
@@ -4,6 +4,7 @@ import { DataPreparation } from "df/core/actions/data_preparation";
 import { IncrementalTable } from "df/core/actions/incremental_table";
 import { Notebook } from "df/core/actions/notebook";
 import { Operation } from "df/core/actions/operation";
+import { PropertyGraph } from "df/core/actions/property_graph";
 import { Table } from "df/core/actions/table";
 import { View } from "df/core/actions/view";
 import { Contextable, Resolvable } from "df/core/contextables";
@@ -20,7 +21,8 @@ type actionsWithDependencies =
   | IncrementalTable
   | Operation
   | Notebook
-  | DataPreparation;
+  | DataPreparation
+  | PropertyGraph;
 
 // This side-steps webpack's require in favour of the real require.
 export const nativeRequire =

--- a/protos/property_graph_config.proto
+++ b/protos/property_graph_config.proto
@@ -15,6 +15,7 @@ message PropertyGraphConfig {
   repeated GraphEntityConfig entities = 4;
   repeated GraphRelationshipConfig relationships = 5;
   bool disabled = 6;
+  bool depend_on_dependency_assertions = 7;
 
   message TargetDataset {
     string project_id = 1;
@@ -103,4 +104,5 @@ message DataSourceRef {
   string name = 1;
   string schema = 2;
   string database = 3;
+  bool include_dependent_assertions = 4;
 }

--- a/tests/integration/BUILD
+++ b/tests/integration/BUILD
@@ -6,12 +6,17 @@ ts_test_suite(
     name = "tests",
     srcs = [
         "bigquery.spec.ts",
+        "property_graph.spec.ts",
         "utils.ts",
     ],
     data = [
         "//test_credentials:bigquery.json",
         "//tests/integration/bigquery_project:files",
         "//tests/integration/bigquery_project:node_modules",
+        "//packages/@dataform/core:bundle.js",
+        "//packages/@dataform/core:package.json",
+        "//tests/integration/property_graph_project:files",
+        "//tests/integration/property_graph_project:node_modules",
     ],
     tags = ["integration"],
     deps = [

--- a/tests/integration/property_graph.spec.ts
+++ b/tests/integration/property_graph.spec.ts
@@ -1,0 +1,83 @@
+import { expect } from "chai";
+import { randomBytes } from "crypto";
+
+import * as dfapi from "df/cli/api";
+import { BigQueryDbAdapter } from "df/cli/api/dbadapters/bigquery";
+import { targetAsReadableString } from "df/core/targets";
+import { dataform } from "df/protos/ts";
+import { suite, test } from "df/testing";
+import { compile, keyBy } from "df/tests/integration/utils";
+
+const PROJECT = "dataform-open-source";
+const GRAPH_NAME = "LibraryGraph";
+
+function makeSuffix() {
+  return (
+    process.env.GITHUB_RUN_ID ??
+    process.env.BUILD_ID ??
+    randomBytes(4).toString("hex")
+  );
+}
+
+async function dropDataset(dbadapter: BigQueryDbAdapter, dataset: string) {
+  await dbadapter.execute(
+    `drop schema if exists \`${PROJECT}.${dataset}\` cascade`
+  );
+}
+
+suite("@dataform/integration/property_graph", { parallel: true }, ({ before, after }) => {
+  const credentials = dfapi.credentials.read("test_credentials/bigquery.json");
+  const schemaSuffix = `e2e_${makeSuffix()}`;
+  const dataset = `df_integration_test_pg_${schemaSuffix}`;
+  const graphTarget = `${dataset}.${GRAPH_NAME}`;
+  let dbadapter: BigQueryDbAdapter;
+
+  before("create adapter", async () => {
+    dbadapter = new BigQueryDbAdapter(credentials);
+  });
+
+  after("drop dataset", async () => {
+    await dropDataset(dbadapter, dataset);
+  });
+
+  test("creates property graph end-to-end", { timeout: 120000 }, async () => {
+    const compiledGraph = await compile(
+      "tests/integration/property_graph_project",
+      schemaSuffix
+    );
+
+    await dropDataset(dbadapter, dataset);
+
+    const executionGraph = await dfapi.build(compiledGraph, {}, dbadapter);
+    const executedGraph = await dfapi.run(dbadapter, executionGraph).result();
+
+    const actionMap = keyBy(executedGraph.actions, v => targetAsReadableString(v.target));
+    expect(Object.keys(actionMap)).to.have.lengthOf(4);
+    for (const [name, action] of Object.entries(actionMap)) {
+      expect(action.status).equals(
+        dataform.ActionResult.ExecutionStatus.SUCCESSFUL,
+        `${name}: ${JSON.stringify(action, null, 2)}`
+      );
+    }
+
+    expect(actionMap).to.have.property(graphTarget);
+
+    const rows = (await dbadapter.execute(
+      `select property_graph_catalog, property_graph_schema,
+              property_graph_name, ddl
+       from \`${PROJECT}.${dataset}\`.INFORMATION_SCHEMA.PROPERTY_GRAPHS`
+    )).rows;
+    expect(rows).to.have.lengthOf(1);
+    const [row] = rows;
+    expect(row.property_graph_catalog).equals(PROJECT);
+    expect(row.property_graph_schema).equals(dataset);
+    expect(row.property_graph_name).equals(GRAPH_NAME);
+    for (const needle of [
+      "NODE TABLES", "EDGE TABLES",
+      "Author", "Book", "Wrote",
+      "authors", "books", "wrote"
+    ]) {
+      expect(row.ddl).to.contain(needle);
+    }
+  });
+});

--- a/tests/integration/property_graph_project/BUILD
+++ b/tests/integration/property_graph_project/BUILD
@@ -1,0 +1,17 @@
+package(default_visibility = ["//tests:__subpackages__"])
+
+load("//tools:node_modules.bzl", "node_modules")
+
+filegroup(
+    name = "files",
+    srcs = glob([
+        "**/*.*",
+    ]),
+)
+
+node_modules(
+    name = "node_modules",
+    deps = [
+        "//packages/@dataform/core:package_tar",
+    ],
+)

--- a/tests/integration/property_graph_project/definitions/authors.sqlx
+++ b/tests/integration/property_graph_project/definitions/authors.sqlx
@@ -1,0 +1,7 @@
+config {
+    type: "table"
+}
+
+select 1 as id, "Alice" as name union all
+select 2 as id, "Bob" as name union all
+select 3 as id, "Carol" as name

--- a/tests/integration/property_graph_project/definitions/books.sqlx
+++ b/tests/integration/property_graph_project/definitions/books.sqlx
@@ -1,0 +1,7 @@
+config {
+    type: "table"
+}
+
+select 1 as id, "Book A" as title union all
+select 2 as id, "Book B" as title union all
+select 3 as id, "Book C" as title

--- a/tests/integration/property_graph_project/definitions/graph.yaml
+++ b/tests/integration/property_graph_project/definitions/graph.yaml
@@ -1,0 +1,31 @@
+name: "LibraryGraph"
+
+entities:
+- name: "Author"
+  ref: "authors"
+  keys: "id"
+  fields:
+  - name: "id"
+    expression: "id"
+  - name: "name"
+    expression: "name"
+
+- name: "Book"
+  ref: "books"
+  keys: "id"
+  fields:
+  - name: "id"
+    expression: "id"
+  - name: "title"
+    expression: "title"
+
+relationships:
+- name: "Wrote"
+  ref: "wrote"
+  keys: ["author_id", "book_id"]
+  source:
+    entity: "Author"
+    join_keys: ["author_id"]
+  destination:
+    entity: "Book"
+    join_keys: ["book_id"]

--- a/tests/integration/property_graph_project/definitions/wrote.sqlx
+++ b/tests/integration/property_graph_project/definitions/wrote.sqlx
@@ -1,0 +1,7 @@
+config {
+    type: "table"
+}
+
+select 1 as author_id, 1 as book_id union all
+select 2 as author_id, 2 as book_id union all
+select 3 as author_id, 3 as book_id

--- a/tests/integration/property_graph_project/workflow_settings.yaml
+++ b/tests/integration/property_graph_project/workflow_settings.yaml
@@ -1,0 +1,1 @@
+defaultDataset: df_integration_test_pg


### PR DESCRIPTION
Cherry-picks the two PropertyGraph PRs merged since #2253. #2258 extends graph.yaml with ref() and DAG dependency support. #2268 wires PropertyGraph into the CLI runtime paths (prune and run) and adds an E2E integration test. Skips the unrelated #2271 vm2 filename fix. Small drive-by rewrites 6 pre-existing chai getter assertions in main_test.ts to function-call form so the pre-push tslint hook accepts the branch.