### PR TITLE
Preserve explicit includeDependentAssertions=false on PropertyGraph refs

### DIFF
--- a/core/actions/property_graph.ts
+++ b/core/actions/property_graph.ts
@@ -256,7 +256,7 @@ export class PropertyGraph extends ActionBuilder<dataform.PropertyGraph> {
       if (ref.database) {
         rawRef.database = ref.database;
       }
-      if (ref.includeDependentAssertions) {
+      if (ref.hasOwnProperty("includeDependentAssertions")) {
         rawRef.includeDependentAssertions = ref.includeDependentAssertions;
       }
       this.pendingRefs.set(pendingKey, rawRef);

--- a/core/actions/property_graph_test.ts
+++ b/core/actions/property_graph_test.ts
@@ -1521,6 +1521,32 @@ suite("property_graph", () => {
     );
   });
 
+  test("ref-level includeDependentAssertions=false overrides graph-level dependOnDependencyAssertions=true", () => {
+    const compiled = build({
+      name: "G",
+      dependOnDependencyAssertions: true,
+      entities: [
+        { name: "A", ref: { name: "books", includeDependentAssertions: false }, keys: ["id"] },
+        { name: "B", ref: "authors", keys: ["id"] }
+      ]
+    }).compile();
+
+    expect(asPlainObject(compiled)).deep.equals(
+      asPlainObject({
+        target: graphTarget("G"),
+        canonicalTarget: graphTarget("G"),
+        dependencyTargets: [
+          { name: "books", includeDependentAssertions: false },
+          { name: "authors", includeDependentAssertions: true }
+        ],
+        fileName: "definitions/graph.yaml",
+        description: "",
+        disabled: false,
+        entities: [{ name: "A", keys: ["id"] }, { name: "B", keys: ["id"] }]
+      })
+    );
+  });
+
   test("ref on relationship also normalizes and populates dependencyTargets", () => {
     const compiled = build({
       name: "G",


### PR DESCRIPTION
The dataSourceRef branch used a truthy check when copying includeDependentAssertions onto the raw target. A user setting the flag to false was indistinguishable from not setting it, so checkAssertionsForDependency fell back to the graph-level dependOnDependencyAssertions and silently flipped the value to true.

Switch to hasOwnProperty to match configTargetToCompiledGraphTarget in utils.ts. Add a regression test covering the graph-level-true and ref-level-false combination.