### PR TITLE
fix: cli compile time increased by ~4x

### DIFF
--- a/common/protos/BUILD
+++ b/common/protos/BUILD
@@ -35,7 +35,6 @@ ts_test_suite(
         "@npm//@types/chai",
         "@npm//@types/node",
         "@npm//chai",
-        "@npm//protobufjs",
     ],
 )
 

--- a/common/protos/BUILD
+++ b/common/protos/BUILD
@@ -13,6 +13,7 @@ ts_library(
         "//:modules-fix",
         "//common/strings",
         "//protos:ts",
+        "@npm//@types/node",
         "@npm//protobufjs",
     ],
 )
@@ -34,6 +35,7 @@ ts_test_suite(
         "@npm//@types/chai",
         "@npm//@types/node",
         "@npm//chai",
+        "@npm//protobufjs",
     ],
 )
 

--- a/common/protos/index.ts
+++ b/common/protos/index.ts
@@ -1,10 +1,63 @@
-import { util } from "protobufjs";
+import { configure, util } from "protobufjs";
 
 import { google } from "df/protos/ts";
 
 const CONFIGS_PROTO_DOCUMENTATION_URL =
   "https://dataform-co.github.io/dataform/docs/configs-reference";
 const REPORT_ISSUE_URL = "https://github.com/dataform-co/dataform/issues";
+
+/**
+ * Whether `candidate` is a `Buffer` class belonging to a realm other than this one.
+ *
+ * A `Buffer` from another realm does not share this realm's `Uint8Array`, so its prototype fails
+ * an `instanceof` check against it.
+ */
+export function isForeignBuffer(candidate: any): boolean {
+  try {
+    if (!candidate?.prototype) {
+      return false;
+    }
+    return !(candidate.prototype instanceof Uint8Array);
+  } catch (e) {
+    // A `Buffer` we cannot even introspect is certainly not one of ours.
+    return true;
+  }
+}
+
+/**
+ * Makes protobufjs encode into plain `Uint8Array`s rather than `Buffer`s when `bufferClass` does
+ * not belong to this realm.
+ *
+ * protobufjs decides once, at load time, whether to encode into a Node `Buffer` or a plain
+ * `Uint8Array`, by looking at `global.Buffer`. Since protobufjs 7.6.0 that lookup reads the global
+ * directly rather than going through `require("buffer")`, which changes the answer inside the vm2
+ * sandbox that the CLI runs Dataform Core in: `require("buffer")` is blocked there, but
+ * `global.Buffer` resolves to the *host* class, reachable through vm2's membrane.
+ *
+ * Encoding through that membrane is pathologically slow. Every `Buffer.allocUnsafe`,
+ * `Buffer.byteLength` and `buf.utf8Write` call crosses the sandbox boundary, and the buffer that
+ * comes back is a proxy whose elements are then read one bridged access at a time. Encoding a
+ * graph with ~39k documented columns took ~2.9s that way, against ~80ms when staying inside the
+ * sandbox.
+ *
+ * A `Uint8Array` allocated inside the sandbox never crosses the boundary at all. The encoded bytes
+ * are identical either way; only the container type differs. Outside a sandbox this is a no-op, so
+ * the host keeps protobufjs's native `Buffer` fast paths.
+ *
+ * See https://github.com/dataform-co/dataform/issues/2298.
+ *
+ * @returns whether protobufjs was reconfigured.
+ */
+export function avoidForeignBufferEncoding(bufferClass: any): boolean {
+  if (!isForeignBuffer(bufferClass)) {
+    return false;
+  }
+  (util as any).Buffer = null;
+  configure();
+  return true;
+}
+
+avoidForeignBufferEncoding(typeof global === "undefined" ? undefined : (global as any).Buffer);
 
 export interface IProtoClass<IProto, Proto> {
   new (): Proto;


### PR DESCRIPTION
Fixes: https://github.com/dataform-co/dataform/issues/2298

AI model used : Claude Opus 5 (high)

AI model was used to find the root cause of the issue and fix. I found this issue myself when I switched to Dataform Core 3.0.69.  I have tested fix on my machine with real Dataform project.

<img width="2086" height="502" alt="CleanShot 2026-09-11 at 08 42 57@2x" src="https://github.com/user-attachments/assets/a8ad3b6e-6f43-479e-888e-1b19faeecb6c" />
