### PR TITLE
Port PropertyGraph tags PR #2275 to dataproc-poc

### DIFF
--- a/cli/api/commands/prune.ts
+++ b/cli/api/commands/prune.ts
@@ -75,7 +75,7 @@ function computeIncludedActionNames(
   // Determine actions selected with --tag option and update applicable actions
   if (hasTagSelector) {
     allActions
-      .filter(action => "tags" in action && action.tags?.some(tag => runConfig.tags.includes(tag)))
+      .filter(action => action.tags?.some(tag => runConfig.tags.includes(tag)))
       .forEach(action => includedActionNames.add(targetAsReadableString(action.target)));
   }
 

--- a/cli/api/commands/prune_test.ts
+++ b/cli/api/commands/prune_test.ts
@@ -32,6 +32,24 @@ const GRAPH_ACTION: dataform.IPropertyGraph = {
   graphBody: "NODE TABLES (`p.d.books` KEY (id))"
 };
 
+const TAGGED_GRAPH_TARGET: dataform.ITarget = { database: "p", schema: "d", name: "NightlyGraph" };
+
+const TAGGED_GRAPH_ACTION: dataform.IPropertyGraph = {
+  target: TAGGED_GRAPH_TARGET,
+  canonicalTarget: TAGGED_GRAPH_TARGET,
+  entities: [
+    {
+      name: "Book",
+      dataSource: TABLE_TARGET,
+      keys: ["id"]
+    }
+  ],
+  relationships: [],
+  dependencyTargets: [TABLE_TARGET],
+  graphBody: "NODE TABLES (`p.d.books` KEY (id))",
+  tags: ["nightly"]
+};
+
 function makeCompiledGraph(): dataform.ICompiledGraph {
   return {
     tables: [TABLE_ACTION],
@@ -107,7 +125,7 @@ suite("prune", () => {
     );
   });
 
-  test("--tags matches tagged tables but never property graphs", () => {
+  test("--tags matches tagged tables and skips untagged property graphs", () => {
     expect(asPlainObject(prune(makeCompiledGraph(), { tags: ["daily"] }))).deep.equals(
       asPlainObject({
         tables: [TABLE_ACTION],
@@ -115,6 +133,25 @@ suite("prune", () => {
         assertions: [],
         propertyGraphs: [],
         targets: [TABLE_TARGET]
+      })
+    );
+  });
+
+  test("--tags matches tagged property graphs", () => {
+    const compiledGraph: dataform.ICompiledGraph = {
+      tables: [TABLE_ACTION],
+      operations: [],
+      assertions: [],
+      propertyGraphs: [GRAPH_ACTION, TAGGED_GRAPH_ACTION],
+      targets: [TABLE_TARGET, GRAPH_TARGET, TAGGED_GRAPH_TARGET]
+    };
+    expect(asPlainObject(prune(compiledGraph, { tags: ["nightly"] }))).deep.equals(
+      asPlainObject({
+        tables: [],
+        operations: [],
+        assertions: [],
+        propertyGraphs: [TAGGED_GRAPH_ACTION],
+        targets: [TAGGED_GRAPH_TARGET]
       })
     );
   });

--- a/core/actions/property_graph.ts
+++ b/core/actions/property_graph.ts
@@ -66,6 +66,9 @@ export class PropertyGraph extends ActionBuilder<dataform.PropertyGraph> {
     if (config.disabled) {
       this.proto.disabled = config.disabled;
     }
+    if (config.tags) {
+      this.proto.tags = config.tags;
+    }
     if (config.dependOnDependencyAssertions) {
       this.dependOnDependencyAssertions = config.dependOnDependencyAssertions;
     }

--- a/core/actions/property_graph_test.ts
+++ b/core/actions/property_graph_test.ts
@@ -64,6 +64,39 @@ suite("property_graph", () => {
     );
   });
 
+  test("propagates tags into the compiled proto", () => {
+    const compiled = compile({
+      name: "Tagged",
+      tags: ["nightly", "reporting"],
+      entities: [
+        {
+          name: "Account",
+          dataSourceString: "proj.ds.Accounts",
+          keys: ["id"]
+        }
+      ]
+    });
+
+    expect(asPlainObject(compiled)).deep.equals(
+      asPlainObject({
+        target: graphTarget("Tagged"),
+        canonicalTarget: graphTarget("Tagged"),
+        fileName: "definitions/graph.yaml",
+        description: "",
+        disabled: false,
+        tags: ["nightly", "reporting"],
+        entities: [
+          {
+            name: "Account",
+            dataSource: { database: "proj", schema: "ds", name: "Accounts" },
+            keys: ["id"]
+          }
+        ],
+        graphBody: "NODE TABLES (\n  `proj.ds.Accounts` AS Account KEY (id)\n)"
+      })
+    );
+  });
+
   test("normalizes scalar keys to a single-element list", () => {
     const compiled = compile({
       name: "G",

--- a/core/main_test.ts
+++ b/core/main_test.ts
@@ -3466,6 +3466,74 @@ entities:
       }));
     });
 
+    test("graph.yaml tags propagate into the compiled proto", () => {
+      const projectDir = tmpDirFixture.createNewTmpDir();
+      fs.writeFileSync(
+        path.join(projectDir, "workflow_settings.yaml"),
+        VALID_WORKFLOW_SETTINGS_YAML
+      );
+      fs.mkdirSync(path.join(projectDir, "definitions"));
+      fs.writeFileSync(
+        path.join(projectDir, "definitions/graph.yaml"),
+        `
+name: TaggedGraph
+tags:
+- nightly
+- reporting
+entities:
+- name: Customer
+  dataSourceString: defaultProject.defaultDataset.customers
+  keys:
+  - id
+`
+      );
+
+      const result = runMainInVm(coreExecutionRequestFromPath(projectDir));
+
+      expect(asPlainObject(result.compile.compiledGraph)).deep.equals(asPlainObject({
+        projectConfig: graphProjectConfig,
+        graphErrors: {},
+        dataformCoreVersion: version,
+        targets: [
+          { schema: "defaultDataset", name: "TaggedGraph", database: "defaultProject" }
+        ],
+        jitData: {},
+        propertyGraphs: [
+          {
+            target: {
+              schema: "defaultDataset",
+              name: "TaggedGraph",
+              database: "defaultProject"
+            },
+            canonicalTarget: {
+              schema: "defaultDataset",
+              name: "TaggedGraph",
+              database: "defaultProject"
+            },
+            fileName: "definitions/graph.yaml",
+            description: "",
+            disabled: false,
+            tags: ["nightly", "reporting"],
+            entities: [
+              {
+                name: "Customer",
+                dataSource: {
+                  schema: "defaultDataset",
+                  name: "customers",
+                  database: "defaultProject"
+                },
+                keys: ["id"]
+              }
+            ],
+            graphBody:
+              "NODE TABLES (\n" +
+              "  `defaultProject.defaultDataset.customers` AS Customer KEY (id)\n" +
+              ")"
+          }
+        ]
+      }));
+    });
+
     test("more than one graph.yaml is rejected", () => {
       const projectDir = tmpDirFixture.createNewTmpDir();
       fs.writeFileSync(

--- a/protos/core.proto
+++ b/protos/core.proto
@@ -462,6 +462,7 @@ message PropertyGraph {
   repeated GraphRelationship relationships = 7;
   string graph_body = 8;
   bool disabled = 9;
+  repeated string tags = 10;
 }
 
 message GraphEntity {

--- a/protos/property_graph_config.proto
+++ b/protos/property_graph_config.proto
@@ -16,6 +16,7 @@ message PropertyGraphConfig {
   repeated GraphRelationshipConfig relationships = 5;
   bool disabled = 6;
   bool depend_on_dependency_assertions = 7;
+  repeated string tags = 8;
 
   message TargetDataset {
     string project_id = 1;

--- a/tests/integration/property_graph_project/definitions/graph.yaml
+++ b/tests/integration/property_graph_project/definitions/graph.yaml
@@ -1,5 +1,7 @@
 name: "LibraryGraph"
 
+tags: ["integration"]
+
 entities:
 - name: "Author"
   ref: "authors"


### PR DESCRIPTION
Cherry-picks #2275 (tags support on PropertyGraph actions) from main into dataproc-poc so the tags field on `PropertyGraph` and `PropertyGraphConfig` reaches Backend once Copybara imports it. No conflicts on the cherry-pick.