### PR TITLE
build(bazel): update Go modules versions and speed up local run script

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -20,18 +20,18 @@ bazel_dep(name = "gazelle", version = "0.37.0", repo_name = "bazel_gazelle")
 go_deps = use_extension("@bazel_gazelle//:extensions.bzl", "go_deps")
 go_deps.module(
     path = "google.golang.org/grpc",
-    sum = "h1:rRYRFMVgRv6E0D70Skyfsr28tDXIuuPZyWGMPdMcnXg=",
-    version = "v1.27.0",
+    sum = "h1:pnP7OclFFFgFi4VHQDQDaoXUVauOFyktqTsqqgzFKbc=",
+    version = "v1.40.1",
 )
 go_deps.module(
     path = "golang.org/x/net",
-    sum = "h1:2mqDk8w/o6UmeUCu5Qiq2y7iMf6anbx+YA8d1JFoFrs=",
-    version = "v0.0.0-20191002035440-2ec189313ef0",
+    sum = "h1:mIYleuAkSbHh0tCv7RvjL3F6ZVbLjq4+R7zbOn3Kokg=",
+    version = "v0.18.0",
 )
 go_deps.module(
     path = "golang.org/x/text",
-    sum = "h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=",
-    version = "v0.3.2",
+    sum = "h1:ScX5w1eTa3QqT8oi6+ziP7dTV1S2+ALU0bI+0zXKWiQ=",
+    version = "v0.14.0",
 )
 use_repo(
     go_deps,

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -15,6 +15,7 @@ process.on("unhandledRejection", async (reason: any) => {
   printError(`Unhandled promise rejection: ${reason?.stack || reason}`);
 });
 
+// TODO: Since yargs launched an actually well typed API in version 12, let's use it as this file is currently not type checked.
 export function runCli() {
   const commands: ICommand[] = [
     initCommand,

--- a/scripts/run
+++ b/scripts/run
@@ -2,4 +2,4 @@
 set -e
 
 bazel build //packages/@dataform/cli:bin
-./bazel-bin/packages/@dataform/cli/bin.sh "$@"
+./bazel-bin/packages/@dataform/cli/bin.sh --nobazel_run_linker "$@"


### PR DESCRIPTION
- **Update Go modules versions (`MODULE.bazel`)**: Updated `grpc`, `x/net`, and `x/text` Go module versions to match resolved dependencies, eliminating Gazelle `DEBUG` mismatch warnings during Bazel builds.
- **Speed up local run script (`scripts/run`)**: Added the `--nobazel_run_linker` flag to bypass redundant `node_modules` symlinking and significantly reduce local CLI startup latency.