### PR TITLE
refactor(cli): scope quiet compilation option to compile command

### DIFF
--- a/cli/commands/compile_command.ts
+++ b/cli/commands/compile_command.ts
@@ -5,7 +5,6 @@ import { compile, prune } from "df/cli/api";
 import {
   jsonOutputOption,
   projectDirMustExistOption,
-  quietCompileOption,
   requiresSelection,
   splitCommas,
   timeoutOption
@@ -82,6 +81,15 @@ const dotOutputOption: INamedOption<yargs.Options> = {
 
 const watchOptionName = "watch";
 const verboseOptionName = "verbose";
+
+const quietCompileOption: INamedOption<yargs.Options> = {
+  name: "quiet",
+  option: {
+    describe: "Less verbose compilation output. Example usage: 'dataform compile --quiet'",
+    type: "boolean",
+    default: false
+  }
+};
 
 export const compileCommand: ICommand = {
   format: `compile [${projectDirMustExistOption.name}]`,

--- a/cli/commands/run_command.ts
+++ b/cli/commands/run_command.ts
@@ -12,7 +12,6 @@ import {
   jsonOutputOption,
   projectDirMustExistOption,
   projectDirOption,
-  quietCompileOption,
   requiresSelection,
   splitCommas,
   timeoutOption
@@ -232,7 +231,7 @@ export const runCommand: ICommand = {
       timeoutMillis: argv[timeoutOption.name] || undefined
     });
     if (compiledGraphHasErrors(compiledGraph)) {
-      printCompiledGraphErrors(compiledGraph.graphErrors, argv[quietCompileOption.name]);
+      printCompiledGraphErrors(compiledGraph.graphErrors);
       return 1;
     }
     logger.success("Compiled successfully.\n");

--- a/cli/commands/test_command.ts
+++ b/cli/commands/test_command.ts
@@ -6,7 +6,6 @@ import {
   jsonOutputOption,
   projectDirMustExistOption,
   projectDirOption,
-  quietCompileOption,
   timeoutOption
 } from "df/cli/common_options";
 import {
@@ -40,7 +39,7 @@ export const testCommand: ICommand = {
       timeoutMillis: argv[timeoutOption.name] || undefined
     });
     if (compiledGraphHasErrors(compiledGraph)) {
-      printCompiledGraphErrors(compiledGraph.graphErrors, argv[quietCompileOption.name]);
+      printCompiledGraphErrors(compiledGraph.graphErrors);
       return 1;
     }
     if (!argv[jsonOutputOption.name]) {

--- a/cli/common_options.ts
+++ b/cli/common_options.ts
@@ -81,15 +81,6 @@ export const timeoutOption: INamedOption<yargs.Options> = {
   }
 };
 
-export const quietCompileOption: INamedOption<yargs.Options> = {
-  name: "quiet",
-  option: {
-    describe: "Less verbose compilation output. Example usage: 'dataform compile --quiet'",
-    type: "boolean",
-    default: false
-  }
-};
-
 // It would be nice to use yargs' "implies" to implement this, but it doesn't work for some reason.
 export const requiresSelection = (
   name: string,

--- a/cli/console.ts
+++ b/cli/console.ts
@@ -207,7 +207,11 @@ export enum compiledGraphOutputType {
   Summary = "summary"
 }
 
-export function printCompiledGraph(graph: dataform.ICompiledGraph, outputType: compiledGraphOutputType, quietCompilation: boolean) {
+export function printCompiledGraph(
+  graph: dataform.ICompiledGraph,
+  outputType: compiledGraphOutputType,
+  quietCompilation: boolean = false
+) {
   
   const interactive = isInteractive();
   
@@ -284,7 +288,10 @@ function formatStackTraceForQuietCompilation(compileError: dataform.ICompilation
   return "";
 }
 
-export function printCompiledGraphErrors(graphErrors: dataform.IGraphErrors, quietCompilation: boolean) {
+export function printCompiledGraphErrors(
+  graphErrors: dataform.IGraphErrors,
+  quietCompilation: boolean = false
+) {
   if (graphErrors.compilationErrors && graphErrors.compilationErrors.length > 0) {
     printError("Compilation errors:", 1);
     graphErrors.compilationErrors.forEach(compileError => {


### PR DESCRIPTION
- Scope `--quiet` to `compile`: Defined `quietCompileOption` locally inside `compile_command.ts` and removed it from `common_options.ts`.
- Clean up `run` and `test`: Removed references to `quietCompileOption` from `run_command.ts` and `test_command.ts` where the flag was never registered as a CLI option.
- Default parameter in console helpers: Added default `quietCompilation: boolean = false` to `printCompiledGraph` and `printCompiledGraphErrors` in `console.ts`, allowing callers outside `compile` to omit the argument.