### PR TITLE
Support extensions on PropertyGraph

### DIFF
--- a/cli/api/execution_sql_test.ts
+++ b/cli/api/execution_sql_test.ts
@@ -164,4 +164,21 @@ EDGE TABLES (
     const expectedSql = fs.readFileSync("cli/api/goldens/property_graph_hrgraph.sql", "utf8");
     expect(sql).to.equal(expectedSql.trim());
   });
+
+  test("emits CREATE OR REPLACE PROPERTY GRAPH with extensions on labels and fields", () => {
+    const graphBody = `NODE TABLES (
+  \`project-id.dataset-id.a\` AS A KEY (id) DEFAULT LABEL OPTIONS(extensions=[("owner", "team-a"), ("tier", "gold")]) PROPERTIES (id, balance OPTIONS(extensions=[("unit", "USD")]))
+)
+EDGE TABLES (
+  \`project-id.dataset-id.a_edge\` AS AtoA SOURCE KEY (src) REFERENCES A (id) DESTINATION KEY (dst) REFERENCES A (id) DEFAULT LABEL OPTIONS(extensions=[("kind", "self_loop")])
+)`;
+    const propertyGraph: dataform.IPropertyGraph = {
+      target: { database: "project-id", schema: "dataset-id", name: "ExtGraph" },
+      graphBody
+    };
+    const tasks = executionSql.createPropertyGraphTasks(propertyGraph);
+    const sql = tasks.map(t => t.statement).join("\n;\n");
+    const expectedSql = fs.readFileSync("cli/api/goldens/property_graph_extensions.sql", "utf8");
+    expect(sql).to.equal(expectedSql.trim());
+  });
 });

--- a/cli/api/goldens/property_graph_extensions.sql
+++ b/cli/api/goldens/property_graph_extensions.sql
@@ -1,0 +1,6 @@
+CREATE OR REPLACE PROPERTY GRAPH `project-id.dataset-id.ExtGraph` NODE TABLES (
+  `project-id.dataset-id.a` AS A KEY (id) DEFAULT LABEL OPTIONS(extensions=[("owner", "team-a"), ("tier", "gold")]) PROPERTIES (id, balance OPTIONS(extensions=[("unit", "USD")]))
+)
+EDGE TABLES (
+  `project-id.dataset-id.a_edge` AS AtoA SOURCE KEY (src) REFERENCES A (id) DESTINATION KEY (dst) REFERENCES A (id) DEFAULT LABEL OPTIONS(extensions=[("kind", "self_loop")])
+)

--- a/core/actions/property_graph.ts
+++ b/core/actions/property_graph.ts
@@ -453,7 +453,8 @@ function buildLabels(
     rootFields.length > 0 ||
     !!rootWildcard ||
     !!config.description ||
-    (config.synonyms && config.synonyms.length > 0);
+    (config.synonyms && config.synonyms.length > 0) ||
+    (config.extensions && config.extensions.length > 0);
   if (!hasRootData) {
     return [];
   }
@@ -461,6 +462,7 @@ function buildLabels(
     name: defaultLabelName,
     description: config.description || undefined,
     synonyms: config.synonyms || [],
+    extensions: config.extensions || [],
     fields: rootFields,
     fieldWildcard: rootWildcard
   });
