### PR TITLE
Mark tests that require valid GCP project credentials as integration tests

### DIFF
--- a/cli/BUILD
+++ b/cli/BUILD
@@ -76,14 +76,43 @@ ts_test_suite(
         "index_init_test.ts",
         "index_project_test.ts",
         "index_compile_test.ts",
+        "util_test.ts",
+        "tests/jit/jit_build_test.ts",
+        "tests/jit/jit_run_test.ts",
+    ],
+    data = [
+        ":node_modules",
+        "//packages/@dataform/core:package_tar",
+        "@nodejs//:node",
+        "@nodejs//:npm",
+    ],
+    deps = [
+        ":index_test_base",
+        "//cli",
+        "//cli/api",
+        "//core",
+        "//protos:ts",
+        "//testing",
+        "@npm//@types/chai",
+        "@npm//@types/fs-extra",
+        "@npm//@types/js-yaml",
+        "@npm//@types/long",
+        "@npm//@types/node",
+        "@npm//chai",
+        "@npm//fs-extra",
+        "@npm//js-yaml",
+        "@npm//ts-mockito",
+    ],
+)
+
+ts_test_suite(
+    name = "integration_tests",
+    srcs = [
         "index_run_e2e_test.ts",
         "tests/jit/index_jit_main_test.ts",
         "tests/jit/index_jit_advanced_test.ts",
         "tests/jit/index_jit_dependency_test.ts",
-        "tests/jit/index_jit_runtime_test.ts",
-        "util_test.ts",
-        "tests/jit/jit_build_test.ts",
-        "tests/jit/jit_run_test.ts",
+        "tests/jit/index_jit_runtime_test.ts"
     ],
     data = [
         ":node_modules",
@@ -92,6 +121,7 @@ ts_test_suite(
         "@nodejs//:node",
         "@nodejs//:npm",
     ],
+    tags = ["integration"],
     deps = [
         ":index_test_base",
         "//cli",

--- a/examples/BUILD
+++ b/examples/BUILD
@@ -23,7 +23,6 @@ ts_test_suite(
         ":all_projects",
         ":node_modules",
         "//packages/@dataform/core:package_tar",
-        "//test_credentials:bigquery.json",
         "@nodejs//:node",
     ],
     deps = [


### PR DESCRIPTION
Currently some of the tests run by ./scripts/run_test require connection to an existing GCP project and valid credentials, and will fail if those are not provided. By tagging all such tests as integration, we maintain a cleaner seperation:
- run_tests runs unit tests that do not require any external connections or setup and should pass out of the box
- run_integration_tests runs tests that require users to provide a bigquery.json file to connect to their GCP project

Additionally removes unnecessary dependency "//test_credentials:bigquery.json" from examples, to ensure the test there runs without providing credentials as well.