### PR TITLE
refactor(cli): clean up help command handling and encapsulate yargs configuration

### DIFF
--- a/cli/commands/help_command.ts
+++ b/cli/commands/help_command.ts
@@ -1,13 +1,22 @@
-import { ICommand } from "df/cli/yargswrapper";
+import yargs from "yargs";
 
-// This dummy command is a hack with the only goal of displaying "help" as a command in the CLI
-// and we need it because of the limitations of yargs considering "help" as an option and not as a command.
-export const helpCommand: ICommand = {
-  format: "help [command]",
-  description: "Show help. If [command] is specified, the help is for the given command.",
-  positionalOptions: [],
-  options: [],
-  processFn: async () => {
-    return 0;
-  }
-};
+import { ICommand, setupYargs } from "df/cli/yargswrapper";
+
+export function createHelpCommand(commands: ICommand[]): ICommand {
+  const helpCmd: ICommand = {
+    format: "help [command]",
+    description: "Show help. If [command] is specified, the help is for the given command.",
+    positionalOptions: [],
+    options: [],
+    processFn: async argv => {
+      if (argv.command) {
+        setupYargs([helpCmd, ...commands], [argv.command, "--help"]).parse();
+      } else {
+        yargs.showHelp();
+      }
+      return 0;
+    }
+  };
+  return helpCmd;
+}
+

--- a/cli/commands/index.ts
+++ b/cli/commands/index.ts
@@ -1,6 +1,6 @@
 export { compileCommand } from "df/cli/commands/compile_command";
 export { formatCommand } from "df/cli/commands/format_command";
-export { helpCommand } from "df/cli/commands/help_command";
+export { createHelpCommand } from "df/cli/commands/help_command";
 export { initCommand } from "df/cli/commands/init_command";
 export { initCredsCommand } from "df/cli/commands/init_creds_command";
 export { installCommand } from "df/cli/commands/install_command";

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -1,9 +1,7 @@
-import yargs from "yargs";
-
 import {
   compileCommand,
+  createHelpCommand,
   formatCommand,
-  helpCommand,
   initCommand,
   initCredsCommand,
   installCommand,
@@ -11,45 +9,24 @@ import {
   testCommand
 } from "df/cli/commands";
 import { printError } from "df/cli/console";
-import { createYargsCli } from "df/cli/yargswrapper";
+import { createYargsCli, ICommand } from "df/cli/yargswrapper";
 
 process.on("unhandledRejection", async (reason: any) => {
   printError(`Unhandled promise rejection: ${reason?.stack || reason}`);
 });
 
-// TODO: Since yargs launched an actually well typed API in version 12, let's use it as this file is currently not type checked.
 export function runCli() {
-  const builtYargs = createYargsCli({
-    commands: [
-      helpCommand,
-      initCommand,
-      installCommand,
-      initCredsCommand,
-      compileCommand,
-      testCommand,
-      runCommand,
-      formatCommand
-    ]
-  })
-    .scriptName("dataform")
-    .strict()
-    .wrap(null)
-    .recommendCommands()
-    .fail(async (msg: string, err: any) => {
-      if (!!err && err.name === "VMError" && err.message.includes("Cannot find module")) {
-        printError("Could not find NPM dependencies. Have you run 'dataform install'?");
-      } else {
-        const message = err?.message ? err.message.split("\n")[0] : msg;
-        printError(`Dataform encountered an error: ${message}`);
-        if (err?.stack) {
-          printError(err.stack);
-        }
-      }
-      process.exit(1);
-    }).argv;
+  const commands: ICommand[] = [
+    initCommand,
+    installCommand,
+    initCredsCommand,
+    compileCommand,
+    testCommand,
+    runCommand,
+    formatCommand
+  ];
 
-  // If no command is specified, show top-level help string.
-  if (!builtYargs._[0]) {
-    yargs.showHelp();
-  }
+  createYargsCli({
+    commands: [createHelpCommand(commands), ...commands]
+  });
 }

--- a/cli/yargswrapper.ts
+++ b/cli/yargswrapper.ts
@@ -1,5 +1,7 @@
 import yargs from "yargs";
 
+import { printError } from "df/cli/console";
+
 export interface ICli {
   commands: ICommand[];
 }
@@ -19,8 +21,32 @@ export interface INamedOption<T> {
 }
 
 export function createYargsCli(cli: ICli) {
-  let yargsChain = yargs(fixArgvForHelp());
-  for (const command of cli.commands) {
+  const yargsInstance = setupYargs(cli.commands, process.argv.slice(2))
+    .strict()
+    .recommendCommands()
+    .fail(async (msg: string, err: any) => {
+      if (!!err && err.name === "VMError" && err.message.includes("Cannot find module")) {
+        printError("Could not find NPM dependencies. Have you run 'dataform install'?");
+      } else {
+        const message = err?.message ? err.message.split("\n")[0] : msg;
+        printError(`Dataform encountered an error: ${message}`);
+        if (err?.stack) {
+          printError(err.stack);
+        }
+      }
+      process.exit(1);
+    });
+
+  const parsed = yargsInstance.argv;
+  if (!parsed._[0]) {
+    yargs.showHelp();
+  }
+  return yargsInstance;
+}
+
+export function setupYargs(commands: ICommand[], args: string[]) {
+  let yargsChain = yargs(args).scriptName("dataform").wrap(null);
+  for (const command of commands) {
     yargsChain = yargsChain.command(
       command.format,
       command.description,
@@ -54,19 +80,4 @@ function createOptionsChain(yargsChain: yargs.Argv, command: ICommand) {
     return true;
   });
   return yargsChain;
-}
-
-function fixArgvForHelp() {
-  // Obviously this is a massive hack.
-  // The outcome of this is that the following commands are interchangeable:
-  // $ dataform help run
-  // $ dataform --help run
-  // The problem is that yargs.help() only allows us to specify an alias for the "--help" built-in option (by default that alias is "help").
-  // But because "--help" is only an option, not a command, it appears to be impossible (?) to configure yargs to respond to "help" correctly
-  // (or at least, to correctly print help strings for commands; it happily prints a top-level help string).
-  const argvCopy = process.argv.slice(2);
-  if (argvCopy[0] === "help") {
-    argvCopy[0] = "--help";
-  }
-  return argvCopy;
 }


### PR DESCRIPTION
- Cleaned up `help` command: Removed the `fixArgvForHelp` hack that mutated `process.argv` in-place. The `help` command is now a proper command that cleanly handles both global help (`dataform help`) and command-specific help (`dataform help <command>`).
- Encapsulated CLI setup: Moved general CLI configuration into `cli/yargswrapper.ts`. This simplifies `cli/index.ts` so it only focuses on defining and registering commands.