### PR TITLE
Bump DF_VERSION from 3.0.68 to 3.0.69

### DIFF
--- a/version.bzl
+++ b/version.bzl
@@ -1,1 +1,1 @@
-DF_VERSION = "3.0.68"
+DF_VERSION = "3.0.69"


### PR DESCRIPTION
Bumps the npm package version to release two shared-config mutation fixes (#2273 View.verifyConfig, #2283 Session.declare — both stop in-place hoists/deletes from stripping fields off a caller-held config) alongside the PropertyGraph improvements from #2275 (tags support) and #2281 (preserve explicit includeDependentAssertions=false).