@@ -488,29 +490,32 @@ function buildLabel(
   const hasWildcard = !!(wildcard && wildcard.importAll);
   const hasDescription = !!label.description;
   const hasSynonyms = !!(label.synonyms && label.synonyms.length > 0);
-  const hasOptions = hasDescription || hasSynonyms;
+  const hasExtensions = !!(label.extensions && label.extensions.length > 0);
+  const hasOptions = hasDescription || hasSynonyms || hasExtensions;
   if (!isDefault && hasOptions) {
     throw new Error(
-      `${where}: label ${labelId} cannot declare 'description' or 'synonyms'; ` +
+      `${where}: label ${labelId} cannot declare 'description', 'synonyms', or 'extensions'; ` +
         `these are only allowed on the DEFAULT label (name absent or 'DEFAULT').`
     );
   }
   if (!hasFields && !hasWildcard && !hasOptions) {
     throw new Error(
       `${where}: label ${labelId} must declare at least one of: 'fields', ` +
-        `'fieldWildcard', 'description', or 'synonyms'.`
+        `'fieldWildcard', 'description', 'synonyms', or 'extensions'.`
     );
   }
   return dataform.GraphLabel.create({
     name: isDefault ? defaultLabelName : label.name,
     description: label.description,
     synonyms: label.synonyms || [],
+    extensions: label.extensions || [],
     fields: (label.fields || []).map(field =>
       dataform.GraphField.create({
         name: field.name,
         expression: field.expression || field.name,
         description: field.description,
-        synonyms: field.synonyms || []
+        synonyms: field.synonyms || [],
+        extensions: field.extensions || []
       })
     ),
     importAll: !!wildcard?.importAll,
@@ -579,7 +584,7 @@ function renderLabelClause(label: dataform.IGraphLabel): string {
   const head = label.isDefault ? "DEFAULT LABEL" : `LABEL ${label.name}`;
   const parts: string[] = [head];
   if (label.isDefault) {
-    const options = renderOptionsClause(label.description, label.synonyms);
+    const options = renderOptionsClause(label.description, label.synonyms, label.extensions);
     if (options) {
       parts.push(options);
     }
@@ -610,13 +615,14 @@ function renderField(field: dataform.IGraphField): string {
     field.expression && field.expression !== field.name
       ? `${field.expression} AS ${field.name}`
       : field.name;
-  const options = renderOptionsClause(field.description, field.synonyms);
+  const options = renderOptionsClause(field.description, field.synonyms, field.extensions);
   return options ? `${expr} ${options}` : expr;
 }
 
 function renderOptionsClause(
   description: string | null | undefined,
-  synonyms: string[] | null | undefined
+  synonyms: string[] | null | undefined,
+  extensions: dataform.IGraphExtension[] | null | undefined
 ): string {
   const parts: string[] = [];
   if (description) {
@@ -624,6 +630,12 @@ function renderOptionsClause(
   }
   if (synonyms && synonyms.length > 0) {
     parts.push(`synonyms=[${synonyms.map(s => JSON.stringify(s)).join(", ")}]`);
+  }
+  if (extensions && extensions.length > 0) {
+    const rendered = extensions
+      .map(ext => `(${JSON.stringify(ext.key || "")}, ${JSON.stringify(ext.value || "")})`)
+      .join(", ");
+    parts.push(`extensions=[${rendered}]`);
   }
   return parts.length > 0 ? `OPTIONS(${parts.join(", ")})` : "";
 }

--- a/core/actions/property_graph_test.ts
+++ b/core/actions/property_graph_test.ts
@@ -1538,7 +1538,6 @@ suite("property_graph", () => {
         {
           name: "AtoB",
           dataSourceString: "p.d.AtoB",
-          keys: ["id"],
           source: { entity: "A", joinKeys: ["a_id"] },
           destination: { entity: "B", joinKeys: ["b_id"] },
           extensions: [{ key: "audit_level", value: "high" }]
@@ -1546,14 +1545,58 @@ suite("property_graph", () => {
       ]
     });
 
-    const graphBody = compiled.graphBody;
-    expect(graphBody).to.contain(
-      `DEFAULT LABEL OPTIONS(extensions=[("audit_level", "high")])`
+    expect(asPlainObject(compiled)).deep.equals(
+      asPlainObject({
+        target: graphTarget("G"),
+        canonicalTarget: graphTarget("G"),
+        fileName: "definitions/graph.yaml",
+        description: "",
+        disabled: false,
+        entities: [
+          {
+            name: "A",
+            dataSource: { database: "p", schema: "d", name: "A" },
+            keys: ["id"]
+          },
+          {
+            name: "B",
+            dataSource: { database: "p", schema: "d", name: "B" },
+            keys: ["id"]
+          }
+        ],
+        relationships: [
+          {
+            name: "AtoB",
+            dataSource: { database: "p", schema: "d", name: "AtoB" },
+            source: {
+              entity: "A",
+              relationshipColumns: ["a_id"],
+              entityColumns: ["id"]
+            },
+            destination: {
+              entity: "B",
+              relationshipColumns: ["b_id"],
+              entityColumns: ["id"]
+            },
+            labels: [
+              {
+                name: "AtoB",
+                description: "",
+                importAll: false,
+                isDefault: true,
+                extensions: [{ key: "audit_level", value: "high" }]
+              }
+            ]
+          }
+        ],
+        graphBody:
+          "NODE TABLES (\n  `p.d.A` AS A KEY (id),\n  `p.d.B` AS B KEY (id)\n)\n" +
+          "EDGE TABLES (\n  `p.d.AtoB` AS AtoB " +
+          "SOURCE KEY (a_id) REFERENCES A (id) " +
+          "DESTINATION KEY (b_id) REFERENCES B (id) " +
+          `DEFAULT LABEL OPTIONS(extensions=[("audit_level", "high")])\n)`
+      })
     );
-    expect(compiled.relationships[0].labels[0].isDefault).to.equal(true);
-    expect(compiled.relationships[0].labels[0].extensions).to.deep.equal([
-      { key: "audit_level", value: "high" }
-    ]);
   });
 
   test("errors when a non-default label declares extensions", () => {
@@ -1595,13 +1638,37 @@ suite("property_graph", () => {
       ]
     });
 
-    expect(compiled.entities[0].labels[0].extensions).to.deep.equal([
-      { key: "tag", value: "first" },
-      { key: "owner", value: "alice" },
-      { key: "tag", value: "second" }
-    ]);
-    expect(compiled.graphBody).to.contain(
-      `extensions=[("tag", "first"), ("owner", "alice"), ("tag", "second")]`
+    expect(asPlainObject(compiled)).deep.equals(
+      asPlainObject({
+        target: graphTarget("G"),
+        canonicalTarget: graphTarget("G"),
+        fileName: "definitions/graph.yaml",
+        description: "",
+        disabled: false,
+        entities: [
+          {
+            name: "A",
+            dataSource: { database: "p", schema: "d", name: "A" },
+            keys: ["id"],
+            labels: [
+              {
+                name: "A",
+                description: "",
+                importAll: false,
+                isDefault: true,
+                extensions: [
+                  { key: "tag", value: "first" },
+                  { key: "owner", value: "alice" },
+                  { key: "tag", value: "second" }
+                ]
+              }
+            ]
+          }
+        ],
+        graphBody:
+          "NODE TABLES (\n  `p.d.A` AS A KEY (id) DEFAULT LABEL " +
+          `OPTIONS(extensions=[("tag", "first"), ("owner", "alice"), ("tag", "second")])\n)`
+      })
     );
   });
 
@@ -1620,9 +1687,35 @@ suite("property_graph", () => {
       ]
     });
 
-    expect(compiled.graphBody).to.contain(
-      `DEFAULT LABEL OPTIONS(description="primary account", synonyms=["BankAccount"], ` +
-        `extensions=[("owner", "core-ledger")])`
+    expect(asPlainObject(compiled)).deep.equals(
+      asPlainObject({
+        target: graphTarget("G"),
+        canonicalTarget: graphTarget("G"),
+        fileName: "definitions/graph.yaml",
+        description: "",
+        disabled: false,
+        entities: [
+          {
+            name: "Account",
+            dataSource: { database: "p", schema: "d", name: "A" },
+            keys: ["id"],
+            labels: [
+              {
+                name: "Account",
+                description: "primary account",
+                synonyms: ["BankAccount"],
+                importAll: false,
+                isDefault: true,
+                extensions: [{ key: "owner", value: "core-ledger" }]
+              }
+            ]
+          }
+        ],
+        graphBody:
+          "NODE TABLES (\n  `p.d.A` AS Account KEY (id) DEFAULT LABEL " +
+          `OPTIONS(description="primary account", synonyms=["BankAccount"], ` +
+          `extensions=[("owner", "core-ledger")])\n)`
+      })
     );
   });
 

--- a/core/actions/property_graph_test.ts
+++ b/core/actions/property_graph_test.ts
@@ -1367,6 +1367,265 @@ suite("property_graph", () => {
     ).to.throw("only one DEFAULT label is allowed");
   });
 
+  test("extensions on DEFAULT label render as OPTIONS(extensions=[...])", () => {
+    const compiled = compile({
+      name: "G",
+      entities: [
+        {
+          name: "Account",
+          dataSourceString: "p.d.A",
+          keys: ["id"],
+          labels: [
+            {
+              name: "DEFAULT",
+              fields: [{ name: "id", expression: "id" }],
+              extensions: [
+                { key: "owner", value: "finance-team" },
+                { key: "retention", value: "7_years" }
+              ]
+            }
+          ]
+        }
+      ]
+    });
+
+    expect(asPlainObject(compiled)).deep.equals(
+      asPlainObject({
+        target: graphTarget("G"),
+        canonicalTarget: graphTarget("G"),
+        fileName: "definitions/graph.yaml",
+        description: "",
+        disabled: false,
+        entities: [
+          {
+            name: "Account",
+            dataSource: { database: "p", schema: "d", name: "A" },
+            keys: ["id"],
+            labels: [
+              {
+                name: "Account",
+                fields: [{ name: "id", expression: "id" }],
+                importAll: false,
+                isDefault: true,
+                extensions: [
+                  { key: "owner", value: "finance-team" },
+                  { key: "retention", value: "7_years" }
+                ]
+              }
+            ]
+          }
+        ],
+        graphBody:
+          "NODE TABLES (\n  `p.d.A` AS Account KEY (id) DEFAULT LABEL " +
+          `OPTIONS(extensions=[("owner", "finance-team"), ("retention", "7_years")]) ` +
+          "PROPERTIES (id)\n)"
+      })
+    );
+  });
+
+  test("extensions on a field render inside the per-field OPTIONS clause", () => {
+    const compiled = compile({
+      name: "G",
+      entities: [
+        {
+          name: "A",
+          dataSourceString: "p.d.A",
+          keys: ["id"],
+          fields: [
+            {
+              name: "balance",
+              expression: "balance",
+              extensions: [
+                { key: "unit", value: "USD" },
+                { key: "source", value: "salesforce" }
+              ]
+            }
+          ]
+        }
+      ]
+    });
+
+    expect(asPlainObject(compiled)).deep.equals(
+      asPlainObject({
+        target: graphTarget("G"),
+        canonicalTarget: graphTarget("G"),
+        fileName: "definitions/graph.yaml",
+        description: "",
+        disabled: false,
+        entities: [
+          {
+            name: "A",
+            dataSource: { database: "p", schema: "d", name: "A" },
+            keys: ["id"],
+            labels: [
+              {
+                name: "A",
+                description: "",
+                fields: [
+                  {
+                    name: "balance",
+                    expression: "balance",
+                    extensions: [
+                      { key: "unit", value: "USD" },
+                      { key: "source", value: "salesforce" }
+                    ]
+                  }
+                ],
+                importAll: false,
+                isDefault: true
+              }
+            ]
+          }
+        ],
+        graphBody:
+          "NODE TABLES (\n  `p.d.A` AS A KEY (id) DEFAULT LABEL PROPERTIES " +
+          `(balance OPTIONS(extensions=[("unit", "USD"), ("source", "salesforce")]))\n)`
+      })
+    );
+  });
+
+  test("root-level extensions on entity fold into the synthesized DEFAULT label", () => {
+    const compiled = compile({
+      name: "G",
+      entities: [
+        {
+          name: "Account",
+          dataSourceString: "p.d.A",
+          keys: ["id"],
+          extensions: [{ key: "tier", value: "gold" }]
+        }
+      ]
+    });
+
+    expect(asPlainObject(compiled)).deep.equals(
+      asPlainObject({
+        target: graphTarget("G"),
+        canonicalTarget: graphTarget("G"),
+        fileName: "definitions/graph.yaml",
+        description: "",
+        disabled: false,
+        entities: [
+          {
+            name: "Account",
+            dataSource: { database: "p", schema: "d", name: "A" },
+            keys: ["id"],
+            labels: [
+              {
+                name: "Account",
+                description: "",
+                importAll: false,
+                isDefault: true,
+                extensions: [{ key: "tier", value: "gold" }]
+              }
+            ]
+          }
+        ],
+        graphBody:
+          "NODE TABLES (\n  `p.d.A` AS Account KEY (id) DEFAULT LABEL " +
+          `OPTIONS(extensions=[("tier", "gold")])\n)`
+      })
+    );
+  });
+
+  test("root-level extensions on relationship fold into the synthesized DEFAULT label", () => {
+    const compiled = compile({
+      name: "G",
+      entities: [
+        { name: "A", dataSourceString: "p.d.A", keys: ["id"] },
+        { name: "B", dataSourceString: "p.d.B", keys: ["id"] }
+      ],
+      relationships: [
+        {
+          name: "AtoB",
+          dataSourceString: "p.d.AtoB",
+          keys: ["id"],
+          source: { entity: "A", joinKeys: ["a_id"] },
+          destination: { entity: "B", joinKeys: ["b_id"] },
+          extensions: [{ key: "audit_level", value: "high" }]
+        }
+      ]
+    });
+
+    const graphBody = compiled.graphBody;
+    expect(graphBody).to.contain(
+      `DEFAULT LABEL OPTIONS(extensions=[("audit_level", "high")])`
+    );
+    expect(compiled.relationships[0].labels[0].isDefault).to.equal(true);
+    expect(compiled.relationships[0].labels[0].extensions).to.deep.equal([
+      { key: "audit_level", value: "high" }
+    ]);
+  });
+
+  test("errors when a non-default label declares extensions", () => {
+    expect(() =>
+      compile({
+        name: "G",
+        entities: [
+          {
+            name: "A",
+            dataSourceString: "p.d.A",
+            keys: ["id"],
+            labels: [
+              {
+                name: "Premium",
+                fields: [{ name: "id", expression: "id" }],
+                extensions: [{ key: "tier", value: "gold" }]
+              }
+            ]
+          }
+        ]
+      })
+    ).to.throw(/label 'Premium' cannot declare 'description', 'synonyms', or 'extensions'/);
+  });
+
+  test("extensions preserve declared order and permit duplicate keys", () => {
+    const compiled = compile({
+      name: "G",
+      entities: [
+        {
+          name: "A",
+          dataSourceString: "p.d.A",
+          keys: ["id"],
+          extensions: [
+            { key: "tag", value: "first" },
+            { key: "owner", value: "alice" },
+            { key: "tag", value: "second" }
+          ]
+        }
+      ]
+    });
+
+    expect(compiled.entities[0].labels[0].extensions).to.deep.equal([
+      { key: "tag", value: "first" },
+      { key: "owner", value: "alice" },
+      { key: "tag", value: "second" }
+    ]);
+    expect(compiled.graphBody).to.contain(
+      `extensions=[("tag", "first"), ("owner", "alice"), ("tag", "second")]`
+    );
+  });
+
+  test("extensions combine with description and synonyms in a single OPTIONS block", () => {
+    const compiled = compile({
+      name: "G",
+      entities: [
+        {
+          name: "Account",
+          dataSourceString: "p.d.A",
+          keys: ["id"],
+          description: "primary account",
+          synonyms: ["BankAccount"],
+          extensions: [{ key: "owner", value: "core-ledger" }]
+        }
+      ]
+    });
+
+    expect(compiled.graphBody).to.contain(
+      `DEFAULT LABEL OPTIONS(description="primary account", synonyms=["BankAccount"], ` +
+        `extensions=[("owner", "core-ledger")])`
+    );
+  });
+
   test("disabled=true propagates onto the compiled PropertyGraph", () => {
     const compiled = compile({
       name: "G",

--- a/protos/core.proto
+++ b/protos/core.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package dataform;
 
 import "extension.proto";
+import "property_graph_config.proto";
 
 import "google/protobuf/struct.proto";
 
@@ -475,6 +476,7 @@ message GraphLabel {
   bool import_all = 5;
   repeated string import_except = 6;
   bool is_default = 7;
+  repeated GraphExtension extensions = 8;
 }
 
 message GraphField {
@@ -482,6 +484,7 @@ message GraphField {
   string expression = 2;
   string description = 3;
   repeated string synonyms = 4;
+  repeated GraphExtension extensions = 5;
 }
 
 message GraphEndpoint {

--- a/protos/property_graph_config.proto
+++ b/protos/property_graph_config.proto
@@ -38,6 +38,7 @@ message GraphEntityConfig {
   repeated GraphFieldConfig fields = 8;
   GraphFieldWildcard field_wildcard = 9;
   repeated GraphLabelConfig labels = 10;
+  repeated GraphExtension extensions = 12;
 }
 
 message GraphRelationshipConfig {
@@ -56,6 +57,7 @@ message GraphRelationshipConfig {
   repeated GraphFieldConfig fields = 10;
   GraphFieldWildcard field_wildcard = 11;
   repeated GraphLabelConfig labels = 12;
+  repeated GraphExtension extensions = 14;
 }
 
 message GraphLabelConfig {
@@ -64,6 +66,7 @@ message GraphLabelConfig {
   repeated string synonyms = 3;
   repeated GraphFieldConfig fields = 4;
   GraphFieldWildcard field_wildcard = 5;
+  repeated GraphExtension extensions = 6;
 }
 
 message GraphFieldConfig {
@@ -71,6 +74,7 @@ message GraphFieldConfig {
   string expression = 2;
   string description = 3;
   repeated string synonyms = 4;
+  repeated GraphExtension extensions = 5;
 }
 
 message GraphFieldWildcard {
@@ -106,4 +110,9 @@ message DataSourceRef {
   string schema = 2;
   string database = 3;
   bool include_dependent_assertions = 4;
+}
+
+message GraphExtension {
+  string key = 1;
+  string value = 2;
 }

--- a/tests/integration/property_graph.spec.ts
+++ b/tests/integration/property_graph.spec.ts
@@ -75,7 +75,10 @@ suite("@dataform/integration/property_graph", { parallel: true }, ({ before, aft
     for (const needle of [
       "NODE TABLES", "EDGE TABLES",
       "Author", "Book", "Wrote",
-      "authors", "books", "wrote"
+      "authors", "books", "wrote",
+      `extensions=[("domain", "library")]`,
+      `extensions=[("pii", "true")]`,
+      `extensions=[("kind", "authorship")]`
     ]) {
       expect(row.ddl).to.contain(needle);
     }

--- a/tests/integration/property_graph_project/definitions/graph.yaml
+++ b/tests/integration/property_graph_project/definitions/graph.yaml
@@ -6,11 +6,17 @@ entities:
 - name: "Author"
   ref: "authors"
   keys: "id"
+  extensions:
+  - key: "domain"
+    value: "library"
   fields:
   - name: "id"
     expression: "id"
   - name: "name"
     expression: "name"
+    extensions:
+    - key: "pii"
+      value: "true"
 
 - name: "Book"
   ref: "books"
@@ -25,6 +31,9 @@ relationships:
 - name: "Wrote"
   ref: "wrote"
   keys: ["author_id", "book_id"]
+  extensions:
+  - key: "kind"
+    value: "authorship"
   source:
     entity: "Author"
     join_keys: ["author_id"]


### PR DESCRIPTION
Add repeated `GraphExtension {key, value}` to the PropertyGraphConfig sub-messages (entity, relationship, label, field) and the compiled counterparts. `renderOptionsClause` emits `extensions=[(k, v), ...]` alongside description and synonyms. Root-level entity and relationship extensions fold into the synthesized DEFAULT label, and non-default labels declaring extensions are rejected (existing DEFAULT-only rule). Covered by property_graph_test, execution_sql_test, a new golden and the integration fixture's INFORMATION_SCHEMA round-trip.