### PR TITLE
Fix Session.declare mutating caller-shared configs (#2280)

### DIFF
--- a/core/actions/declaration_test.ts
+++ b/core/actions/declaration_test.ts
@@ -216,6 +216,47 @@ actions:
     );
   });
 
+  suite("shared config", () => {
+    test("declare() does not mutate the caller's config object", () => {
+      const projectDir = tmpDirFixture.createNewTmpDir();
+      fs.writeFileSync(
+        path.join(projectDir, "workflow_settings.yaml"),
+        VALID_WORKFLOW_SETTINGS_YAML
+      );
+      fs.mkdirSync(path.join(projectDir, "definitions"));
+      fs.writeFileSync(
+        path.join(projectDir, "definitions/shared.js"),
+        `
+const src = {
+  database: "defaultProject",
+  schema: "defaultDataset",
+  name: "orders",
+  columns: { id: "Order id", total: "Order total" }
+};
+declare(src);
+
+publish("stg_orders", { type: "view", columns: src.columns })
+  .query(_ => \`SELECT '\${src.database}.\${src.schema}.\${src.name}' AS declared_from\`);
+`
+      );
+
+      const result = runMainInVm(coreExecutionRequestFromPath(projectDir));
+
+      expect(result.compile.compiledGraph.graphErrors.compilationErrors).deep.equals([]);
+
+      const stgOrders = result.compile.compiledGraph.tables.find(
+        t => t.target.name === "stg_orders"
+      );
+      expect(stgOrders.query).equals(
+        "SELECT 'defaultProject.defaultDataset.orders' AS declared_from"
+      );
+      expect(asPlainObject(stgOrders.actionDescriptor.columns)).deep.equals([
+        { path: ["id"], description: "Order id" },
+        { path: ["total"], description: "Order total" }
+      ]);
+    });
+  });
+
   test(`SQLx backward compatible with LegacyConfig`, () => {
     const projectDir = tmpDirFixture.createNewTmpDir();
     fs.writeFileSync(path.join(projectDir, "workflow_settings.yaml"), VALID_WORKFLOW_SETTINGS_YAML);

--- a/core/session.ts
+++ b/core/session.ts
@@ -424,7 +424,13 @@ export class Session {
       // without breaking typescript consumers of Dataform.
       | any
   ): Declaration {
-    const declaration = new Declaration(this, config, utils.getCallerFile(this.rootDir));
+    // Shallow-clone so verifyConfig's in-place renames/deletes don't mutate a caller-shared object,
+    // matching how publish(), operate() and assert() spread their configs.
+    const declaration = new Declaration(
+      this,
+      !!config && typeof config === "object" ? { ...config } : config,
+      utils.getCallerFile(this.rootDir)
+    );
     this.actions.push(declaration);
     return declaration;
   }


### PR DESCRIPTION
Shallow-clone the incoming config in Session.declare so Declaration.verifyConfig's in-place hoists (`database`->`project`, `schema`->`dataset`) and `columns` proto-conversion no longer strip fields from an object the caller still holds. publish(), operate() and assert() already spread their configs at this entry point; declare() was the only sibling passing the caller's object straight through.

Fixes #2280.