### PR TITLE
refactor(cli): strongly type yargs commands

### DIFF
--- a/cli/BUILD
+++ b/cli/BUILD
@@ -10,6 +10,7 @@ ts_library(
     name = "cli",
     srcs = [
         "commands/compile_command.ts",
+        "commands/compile_options.ts",
         "commands/format_command.ts",
         "commands/help_command.ts",
         "commands/index.ts",
@@ -17,6 +18,7 @@ ts_library(
         "commands/init_creds_command.ts",
         "commands/install_command.ts",
         "commands/run_command.ts",
+        "commands/run_options.ts",
         "commands/test_command.ts",
         "common_options.ts",
         "console.ts",

--- a/cli/commands/compile_command.ts
+++ b/cli/commands/compile_command.ts
@@ -4,6 +4,9 @@ import yargs from "yargs";
 import { compile, prune } from "df/cli/api";
 import {
   assertProjectDirExists,
+  IJsonOutputArgs,
+  IProjectDirArgs,
+  ITimeoutArgs,
   jsonOutputOption,
   projectDirOption,
   requiresSelection,
@@ -18,16 +21,31 @@ import {
   printCompiledGraphErrors,
   printError
 } from "df/cli/console";
-import { ProjectConfigOptions } from "df/cli/project_config_options";
+import { IProjectConfigArgs, ProjectConfigOptions } from "df/cli/project_config_options";
 import { compiledGraphHasErrors } from "df/cli/util";
 import { ICommand, INamedOption } from "df/cli/yargswrapper";
 
 const RECOMPILE_DELAY = 500;
 
+export interface ICompileArgs
+  extends IProjectDirArgs,
+    IProjectConfigArgs,
+    IJsonOutputArgs,
+    ITimeoutArgs {
+  watch: boolean;
+  dot: boolean;
+  quiet: boolean;
+  outputActions?: string[];
+  outputTags?: string[];
+  outputIncludeDeps?: boolean;
+  outputIncludeDependents?: boolean;
+  verbose: boolean;
+}
+
 // `compile` reuses the same prune() filtering as run/build, but these flags only
 // filter the *printed output* -- the whole project still compiles. The `output-`
 // prefix makes that distinction explicit.
-const outputActionsOption: INamedOption<yargs.Options> = {
+const outputActionsOption: INamedOption<yargs.Options, ICompileArgs> = {
   name: "output-actions",
   option: {
     // No wildcard support: prune()'s matchPatterns() does exact matching on the
@@ -38,7 +56,7 @@ const outputActionsOption: INamedOption<yargs.Options> = {
   }
 };
 
-const outputTagsOption: INamedOption<yargs.Options> = {
+const outputTagsOption: INamedOption<yargs.Options, ICompileArgs> = {
   name: "output-tags",
   option: {
     describe: "A list of tags to filter the compiled output to.",
@@ -47,7 +65,7 @@ const outputTagsOption: INamedOption<yargs.Options> = {
   }
 };
 
-const outputIncludeDepsOption: INamedOption<yargs.Options> = {
+const outputIncludeDepsOption: INamedOption<yargs.Options, ICompileArgs> = {
   name: "output-include-deps",
   option: {
     describe: "If set, dependencies of the selected actions are also included in the output.",
@@ -56,7 +74,7 @@ const outputIncludeDepsOption: INamedOption<yargs.Options> = {
   check: requiresSelection("output-include-deps", outputActionsOption, outputTagsOption)
 };
 
-const outputIncludeDependentsOption: INamedOption<yargs.Options> = {
+const outputIncludeDependentsOption: INamedOption<yargs.Options, ICompileArgs> = {
   name: "output-include-dependents",
   option: {
     describe:
@@ -66,24 +84,21 @@ const outputIncludeDependentsOption: INamedOption<yargs.Options> = {
   check: requiresSelection("output-include-dependents", outputActionsOption, outputTagsOption)
 };
 
-const dotOutputOption: INamedOption<yargs.Options> = {
+const dotOutputOption: INamedOption<yargs.Options, ICompileArgs> = {
   name: "dot",
   option: {
     describe: "Outputs a dot representation of the compiled project.",
     type: "boolean",
     default: false
   },
-  check: (argv: yargs.Arguments<any>) => {
+  check: (argv: yargs.Arguments<ICompileArgs>) => {
     if (argv.json && argv.dot) {
       throw new Error("Arguments --json and --dot are mutually exclusive.");
     }
   }
 };
 
-const watchOptionName = "watch";
-const verboseOptionName = "verbose";
-
-const quietCompileOption: INamedOption<yargs.Options> = {
+const quietCompileOption: INamedOption<yargs.Options, ICompileArgs> = {
   name: "quiet",
   option: {
     describe: "Less verbose compilation output. Example usage: 'dataform compile --quiet'",
@@ -92,14 +107,14 @@ const quietCompileOption: INamedOption<yargs.Options> = {
   }
 };
 
-export const compileCommand: ICommand = {
+export const compileCommand: ICommand<ICompileArgs> = {
   format: `compile [${projectDirOption.name}]`,
   description:
     "Compile the dataform project. Produces JSON output describing the non-executable graph.",
   positionalOptions: [projectDirOption],
   options: [
     {
-      name: watchOptionName,
+      name: "watch",
       option: {
         describe: "Whether to watch the changes in the project directory.",
         type: "boolean",
@@ -115,13 +130,13 @@ export const compileCommand: ICommand = {
     outputIncludeDepsOption,
     outputIncludeDependentsOption,
     {
-      name: verboseOptionName,
+      name: "verbose",
       option: {
         describe: "Enable verbose compilation output. Example usage: 'dataform compile --verbose'",
         type: "boolean",
         default: false
       },
-      check: (argv: yargs.Arguments) => {
+      check: (argv: yargs.Arguments<ICompileArgs>) => {
         if (argv.quiet && argv.verbose) {
           throw new Error("Arguments --verbose and --quiet are mutually exclusive.");
         }
@@ -131,14 +146,14 @@ export const compileCommand: ICommand = {
   ],
   check: [assertProjectDirExists],
   processFn: async argv => {
-    const projectDir = argv[projectDirOption.name];
-    const logger = new Logger(!argv[jsonOutputOption.name]);
+    const projectDir = argv.projectDir;
+    const logger = new Logger(!argv.json);
 
     async function compileAndPrint() {
       let outputType = compiledGraphOutputType.Summary;
-      if (argv[jsonOutputOption.name]) {
+      if (argv.json) {
         outputType = compiledGraphOutputType.Json;
-      } else if (argv[dotOutputOption.name]) {
+      } else if (argv.dot) {
         outputType = compiledGraphOutputType.Dot;
       }
 
@@ -148,8 +163,8 @@ export const compileCommand: ICommand = {
       const compiledGraph = await compile({
         projectDir,
         projectConfigOverride: ProjectConfigOptions.constructProjectConfigOverride(argv),
-        timeoutMillis: argv[timeoutOption.name] || undefined,
-        verbose: argv[verboseOptionName] || false
+        timeoutMillis: argv.timeout || undefined,
+        verbose: argv.verbose || false
       });
 
       // The whole project must compile (ref() resolution needs every action
@@ -158,20 +173,20 @@ export const compileCommand: ICommand = {
       // a clean graph; if compilation produced errors we print the full graph
       // plus the errors, keeping graph-level errors as-is.
       const hasSelector =
-        argv[outputActionsOption.name]?.length > 0 || argv[outputTagsOption.name]?.length > 0;
+        (argv.outputActions?.length ?? 0) > 0 || (argv.outputTags?.length ?? 0) > 0;
       const outputGraph =
         hasSelector && !compiledGraphHasErrors(compiledGraph)
           ? prune(compiledGraph, {
-              actions: argv[outputActionsOption.name],
-              tags: argv[outputTagsOption.name],
-              includeDependencies: argv[outputIncludeDepsOption.name],
-              includeDependents: argv[outputIncludeDependentsOption.name]
+              actions: argv.outputActions,
+              tags: argv.outputTags,
+              includeDependencies: argv.outputIncludeDeps,
+              includeDependents: argv.outputIncludeDependents
             })
           : compiledGraph;
-      printCompiledGraph(outputGraph, outputType, argv[quietCompileOption.name]);
+      printCompiledGraph(outputGraph, outputType, argv.quiet);
       if (compiledGraphHasErrors(compiledGraph)) {
         print("");
-        printCompiledGraphErrors(compiledGraph.graphErrors, argv[quietCompileOption.name]);
+        printCompiledGraphErrors(compiledGraph.graphErrors, argv.quiet);
         return true;
       }
       return false;
@@ -179,7 +194,7 @@ export const compileCommand: ICommand = {
 
     const graphHasErrors = await compileAndPrint();
 
-    if (!argv[watchOptionName]) {
+    if (!argv.watch) {
       return graphHasErrors ? 1 : 0;
     }
 

--- a/cli/commands/compile_command.ts
+++ b/cli/commands/compile_command.ts
@@ -107,20 +107,37 @@ const quietCompileOption: INamedOption<yargs.Options, ICompileArgs> = {
   }
 };
 
+const watchOption: INamedOption<yargs.Options, ICompileArgs> = {
+  name: "watch",
+  option: {
+    describe: "Whether to watch the changes in the project directory.",
+    type: "boolean",
+    default: false
+  }
+};
+
+const verboseOption: INamedOption<yargs.Options, ICompileArgs> = {
+  name: "verbose",
+  option: {
+    describe: "Enable verbose compilation output. Example usage: 'dataform compile --verbose'",
+    type: "boolean",
+    default: false
+  },
+  check: (argv: yargs.Arguments<ICompileArgs>) => {
+    if (argv.quiet && argv.verbose) {
+      throw new Error("Arguments --verbose and --quiet are mutually exclusive.");
+    }
+  }
+};
+
 export const compileCommand: ICommand<ICompileArgs> = {
   format: `compile [${projectDirOption.name}]`,
   description:
     "Compile the dataform project. Produces JSON output describing the non-executable graph.",
   positionalOptions: [projectDirOption],
   options: [
-    {
-      name: "watch",
-      option: {
-        describe: "Whether to watch the changes in the project directory.",
-        type: "boolean",
-        default: false
-      }
-    },
+    watchOption,
+    verboseOption,
     jsonOutputOption,
     dotOutputOption,
     timeoutOption,
@@ -129,19 +146,6 @@ export const compileCommand: ICommand<ICompileArgs> = {
     outputTagsOption,
     outputIncludeDepsOption,
     outputIncludeDependentsOption,
-    {
-      name: "verbose",
-      option: {
-        describe: "Enable verbose compilation output. Example usage: 'dataform compile --verbose'",
-        type: "boolean",
-        default: false
-      },
-      check: (argv: yargs.Arguments<ICompileArgs>) => {
-        if (argv.quiet && argv.verbose) {
-          throw new Error("Arguments --verbose and --quiet are mutually exclusive.");
-        }
-      }
-    },
     ...ProjectConfigOptions.allYargsOptions
   ],
   check: [assertProjectDirExists],

--- a/cli/commands/compile_command.ts
+++ b/cli/commands/compile_command.ts
@@ -3,8 +3,9 @@ import yargs from "yargs";
 
 import { compile, prune } from "df/cli/api";
 import {
+  assertProjectDirExists,
   jsonOutputOption,
-  projectDirMustExistOption,
+  projectDirOption,
   requiresSelection,
   splitCommas,
   timeoutOption
@@ -92,10 +93,10 @@ const quietCompileOption: INamedOption<yargs.Options> = {
 };
 
 export const compileCommand: ICommand = {
-  format: `compile [${projectDirMustExistOption.name}]`,
+  format: `compile [${projectDirOption.name}]`,
   description:
     "Compile the dataform project. Produces JSON output describing the non-executable graph.",
-  positionalOptions: [projectDirMustExistOption],
+  positionalOptions: [projectDirOption],
   options: [
     {
       name: watchOptionName,
@@ -128,8 +129,9 @@ export const compileCommand: ICommand = {
     },
     ...ProjectConfigOptions.allYargsOptions
   ],
+  check: [assertProjectDirExists],
   processFn: async argv => {
-    const projectDir = argv[projectDirMustExistOption.name];
+    const projectDir = argv[projectDirOption.name];
     const logger = new Logger(!argv[jsonOutputOption.name]);
 
     async function compileAndPrint() {

--- a/cli/commands/compile_command.ts
+++ b/cli/commands/compile_command.ts
@@ -1,18 +1,8 @@
 import * as chokidar from "chokidar";
-import yargs from "yargs";
 
 import { compile, prune } from "df/cli/api";
-import {
-  assertProjectDirExists,
-  IJsonOutputArgs,
-  IProjectDirArgs,
-  ITimeoutArgs,
-  jsonOutputOption,
-  projectDirOption,
-  requiresSelection,
-  splitCommas,
-  timeoutOption
-} from "df/cli/common_options";
+import { compileOptions, ICompileArgs } from "df/cli/commands/compile_options";
+import { assertProjectDirExists, projectDirOption } from "df/cli/common_options";
 import {
   compiledGraphOutputType,
   Logger,
@@ -21,133 +11,18 @@ import {
   printCompiledGraphErrors,
   printError
 } from "df/cli/console";
-import { IProjectConfigArgs, ProjectConfigOptions } from "df/cli/project_config_options";
+import { ProjectConfigOptions } from "df/cli/project_config_options";
 import { compiledGraphHasErrors } from "df/cli/util";
-import { ICommand, INamedOption } from "df/cli/yargswrapper";
+import { ICommand } from "df/cli/yargswrapper";
 
 const RECOMPILE_DELAY = 500;
-
-export interface ICompileArgs
-  extends IProjectDirArgs,
-    IProjectConfigArgs,
-    IJsonOutputArgs,
-    ITimeoutArgs {
-  watch: boolean;
-  dot: boolean;
-  quiet: boolean;
-  outputActions?: string[];
-  outputTags?: string[];
-  outputIncludeDeps?: boolean;
-  outputIncludeDependents?: boolean;
-  verbose: boolean;
-}
-
-// `compile` reuses the same prune() filtering as run/build, but these flags only
-// filter the *printed output* -- the whole project still compiles. The `output-`
-// prefix makes that distinction explicit.
-const outputActionsOption: INamedOption<yargs.Options, ICompileArgs> = {
-  name: "output-actions",
-  option: {
-    // No wildcard support: prune()'s matchPatterns() does exact matching on the
-    // action name or its fully-qualified `database.schema.name`.
-    describe: "A list of action names to filter the compiled output to.",
-    type: "array",
-    coerce: splitCommas
-  }
-};
-
-const outputTagsOption: INamedOption<yargs.Options, ICompileArgs> = {
-  name: "output-tags",
-  option: {
-    describe: "A list of tags to filter the compiled output to.",
-    type: "array",
-    coerce: splitCommas
-  }
-};
-
-const outputIncludeDepsOption: INamedOption<yargs.Options, ICompileArgs> = {
-  name: "output-include-deps",
-  option: {
-    describe: "If set, dependencies of the selected actions are also included in the output.",
-    type: "boolean"
-  },
-  check: requiresSelection("output-include-deps", outputActionsOption, outputTagsOption)
-};
-
-const outputIncludeDependentsOption: INamedOption<yargs.Options, ICompileArgs> = {
-  name: "output-include-dependents",
-  option: {
-    describe:
-      "If set, dependents (downstream) of the selected actions are also included in the output.",
-    type: "boolean"
-  },
-  check: requiresSelection("output-include-dependents", outputActionsOption, outputTagsOption)
-};
-
-const dotOutputOption: INamedOption<yargs.Options, ICompileArgs> = {
-  name: "dot",
-  option: {
-    describe: "Outputs a dot representation of the compiled project.",
-    type: "boolean",
-    default: false
-  },
-  check: (argv: yargs.Arguments<ICompileArgs>) => {
-    if (argv.json && argv.dot) {
-      throw new Error("Arguments --json and --dot are mutually exclusive.");
-    }
-  }
-};
-
-const quietCompileOption: INamedOption<yargs.Options, ICompileArgs> = {
-  name: "quiet",
-  option: {
-    describe: "Less verbose compilation output. Example usage: 'dataform compile --quiet'",
-    type: "boolean",
-    default: false
-  }
-};
-
-const watchOption: INamedOption<yargs.Options, ICompileArgs> = {
-  name: "watch",
-  option: {
-    describe: "Whether to watch the changes in the project directory.",
-    type: "boolean",
-    default: false
-  }
-};
-
-const verboseOption: INamedOption<yargs.Options, ICompileArgs> = {
-  name: "verbose",
-  option: {
-    describe: "Enable verbose compilation output. Example usage: 'dataform compile --verbose'",
-    type: "boolean",
-    default: false
-  },
-  check: (argv: yargs.Arguments<ICompileArgs>) => {
-    if (argv.quiet && argv.verbose) {
-      throw new Error("Arguments --verbose and --quiet are mutually exclusive.");
-    }
-  }
-};
 
 export const compileCommand: ICommand<ICompileArgs> = {
   format: `compile [${projectDirOption.name}]`,
   description:
     "Compile the dataform project. Produces JSON output describing the non-executable graph.",
   positionalOptions: [projectDirOption],
-  options: [
-    watchOption,
-    verboseOption,
-    jsonOutputOption,
-    dotOutputOption,
-    timeoutOption,
-    quietCompileOption,
-    outputActionsOption,
-    outputTagsOption,
-    outputIncludeDepsOption,
-    outputIncludeDependentsOption,
-    ...ProjectConfigOptions.allYargsOptions
-  ],
+  options: compileOptions,
   check: [assertProjectDirExists],
   processFn: async argv => {
     const projectDir = argv.projectDir;

--- a/cli/commands/compile_command.ts
+++ b/cli/commands/compile_command.ts
@@ -130,5 +130,6 @@ export const compileCommand: ICommand<ICompileArgs> = {
     while (watching) {
       await new Promise((resolve, reject) => setTimeout(() => resolve(), 100));
     }
+    return 0;
   }
 };

--- a/cli/commands/compile_options.ts
+++ b/cli/commands/compile_options.ts
@@ -1,0 +1,130 @@
+import yargs from "yargs";
+
+import {
+  IJsonOutputArgs,
+  IProjectDirArgs,
+  ITimeoutArgs,
+  jsonOutputOption,
+  requiresSelection,
+  splitCommas,
+  timeoutOption
+} from "df/cli/common_options";
+import { IProjectConfigArgs, ProjectConfigOptions } from "df/cli/project_config_options";
+import { INamedOption } from "df/cli/yargswrapper";
+
+export interface ICompileArgs
+  extends IProjectDirArgs,
+    IProjectConfigArgs,
+    IJsonOutputArgs,
+    ITimeoutArgs {
+  watch: boolean;
+  dot: boolean;
+  quiet: boolean;
+  outputActions?: string[];
+  outputTags?: string[];
+  outputIncludeDeps?: boolean;
+  outputIncludeDependents?: boolean;
+  verbose: boolean;
+}
+
+// `compile` reuses the same prune() filtering as run/build, but these flags only
+// filter the *printed output* -- the whole project still compiles. The `output-`
+// prefix makes that distinction explicit.
+export const outputActionsOption: INamedOption<yargs.Options, ICompileArgs> = {
+  name: "output-actions",
+  option: {
+    // No wildcard support: prune()'s matchPatterns() does exact matching on the
+    // action name or its fully-qualified `database.schema.name`.
+    describe: "A list of action names to filter the compiled output to.",
+    type: "array",
+    coerce: splitCommas
+  }
+};
+
+export const outputTagsOption: INamedOption<yargs.Options, ICompileArgs> = {
+  name: "output-tags",
+  option: {
+    describe: "A list of tags to filter the compiled output to.",
+    type: "array",
+    coerce: splitCommas
+  }
+};
+
+export const outputIncludeDepsOption: INamedOption<yargs.Options, ICompileArgs> = {
+  name: "output-include-deps",
+  option: {
+    describe: "If set, dependencies of the selected actions are also included in the output.",
+    type: "boolean"
+  },
+  check: requiresSelection("output-include-deps", outputActionsOption, outputTagsOption)
+};
+
+export const outputIncludeDependentsOption: INamedOption<yargs.Options, ICompileArgs> = {
+  name: "output-include-dependents",
+  option: {
+    describe:
+      "If set, dependents (downstream) of the selected actions are also included in the output.",
+    type: "boolean"
+  },
+  check: requiresSelection("output-include-dependents", outputActionsOption, outputTagsOption)
+};
+
+export const dotOutputOption: INamedOption<yargs.Options, ICompileArgs> = {
+  name: "dot",
+  option: {
+    describe: "Outputs a dot representation of the compiled project.",
+    type: "boolean",
+    default: false
+  },
+  check: (argv: yargs.Arguments<ICompileArgs>) => {
+    if (argv.json && argv.dot) {
+      throw new Error("Arguments --json and --dot are mutually exclusive.");
+    }
+  }
+};
+
+export const quietCompileOption: INamedOption<yargs.Options, ICompileArgs> = {
+  name: "quiet",
+  option: {
+    describe: "Less verbose compilation output. Example usage: 'dataform compile --quiet'",
+    type: "boolean",
+    default: false
+  }
+};
+
+export const watchOption: INamedOption<yargs.Options, ICompileArgs> = {
+  name: "watch",
+  option: {
+    describe: "Whether to watch the changes in the project directory.",
+    type: "boolean",
+    default: false
+  }
+};
+
+export const verboseOption: INamedOption<yargs.Options, ICompileArgs> = {
+  name: "verbose",
+  option: {
+    describe: "Enable verbose compilation output. Example usage: 'dataform compile --verbose'",
+    type: "boolean",
+    default: false
+  },
+  check: (argv: yargs.Arguments<ICompileArgs>) => {
+    if (argv.quiet && argv.verbose) {
+      throw new Error("Arguments --verbose and --quiet are mutually exclusive.");
+    }
+  }
+};
+
+export const compileOptions: Array<INamedOption<yargs.Options, ICompileArgs>> = [
+  watchOption,
+  verboseOption,
+  jsonOutputOption,
+  dotOutputOption,
+  timeoutOption,
+  quietCompileOption,
+  outputActionsOption,
+  outputTagsOption,
+  outputIncludeDepsOption,
+  outputIncludeDependentsOption,
+  ...ProjectConfigOptions.allYargsOptions
+];

--- a/cli/commands/format_command.ts
+++ b/cli/commands/format_command.ts
@@ -3,12 +3,23 @@ import * as glob from "glob";
 import * as path from "path";
 import yargs from "yargs";
 
-import { actionsOption, assertProjectDirExists, projectDirOption } from "df/cli/common_options";
+import {
+  actionsOption,
+  assertProjectDirExists,
+  IActionsArgs,
+  IProjectDirArgs,
+  projectDirOption
+} from "df/cli/common_options";
 import { printError, printFormatFilesResult, printSuccess } from "df/cli/console";
 import { ICommand, INamedOption } from "df/cli/yargswrapper";
 import { formatFile } from "df/sqlx/format";
 
-const fmtIgnoreJsOption: INamedOption<yargs.Options> = {
+export interface IFormatArgs extends IProjectDirArgs, IActionsArgs {
+  ignoreJsFiles: boolean;
+  check: boolean;
+}
+
+const fmtIgnoreJsOption: INamedOption<yargs.Options, IFormatArgs> = {
   name: "ignore-js-files",
   option: {
     describe: "If set, the formatter will not consider javascript files (.js)",
@@ -17,10 +28,8 @@ const fmtIgnoreJsOption: INamedOption<yargs.Options> = {
   }
 };
 
-const checkOptionName = "check";
-
-const checkOption: INamedOption<yargs.Options> = {
-  name: checkOptionName,
+const checkOption: INamedOption<yargs.Options, IFormatArgs> = {
+  name: "check",
   option: {
     describe: "Check if files are formatted correctly without modifying them.",
     type: "boolean",
@@ -28,23 +37,23 @@ const checkOption: INamedOption<yargs.Options> = {
   }
 };
 
-export const formatCommand: ICommand = {
+export const formatCommand: ICommand<IFormatArgs> = {
   format: `format [${projectDirOption.name}]`,
   description: "Format the dataform project's files.",
   positionalOptions: [projectDirOption],
   options: [actionsOption, fmtIgnoreJsOption, checkOption],
   check: [assertProjectDirExists],
   processFn: async argv => {
-    const extensions = argv[fmtIgnoreJsOption.name] ? "*.sqlx" : "*.{js,sqlx}";
+    const extensions = argv.ignoreJsFiles ? "*.sqlx" : "*.{js,sqlx}";
     let actions = [`{definitions,includes}/**/${extensions}`];
-    if (actionsOption.name in argv && argv[actionsOption.name].length > 0) {
-      actions = argv[actionsOption.name];
+    if (argv.actions && argv.actions.length > 0) {
+      actions = argv.actions;
     }
     const filenames = actions
-      .map((action: string) => glob.sync(action, { cwd: argv[projectDirOption.name] }))
+      .map((action: string) => glob.sync(action, { cwd: argv.projectDir }))
       .flat();
 
-    const isCheckMode = argv[checkOptionName];
+    const isCheckMode = argv.check;
     const results: Array<{
       filename: string;
       err?: Error;
@@ -52,7 +61,7 @@ export const formatCommand: ICommand = {
     }> = await Promise.all(
       filenames.map(async (filename: string) => {
         try {
-          const filePath = path.resolve(argv[projectDirOption.name], filename);
+          const filePath = path.resolve(argv.projectDir, filename);
           if (isCheckMode) {
             // In check mode, we don't modify files, just check if they need formatting
             const fileContent = fs.readFileSync(filePath).toString();

--- a/cli/commands/format_command.ts
+++ b/cli/commands/format_command.ts
@@ -3,7 +3,7 @@ import * as glob from "glob";
 import * as path from "path";
 import yargs from "yargs";
 
-import { actionsOption, projectDirMustExistOption } from "df/cli/common_options";
+import { actionsOption, assertProjectDirExists, projectDirOption } from "df/cli/common_options";
 import { printError, printFormatFilesResult, printSuccess } from "df/cli/console";
 import { ICommand, INamedOption } from "df/cli/yargswrapper";
 import { formatFile } from "df/sqlx/format";
@@ -29,10 +29,11 @@ const checkOption: INamedOption<yargs.Options> = {
 };
 
 export const formatCommand: ICommand = {
-  format: `format [${projectDirMustExistOption.name}]`,
+  format: `format [${projectDirOption.name}]`,
   description: "Format the dataform project's files.",
-  positionalOptions: [projectDirMustExistOption],
+  positionalOptions: [projectDirOption],
   options: [actionsOption, fmtIgnoreJsOption, checkOption],
+  check: [assertProjectDirExists],
   processFn: async argv => {
     const extensions = argv[fmtIgnoreJsOption.name] ? "*.sqlx" : "*.{js,sqlx}";
     let actions = [`{definitions,includes}/**/${extensions}`];
@@ -40,7 +41,7 @@ export const formatCommand: ICommand = {
       actions = argv[actionsOption.name];
     }
     const filenames = actions
-      .map((action: string) => glob.sync(action, { cwd: argv[projectDirMustExistOption.name] }))
+      .map((action: string) => glob.sync(action, { cwd: argv[projectDirOption.name] }))
       .flat();
 
     const isCheckMode = argv[checkOptionName];
@@ -51,7 +52,7 @@ export const formatCommand: ICommand = {
     }> = await Promise.all(
       filenames.map(async (filename: string) => {
         try {
-          const filePath = path.resolve(argv[projectDirMustExistOption.name], filename);
+          const filePath = path.resolve(argv[projectDirOption.name], filename);
           if (isCheckMode) {
             // In check mode, we don't modify files, just check if they need formatting
             const fileContent = fs.readFileSync(filePath).toString();

--- a/cli/commands/help_command.ts
+++ b/cli/commands/help_command.ts
@@ -1,9 +1,13 @@
 import yargs from "yargs";
 
-import { ICommand, setupYargs } from "df/cli/yargswrapper";
+import { ICommand, ICommandBase, setupYargs } from "df/cli/yargswrapper";
 
-export function createHelpCommand(commands: ICommand[]): ICommand {
-  const helpCmd: ICommand = {
+export interface IHelpArgs {
+  command?: string;
+}
+
+export function createHelpCommand(commands: ICommandBase[]): ICommand<IHelpArgs> {
+  const helpCmd: ICommand<IHelpArgs> = {
     format: "help [command]",
     description: "Show help. If [command] is specified, the help is for the given command.",
     positionalOptions: [],

--- a/cli/commands/init_command.ts
+++ b/cli/commands/init_command.ts
@@ -23,43 +23,47 @@ const icebergOption: INamedOption<yargs.Options, IInitArgs> = {
   }
 };
 
+const defaultDatabaseOption: INamedOption<yargs.PositionalOptions, IInitArgs> = {
+  name: ProjectConfigOptions.defaultDatabase.name,
+  option: {
+    describe: "The default database to use, equivalent to Google Cloud Project ID."
+  },
+  check: (argv: yargs.Arguments<IInitArgs>) => {
+    if (!argv.defaultDatabase) {
+      throw new Error(
+        `The ${ProjectConfigOptions.defaultDatabase.name} positional argument is ` +
+          `required. Use "dataform help init" for more info.`
+      );
+    }
+  }
+};
+
+const defaultLocationOption: INamedOption<yargs.PositionalOptions, IInitArgs> = {
+  name: ProjectConfigOptions.defaultLocation.name,
+  option: {
+    describe:
+      "The default location to use. See " +
+      "https://cloud.google.com/bigquery/docs/locations for supported values."
+  },
+  check: (argv: yargs.Arguments<IInitArgs>) => {
+    if (!argv.defaultLocation) {
+      throw new Error(
+        `The ${ProjectConfigOptions.defaultLocation.name} positional argument is ` +
+          `required. Use "dataform help init" for more info.`
+      );
+    }
+  }
+};
+
 export const initCommand: ICommand<IInitArgs> = {
   format:
-    `init [${projectDirOption.name}] [${ProjectConfigOptions.defaultDatabase.name}]` +
-    ` [${ProjectConfigOptions.defaultLocation.name}]`,
+    `init [${projectDirOption.name}] [${defaultDatabaseOption.name}]` +
+    ` [${defaultLocationOption.name}]`,
   description: "Create a new dataform project.",
   positionalOptions: [
     projectDirOption,
-    {
-      name: ProjectConfigOptions.defaultDatabase.name,
-      option: {
-        describe: "The default database to use, equivalent to Google Cloud Project ID."
-      },
-      check: (argv: yargs.Arguments<IInitArgs>) => {
-        if (!argv.defaultDatabase) {
-          throw new Error(
-            `The ${ProjectConfigOptions.defaultDatabase.name} positional argument is ` +
-              `required. Use "dataform help init" for more info.`
-          );
-        }
-      }
-    },
-    {
-      name: ProjectConfigOptions.defaultLocation.name,
-      option: {
-        describe:
-          "The default location to use. See " +
-          "https://cloud.google.com/bigquery/docs/locations for supported values."
-      },
-      check: (argv: yargs.Arguments<IInitArgs>) => {
-        if (!argv.defaultLocation) {
-          throw new Error(
-            `The ${ProjectConfigOptions.defaultLocation.name} positional argument is ` +
-              `required. Use "dataform help init" for more info.`
-          );
-        }
-      }
-    }
+    defaultDatabaseOption,
+    defaultLocationOption
   ],
   options: [icebergOption],
   processFn: async argv => {

--- a/cli/commands/init_command.ts
+++ b/cli/commands/init_command.ts
@@ -1,14 +1,20 @@
 import yargs from "yargs";
 
 import { init } from "df/cli/api";
-import { projectDirOption } from "df/cli/common_options";
+import { IProjectDirArgs, projectDirOption } from "df/cli/common_options";
 import { print, printInitResult } from "df/cli/console";
 import { ProjectConfigOptions } from "df/cli/project_config_options";
 import { promptForIcebergConfig } from "df/cli/util";
 import { ICommand, INamedOption } from "df/cli/yargswrapper";
 import { dataform } from "df/protos/ts";
 
-const icebergOption: INamedOption<yargs.Options> = {
+export interface IInitArgs extends IProjectDirArgs {
+  defaultDatabase: string;
+  defaultLocation: string;
+  iceberg: boolean;
+}
+
+const icebergOption: INamedOption<yargs.Options, IInitArgs> = {
   name: "iceberg",
   option: {
     describe: "Initialize the project with workflow-level Iceberg tables configuration.",
@@ -17,7 +23,7 @@ const icebergOption: INamedOption<yargs.Options> = {
   }
 };
 
-export const initCommand: ICommand = {
+export const initCommand: ICommand<IInitArgs> = {
   format:
     `init [${projectDirOption.name}] [${ProjectConfigOptions.defaultDatabase.name}]` +
     ` [${ProjectConfigOptions.defaultLocation.name}]`,
@@ -29,8 +35,8 @@ export const initCommand: ICommand = {
       option: {
         describe: "The default database to use, equivalent to Google Cloud Project ID."
       },
-      check: (argv: yargs.Arguments<any>) => {
-        if (!argv[ProjectConfigOptions.defaultDatabase.name]) {
+      check: (argv: yargs.Arguments<IInitArgs>) => {
+        if (!argv.defaultDatabase) {
           throw new Error(
             `The ${ProjectConfigOptions.defaultDatabase.name} positional argument is ` +
               `required. Use "dataform help init" for more info.`
@@ -45,8 +51,8 @@ export const initCommand: ICommand = {
           "The default location to use. See " +
           "https://cloud.google.com/bigquery/docs/locations for supported values."
       },
-      check: (argv: yargs.Arguments<any>) => {
-        if (!argv[ProjectConfigOptions.defaultLocation.name]) {
+      check: (argv: yargs.Arguments<IInitArgs>) => {
+        if (!argv.defaultLocation) {
           throw new Error(
             `The ${ProjectConfigOptions.defaultLocation.name} positional argument is ` +
               `required. Use "dataform help init" for more info.`
@@ -57,13 +63,12 @@ export const initCommand: ICommand = {
   ],
   options: [icebergOption],
   processFn: async argv => {
-    const projectDir = argv[projectDirOption.name];
     const projectConfig: dataform.IProjectConfig = {
-      defaultDatabase: argv[ProjectConfigOptions.defaultDatabase.name],
-      defaultLocation: argv[ProjectConfigOptions.defaultLocation.name]
+      defaultDatabase: argv.defaultDatabase,
+      defaultLocation: argv.defaultLocation
     };
 
-    if (argv[icebergOption.name]) {
+    if (argv.iceberg) {
       const icebergConfig = promptForIcebergConfig();
       if (icebergConfig) {
         projectConfig.defaultIcebergConfig = icebergConfig;
@@ -72,7 +77,7 @@ export const initCommand: ICommand = {
 
     print("Writing project files...\n");
 
-    const initResult = await init(projectDir, projectConfig);
+    const initResult = await init(argv.projectDir, projectConfig);
     printInitResult(initResult);
     return 0;
   }

--- a/cli/commands/init_creds_command.ts
+++ b/cli/commands/init_creds_command.ts
@@ -5,7 +5,7 @@ import yargs from "yargs";
 import { credentials } from "df/cli/api";
 import { BigQueryDbAdapter } from "df/cli/api/dbadapters/bigquery";
 import { prettyJsonStringify } from "df/cli/api/utils";
-import { projectDirMustExistOption } from "df/cli/common_options";
+import { assertProjectDirExists, projectDirOption } from "df/cli/common_options";
 import { print, printInitCredsResult, printSuccess } from "df/cli/console";
 import { getBigQueryCredentials } from "df/cli/credentials";
 import { ICommand, INamedOption } from "df/cli/yargswrapper";
@@ -22,12 +22,13 @@ const testConnectionOption: INamedOption<yargs.Options> = {
 };
 
 export const initCredsCommand: ICommand = {
-  format: `init-creds [${projectDirMustExistOption.name}]`,
+  format: `init-creds [${projectDirOption.name}]`,
   description:
     `Create a ${credentials.CREDENTIALS_FILENAME} file for Dataform to use when ` +
     `accessing BigQuery.`,
-  positionalOptions: [projectDirMustExistOption],
+  positionalOptions: [projectDirOption],
   options: [testConnectionOption],
+  check: [assertProjectDirExists],
   processFn: async argv => {
     const finalCredentials = getBigQueryCredentials();
     if (argv[testConnectionOptionName]) {
@@ -52,7 +53,7 @@ export const initCredsCommand: ICommand = {
       print("\nCredentials test query was not run.\n");
     }
     const filePath = path.resolve(
-      argv[projectDirMustExistOption.name],
+      argv[projectDirOption.name],
       credentials.CREDENTIALS_FILENAME
     );
     fs.writeFileSync(filePath, prettyJsonStringify(finalCredentials));

--- a/cli/commands/init_creds_command.ts
+++ b/cli/commands/init_creds_command.ts
@@ -5,15 +5,17 @@ import yargs from "yargs";
 import { credentials } from "df/cli/api";
 import { BigQueryDbAdapter } from "df/cli/api/dbadapters/bigquery";
 import { prettyJsonStringify } from "df/cli/api/utils";
-import { assertProjectDirExists, projectDirOption } from "df/cli/common_options";
+import { assertProjectDirExists, IProjectDirArgs, projectDirOption } from "df/cli/common_options";
 import { print, printInitCredsResult, printSuccess } from "df/cli/console";
 import { getBigQueryCredentials } from "df/cli/credentials";
 import { ICommand, INamedOption } from "df/cli/yargswrapper";
 
-const testConnectionOptionName = "test-connection";
+export interface IInitCredsArgs extends IProjectDirArgs {
+  testConnection: boolean;
+}
 
-const testConnectionOption: INamedOption<yargs.Options> = {
-  name: testConnectionOptionName,
+const testConnectionOption: INamedOption<yargs.Options, IInitCredsArgs> = {
+  name: "test-connection",
   option: {
     describe: "If true, a test query will be run using your final credentials.",
     type: "boolean",
@@ -21,7 +23,7 @@ const testConnectionOption: INamedOption<yargs.Options> = {
   }
 };
 
-export const initCredsCommand: ICommand = {
+export const initCredsCommand: ICommand<IInitCredsArgs> = {
   format: `init-creds [${projectDirOption.name}]`,
   description:
     `Create a ${credentials.CREDENTIALS_FILENAME} file for Dataform to use when ` +
@@ -31,7 +33,7 @@ export const initCredsCommand: ICommand = {
   check: [assertProjectDirExists],
   processFn: async argv => {
     const finalCredentials = getBigQueryCredentials();
-    if (argv[testConnectionOptionName]) {
+    if (argv.testConnection) {
       print("\nRunning connection test...");
       const dbadapter = new BigQueryDbAdapter(finalCredentials);
       const testResult = await credentials.test(dbadapter);
@@ -53,7 +55,7 @@ export const initCredsCommand: ICommand = {
       print("\nCredentials test query was not run.\n");
     }
     const filePath = path.resolve(
-      argv[projectDirOption.name],
+      argv.projectDir,
       credentials.CREDENTIALS_FILENAME
     );
     fs.writeFileSync(filePath, prettyJsonStringify(finalCredentials));

--- a/cli/commands/install_command.ts
+++ b/cli/commands/install_command.ts
@@ -1,9 +1,11 @@
 import { install } from "df/cli/api";
-import { assertProjectDirExists, projectDirOption } from "df/cli/common_options";
+import { assertProjectDirExists, IProjectDirArgs, projectDirOption } from "df/cli/common_options";
 import { print, printSuccess } from "df/cli/console";
 import { ICommand } from "df/cli/yargswrapper";
 
-export const installCommand: ICommand = {
+export interface IInstallArgs extends IProjectDirArgs {}
+
+export const installCommand: ICommand<IInstallArgs> = {
   format: `install [${projectDirOption.name}]`,
   description: "Install a project's NPM dependencies.",
   positionalOptions: [projectDirOption],
@@ -11,7 +13,7 @@ export const installCommand: ICommand = {
   check: [assertProjectDirExists],
   processFn: async argv => {
     print("Installing NPM dependencies...\n");
-    await install(argv[projectDirOption.name]);
+    await install(argv.projectDir);
     printSuccess("Project dependencies successfully installed.");
     return 0;
   }

--- a/cli/commands/install_command.ts
+++ b/cli/commands/install_command.ts
@@ -1,16 +1,17 @@
 import { install } from "df/cli/api";
-import { projectDirMustExistOption } from "df/cli/common_options";
+import { assertProjectDirExists, projectDirOption } from "df/cli/common_options";
 import { print, printSuccess } from "df/cli/console";
 import { ICommand } from "df/cli/yargswrapper";
 
 export const installCommand: ICommand = {
-  format: `install [${projectDirMustExistOption.name}]`,
+  format: `install [${projectDirOption.name}]`,
   description: "Install a project's NPM dependencies.",
-  positionalOptions: [projectDirMustExistOption],
+  positionalOptions: [projectDirOption],
   options: [],
+  check: [assertProjectDirExists],
   processFn: async argv => {
     print("Installing NPM dependencies...\n");
-    await install(argv[projectDirMustExistOption.name]);
+    await install(argv[projectDirOption.name]);
     printSuccess("Project dependencies successfully installed.");
     return 0;
   }

--- a/cli/commands/run_command.ts
+++ b/cli/commands/run_command.ts
@@ -7,10 +7,10 @@ import { createLineageEmitter as createLineageEmitterFromFactory } from "df/cli/
 import { prettyJsonStringify } from "df/cli/api/utils";
 import {
   actionsOption,
+  assertProjectDirExists,
   coerceTimeout,
   credentialsOption,
   jsonOutputOption,
-  projectDirMustExistOption,
   projectDirOption,
   requiresSelection,
   splitCommas,
@@ -160,9 +160,10 @@ function createLineageEmitter(
 }
 
 export const runCommand: ICommand = {
-  format: `run [${projectDirMustExistOption.name}]`,
+  format: `run [${projectDirOption.name}]`,
   description: "Run the dataform project.",
-  positionalOptions: [projectDirMustExistOption],
+  positionalOptions: [projectDirOption],
+  check: [assertProjectDirExists],
   options: [
     {
       name: dryRunOptionName,

--- a/cli/commands/run_command.ts
+++ b/cli/commands/run_command.ts
@@ -119,7 +119,7 @@ export const runCommand: ICommand<IRunArgs> = {
       !executionGraph.actions.some(action => !!action.jitCode)
     ) {
       printExecutionGraph(executionGraph, isJsonOutput);
-      return;
+      return 0;
     }
 
     if (argv.runTests) {

--- a/cli/commands/run_command.ts
+++ b/cli/commands/run_command.ts
@@ -6,20 +6,15 @@ import { LineageEmitter } from "df/cli/api/lineage/emitter";
 import { createLineageEmitter as createLineageEmitterFromFactory } from "df/cli/api/lineage/emitter_factory";
 import { prettyJsonStringify } from "df/cli/api/utils";
 import {
-  actionsOption,
+  dryRunOption,
+  executionTimeoutOption,
+  IRunArgs,
+  runOptions
+} from "df/cli/commands/run_options";
+import {
   assertProjectDirExists,
-  coerceTimeout,
-  credentialsOption,
-  IActionsArgs,
-  ICredentialsArgs,
-  IJsonOutputArgs,
-  IProjectDirArgs,
-  ITimeoutArgs,
   jsonOutputOption,
-  projectDirOption,
-  requiresSelection,
-  splitCommas,
-  timeoutOption
+  projectDirOption
 } from "df/cli/common_options";
 import {
   Logger,
@@ -31,9 +26,9 @@ import {
   printTestResult,
   printWarning
 } from "df/cli/console";
-import { IProjectConfigArgs, ProjectConfigOptions } from "df/cli/project_config_options";
+import { ProjectConfigOptions } from "df/cli/project_config_options";
 import { actuallyResolve, compiledGraphHasErrors } from "df/cli/util";
-import { ICommand, INamedOption } from "df/cli/yargswrapper";
+import { ICommand } from "df/cli/yargswrapper";
 import { targetAsReadableString } from "df/core/targets";
 import { dataform } from "df/protos/ts";
 
@@ -42,156 +37,6 @@ import { dataform } from "df/protos/ts";
 // within this window, in-flight requests are abandoned and the run status is
 // unaffected.
 const LINEAGE_DRAIN_TIMEOUT_MS = 15_000;
-
-export interface IRunArgs
-  extends IProjectDirArgs,
-    IProjectConfigArgs,
-    ICredentialsArgs,
-    IActionsArgs,
-    IJsonOutputArgs,
-    ITimeoutArgs {
-  dryRun?: boolean;
-  runTests?: boolean;
-  actionRetryLimit: number;
-  emitLineage?: boolean;
-  fullRefresh: boolean;
-  includeDeps?: boolean;
-  includeDependents?: boolean;
-  executionTimeout?: number | null;
-  jitTimeout?: number | null;
-  jobPrefix?: string | null;
-  tags?: string[];
-  jobLabels?: { [key: string]: string };
-}
-
-const dryRunOption: INamedOption<yargs.Options, IRunArgs> = {
-  name: "dry-run",
-  option: {
-    describe:
-      "If set, BigQuery will validate the run SQL without applying changes to the warehouse.",
-    type: "boolean"
-  }
-};
-
-const runTestsOption: INamedOption<yargs.Options, IRunArgs> = {
-  name: "run-tests",
-  option: {
-    describe:
-      "If set, the project's unit tests are required to pass before running the project.",
-    type: "boolean"
-  }
-};
-
-const actionRetryLimitOption: INamedOption<yargs.Options, IRunArgs> = {
-  name: "action-retry-limit",
-  option: {
-    describe: "If set, idempotent actions will be retried up to the limit.",
-    type: "number",
-    default: 0
-  }
-};
-
-const fullRefreshOption: INamedOption<yargs.Options, IRunArgs> = {
-  name: "full-refresh",
-  option: {
-    describe: "Forces incremental tables to be rebuilt from scratch.",
-    type: "boolean",
-    default: false
-  }
-};
-
-const tagsOption: INamedOption<yargs.Options, IRunArgs> = {
-  name: "tags",
-  option: {
-    describe: "A list of tags to filter the actions to run.",
-    type: "array",
-    coerce: splitCommas
-  }
-};
-
-const includeDepsOption: INamedOption<yargs.Options, IRunArgs> = {
-  name: "include-deps",
-  option: {
-    describe: "If set, dependencies for selected actions will also be run.",
-    type: "boolean"
-  },
-  check: requiresSelection("include-deps", actionsOption, tagsOption)
-};
-
-const includeDependentsOption: INamedOption<yargs.Options, IRunArgs> = {
-  name: "include-dependents",
-  option: {
-    describe: "If set, dependents (downstream) for selected actions will also be run.",
-    type: "boolean"
-  },
-  check: requiresSelection("include-dependents", actionsOption, tagsOption)
-};
-
-const emitLineageOption: INamedOption<yargs.Options, IRunArgs> = {
-  name: "emit-lineage",
-  option: {
-    describe:
-      "If set, emit OpenLineage RunEvents to Knowledge Catalog Lineage for each executed action. " +
-      "Overrides workflow_settings.yaml lineage.enabled when specified.",
-    type: "boolean"
-  }
-};
-
-const executionTimeoutOption: INamedOption<yargs.Options, IRunArgs> = {
-  name: "execution-timeout",
-  option: {
-    describe:
-      "Wall-clock deadline for the entire run (compile + all actions). When it fires, " +
-      "in-flight actions are cancelled and pending actions are skipped. Off by default. " +
-      "Examples: '10m', '2h'.",
-    type: "string",
-    default: null,
-    coerce: coerceTimeout
-  }
-};
-
-const jitTimeoutOption: INamedOption<yargs.Options, IRunArgs> = {
-  name: "jit-timeout",
-  option: {
-    describe:
-      "Per-model JiT compilation worker timeout. Each action with jitCode gets " +
-      "its own fresh deadline; independent of --execution-timeout. When unset, no " +
-      "per-model cap is applied and only --execution-timeout bounds JiT work. " +
-      "Examples: '30s', '2m'.",
-    type: "string",
-    default: null,
-    coerce: coerceTimeout
-  }
-};
-
-const jobPrefixOption: INamedOption<yargs.Options, IRunArgs> = {
-  name: "job-prefix",
-  option: {
-    describe: "Adds an additional prefix in the form of `dataform-${jobPrefix}-`.",
-    type: "string",
-    default: null
-  }
-};
-
-const bigqueryJobLabelsOption: INamedOption<yargs.Options, IRunArgs> = {
-  name: "job-labels",
-  option: {
-    describe:
-      "Comma-separated list of labels to add to BigQuery jobs, e.g. 'key1=val1,key2=val2'.",
-    type: "string",
-    coerce: (raw: string | null) => {
-      const labels: { [key: string]: string } = {};
-      raw?.split(",").forEach(kv => {
-        if (!kv) {
-          return;
-        }
-        const [key, ...rest] = kv.split("=");
-        labels[key] = rest.join("=") || "";
-      });
-      return labels;
-    }
-  }
-};
 
 function createLineageEmitter(
   argv: yargs.Arguments<IRunArgs>,
@@ -212,25 +57,7 @@ export const runCommand: ICommand<IRunArgs> = {
   description: "Run the dataform project.",
   positionalOptions: [projectDirOption],
   check: [assertProjectDirExists],
-  options: [
-    dryRunOption,
-    runTestsOption,
-    actionRetryLimitOption,
-    actionsOption,
-    credentialsOption,
-    emitLineageOption,
-    fullRefreshOption,
-    includeDepsOption,
-    includeDependentsOption,
-    jsonOutputOption,
-    timeoutOption,
-    executionTimeoutOption,
-    jitTimeoutOption,
-    jobPrefixOption,
-    tagsOption,
-    bigqueryJobLabelsOption,
-    ...ProjectConfigOptions.allYargsOptions
-  ],
+  options: runOptions,
   processFn: async argv => {
     const isJsonOutput = argv.json;
     const logger = new Logger(!isJsonOutput);

--- a/cli/commands/run_command.ts
+++ b/cli/commands/run_command.ts
@@ -10,6 +10,11 @@ import {
   assertProjectDirExists,
   coerceTimeout,
   credentialsOption,
+  IActionsArgs,
+  ICredentialsArgs,
+  IJsonOutputArgs,
+  IProjectDirArgs,
+  ITimeoutArgs,
   jsonOutputOption,
   projectDirOption,
   requiresSelection,
@@ -26,7 +31,7 @@ import {
   printTestResult,
   printWarning
 } from "df/cli/console";
-import { ProjectConfigOptions } from "df/cli/project_config_options";
+import { IProjectConfigArgs, ProjectConfigOptions } from "df/cli/project_config_options";
 import { actuallyResolve, compiledGraphHasErrors } from "df/cli/util";
 import { ICommand, INamedOption } from "df/cli/yargswrapper";
 import { targetAsReadableString } from "df/core/targets";
@@ -38,7 +43,55 @@ import { dataform } from "df/protos/ts";
 // unaffected.
 const LINEAGE_DRAIN_TIMEOUT_MS = 15_000;
 
-const fullRefreshOption: INamedOption<yargs.Options> = {
+export interface IRunArgs
+  extends IProjectDirArgs,
+    IProjectConfigArgs,
+    ICredentialsArgs,
+    IActionsArgs,
+    IJsonOutputArgs,
+    ITimeoutArgs {
+  dryRun?: boolean;
+  runTests?: boolean;
+  actionRetryLimit: number;
+  emitLineage?: boolean;
+  fullRefresh: boolean;
+  includeDeps?: boolean;
+  includeDependents?: boolean;
+  executionTimeout?: number | null;
+  jitTimeout?: number | null;
+  jobPrefix?: string | null;
+  tags?: string[];
+  jobLabels?: { [key: string]: string };
+}
+
+const dryRunOption: INamedOption<yargs.Options, IRunArgs> = {
+  name: "dry-run",
+  option: {
+    describe:
+      "If set, BigQuery will validate the run SQL without applying changes to the warehouse.",
+    type: "boolean"
+  }
+};
+
+const runTestsOption: INamedOption<yargs.Options, IRunArgs> = {
+  name: "run-tests",
+  option: {
+    describe:
+      "If set, the project's unit tests are required to pass before running the project.",
+    type: "boolean"
+  }
+};
+
+const actionRetryLimitOption: INamedOption<yargs.Options, IRunArgs> = {
+  name: "action-retry-limit",
+  option: {
+    describe: "If set, idempotent actions will be retried up to the limit.",
+    type: "number",
+    default: 0
+  }
+};
+
+const fullRefreshOption: INamedOption<yargs.Options, IRunArgs> = {
   name: "full-refresh",
   option: {
     describe: "Forces incremental tables to be rebuilt from scratch.",
@@ -47,7 +100,7 @@ const fullRefreshOption: INamedOption<yargs.Options> = {
   }
 };
 
-const tagsOption: INamedOption<yargs.Options> = {
+const tagsOption: INamedOption<yargs.Options, IRunArgs> = {
   name: "tags",
   option: {
     describe: "A list of tags to filter the actions to run.",
@@ -56,7 +109,7 @@ const tagsOption: INamedOption<yargs.Options> = {
   }
 };
 
-const includeDepsOption: INamedOption<yargs.Options> = {
+const includeDepsOption: INamedOption<yargs.Options, IRunArgs> = {
   name: "include-deps",
   option: {
     describe: "If set, dependencies for selected actions will also be run.",
@@ -65,7 +118,7 @@ const includeDepsOption: INamedOption<yargs.Options> = {
   check: requiresSelection("include-deps", actionsOption, tagsOption)
 };
 
-const includeDependentsOption: INamedOption<yargs.Options> = {
+const includeDependentsOption: INamedOption<yargs.Options, IRunArgs> = {
   name: "include-dependents",
   option: {
     describe: "If set, dependents (downstream) for selected actions will also be run.",
@@ -74,7 +127,7 @@ const includeDependentsOption: INamedOption<yargs.Options> = {
   check: requiresSelection("include-dependents", actionsOption, tagsOption)
 };
 
-const emitLineageOption: INamedOption<yargs.Options> = {
+const emitLineageOption: INamedOption<yargs.Options, IRunArgs> = {
   name: "emit-lineage",
   option: {
     describe:
@@ -84,7 +137,7 @@ const emitLineageOption: INamedOption<yargs.Options> = {
   }
 };
 
-const executionTimeoutOption: INamedOption<yargs.Options> = {
+const executionTimeoutOption: INamedOption<yargs.Options, IRunArgs> = {
   name: "execution-timeout",
   option: {
     describe:
@@ -97,7 +150,7 @@ const executionTimeoutOption: INamedOption<yargs.Options> = {
   }
 };
 
-const jitTimeoutOption: INamedOption<yargs.Options> = {
+const jitTimeoutOption: INamedOption<yargs.Options, IRunArgs> = {
   name: "jit-timeout",
   option: {
     describe:
@@ -111,7 +164,7 @@ const jitTimeoutOption: INamedOption<yargs.Options> = {
   }
 };
 
-const jobPrefixOption: INamedOption<yargs.Options> = {
+const jobPrefixOption: INamedOption<yargs.Options, IRunArgs> = {
   name: "job-prefix",
   option: {
     describe: "Adds an additional prefix in the form of `dataform-${jobPrefix}-`.",
@@ -120,7 +173,7 @@ const jobPrefixOption: INamedOption<yargs.Options> = {
   }
 };
 
-const bigqueryJobLabelsOption: INamedOption<yargs.Options> = {
+const bigqueryJobLabelsOption: INamedOption<yargs.Options, IRunArgs> = {
   name: "job-labels",
   option: {
     describe:
@@ -140,55 +193,29 @@ const bigqueryJobLabelsOption: INamedOption<yargs.Options> = {
   }
 };
 
-const dryRunOptionName = "dry-run";
-const runTestsOptionName = "run-tests";
-
-const actionRetryLimitName = "action-retry-limit";
-
 function createLineageEmitter(
-  argv: yargs.Arguments<any>,
+  argv: yargs.Arguments<IRunArgs>,
   executionGraph: dataform.IExecutionGraph,
   readCredentials: dataform.IBigQuery | undefined
 ): LineageEmitter | undefined {
   return createLineageEmitterFromFactory({
-    cliEmitLineage: argv[emitLineageOption.name] as boolean | undefined,
+    cliEmitLineage: argv.emitLineage,
     workflowLineageEnabled: executionGraph.projectConfig?.lineageEnabled ?? undefined,
-    dryRun: !!argv[dryRunOptionName],
-    projectDir: argv[projectDirOption.name] || process.cwd(),
+    dryRun: !!argv.dryRun,
+    projectDir: argv.projectDir || process.cwd(),
     readCredentials
   });
 }
 
-export const runCommand: ICommand = {
+export const runCommand: ICommand<IRunArgs> = {
   format: `run [${projectDirOption.name}]`,
   description: "Run the dataform project.",
   positionalOptions: [projectDirOption],
   check: [assertProjectDirExists],
   options: [
-    {
-      name: dryRunOptionName,
-      option: {
-        describe:
-          "If set, BigQuery will validate the run SQL without applying changes to the warehouse.",
-        type: "boolean"
-      }
-    },
-    {
-      name: runTestsOptionName,
-      option: {
-        describe:
-          "If set, the project's unit tests are required to pass before running the project.",
-        type: "boolean"
-      }
-    },
-    {
-      name: actionRetryLimitName,
-      option: {
-        describe: "If set, idempotent actions will be retried up to the limit.",
-        type: "number",
-        default: 0
-      }
-    },
+    dryRunOption,
+    runTestsOption,
+    actionRetryLimitOption,
     actionsOption,
     credentialsOption,
     emitLineageOption,
@@ -205,20 +232,20 @@ export const runCommand: ICommand = {
     ...ProjectConfigOptions.allYargsOptions
   ],
   processFn: async argv => {
-    const isJsonOutput = argv[jsonOutputOption.name];
+    const isJsonOutput = argv.json;
     const logger = new Logger(!isJsonOutput);
 
-    if (isJsonOutput && !argv[dryRunOptionName]) {
+    if (isJsonOutput && !argv.dryRun) {
       printError(
         `For execution, the --${jsonOutputOption.name} option is only supported if the ` +
-          `--${dryRunOptionName} option is enabled`
+          `--${dryRunOption.name} option is enabled`
       );
       return 1;
     }
     if (
       !isJsonOutput &&
-      argv[timeoutOption.name] != null &&
-      argv[executionTimeoutOption.name] == null
+      argv.timeout != null &&
+      argv.executionTimeout == null
     ) {
       printWarning(
         "Note: --timeout only bounds project compilation. " +
@@ -227,9 +254,9 @@ export const runCommand: ICommand = {
     }
     logger.log("Compiling...\n");
     const compiledGraph = await compile({
-      projectDir: argv[projectDirOption.name],
+      projectDir: argv.projectDir,
       projectConfigOverride: ProjectConfigOptions.constructProjectConfigOverride(argv),
-      timeoutMillis: argv[timeoutOption.name] || undefined
+      timeoutMillis: argv.timeout || undefined
     });
     if (compiledGraphHasErrors(compiledGraph)) {
       printCompiledGraphErrors(compiledGraph.graphErrors);
@@ -237,26 +264,26 @@ export const runCommand: ICommand = {
     }
     logger.success("Compiled successfully.\n");
     const readCredentials = credentials.read(
-      actuallyResolve(argv[projectDirOption.name], argv[credentialsOption.name])
+      actuallyResolve(argv.projectDir, argv.credentials)
     );
 
     const dbadapter = new BigQueryDbAdapter(readCredentials);
     const executionGraph = await build(
       compiledGraph,
       {
-        fullRefresh: argv[fullRefreshOption.name],
-        actions: argv[actionsOption.name],
-        includeDependencies: argv[includeDepsOption.name],
-        includeDependents: argv[includeDependentsOption.name],
-        tags: argv[tagsOption.name],
-        timeoutMillis: argv[executionTimeoutOption.name] || undefined,
-        jitTimeoutMillis: argv[jitTimeoutOption.name] || undefined
+        fullRefresh: argv.fullRefresh,
+        actions: argv.actions,
+        includeDependencies: argv.includeDeps,
+        includeDependents: argv.includeDependents,
+        tags: argv.tags,
+        timeoutMillis: argv.executionTimeout || undefined,
+        jitTimeoutMillis: argv.jitTimeout || undefined
       },
       dbadapter
     );
 
     if (
-      argv[dryRunOptionName] &&
+      argv.dryRun &&
       isJsonOutput &&
       // Skip the early graph print when JiT actions are present: their compiled
       // SQL is only produced once the Runner triggers JiT compilation, so falling
@@ -268,7 +295,7 @@ export const runCommand: ICommand = {
       return;
     }
 
-    if (argv[runTestsOptionName]) {
+    if (argv.runTests) {
       logger.log(`Running ${compiledGraph.tests.length} unit tests...\n`);
       const testResults = await test(dbadapter, compiledGraph.tests);
       testResults.forEach(testResult => printTestResult(testResult));
@@ -280,16 +307,16 @@ export const runCommand: ICommand = {
     }
 
     let bigqueryOptions: {} = {
-      actionRetryLimit: argv[actionRetryLimitName]
+      actionRetryLimit: argv.actionRetryLimit
     };
-    if (argv[dryRunOptionName]) {
-      bigqueryOptions = { ...bigqueryOptions, dryRun: argv[dryRunOptionName] };
+    if (argv.dryRun) {
+      bigqueryOptions = { ...bigqueryOptions, dryRun: argv.dryRun };
     }
-    if (argv[jobPrefixOption.name]) {
-      bigqueryOptions = { ...bigqueryOptions, jobPrefix: argv[jobPrefixOption.name] };
+    if (argv.jobPrefix) {
+      bigqueryOptions = { ...bigqueryOptions, jobPrefix: argv.jobPrefix };
     }
-    if (argv[bigqueryJobLabelsOption.name]) {
-      bigqueryOptions = { ...bigqueryOptions, labels: argv[bigqueryJobLabelsOption.name] };
+    if (argv.jobLabels) {
+      bigqueryOptions = { ...bigqueryOptions, labels: argv.jobLabels };
     }
 
     const actionsByName = new Map<string, dataform.IExecutionAction>();
@@ -302,7 +329,7 @@ export const runCommand: ICommand = {
       return 0;
     }
 
-    if (argv[dryRunOptionName]) {
+    if (argv.dryRun) {
       logger.log("Dry running (no changes to the warehouse will be applied)...");
     } else {
       logger.log("Running...\n");
@@ -314,7 +341,7 @@ export const runCommand: ICommand = {
       dbadapter,
       executionGraph,
       {
-        projectDir: argv[projectDirOption.name],
+        projectDir: argv.projectDir,
         bigquery: bigqueryOptions,
         lineageEmitter
       }
@@ -339,7 +366,7 @@ export const runCommand: ICommand = {
           printExecutedAction(
             executedAction,
             actionsByName.get(targetAsReadableString(executedAction.target)),
-            argv[dryRunOptionName]
+            argv.dryRun
           );
           alreadyPrintedActions.add(targetAsReadableString(executedAction.target));
         });
@@ -360,9 +387,9 @@ export const runCommand: ICommand = {
     }
     if (!isJsonOutput) {
       if (runResult.status === dataform.RunResult.ExecutionStatus.TIMED_OUT) {
-        const executionTimeoutMillis = argv[executionTimeoutOption.name];
+        const executionTimeoutMillis = argv.executionTimeout;
         const suffix = executionTimeoutMillis
-          ? ` after ${executionTimeoutMillis / 1000} seconds (--execution-timeout)`
+          ? ` after ${executionTimeoutMillis / 1000} seconds (--${executionTimeoutOption.name})`
           : "";
         printError(`Run timed out${suffix}.`);
       } else if (runResult.status === dataform.RunResult.ExecutionStatus.CANCELLED) {

--- a/cli/commands/run_options.ts
+++ b/cli/commands/run_options.ts
@@ -1,0 +1,188 @@
+import yargs from "yargs";
+
+import {
+  actionsOption,
+  coerceTimeout,
+  credentialsOption,
+  IActionsArgs,
+  ICredentialsArgs,
+  IJsonOutputArgs,
+  IProjectDirArgs,
+  ITimeoutArgs,
+  jsonOutputOption,
+  requiresSelection,
+  splitCommas,
+  timeoutOption
+} from "df/cli/common_options";
+import { IProjectConfigArgs, ProjectConfigOptions } from "df/cli/project_config_options";
+import { INamedOption } from "df/cli/yargswrapper";
+
+export interface IRunArgs
+  extends IProjectDirArgs,
+    IProjectConfigArgs,
+    ICredentialsArgs,
+    IActionsArgs,
+    IJsonOutputArgs,
+    ITimeoutArgs {
+  dryRun?: boolean;
+  runTests?: boolean;
+  actionRetryLimit: number;
+  emitLineage?: boolean;
+  fullRefresh: boolean;
+  includeDeps?: boolean;
+  includeDependents?: boolean;
+  executionTimeout?: number | null;
+  jitTimeout?: number | null;
+  jobPrefix?: string | null;
+  tags?: string[];
+  jobLabels?: { [key: string]: string };
+}
+
+export const dryRunOption: INamedOption<yargs.Options, IRunArgs> = {
+  name: "dry-run",
+  option: {
+    describe:
+      "If set, BigQuery will validate the run SQL without applying changes to the warehouse.",
+    type: "boolean"
+  }
+};
+
+export const runTestsOption: INamedOption<yargs.Options, IRunArgs> = {
+  name: "run-tests",
+  option: {
+    describe:
+      "If set, the project's unit tests are required to pass before running the project.",
+    type: "boolean"
+  }
+};
+
+export const actionRetryLimitOption: INamedOption<yargs.Options, IRunArgs> = {
+  name: "action-retry-limit",
+  option: {
+    describe: "If set, idempotent actions will be retried up to the limit.",
+    type: "number",
+    default: 0
+  }
+};
+
+export const fullRefreshOption: INamedOption<yargs.Options, IRunArgs> = {
+  name: "full-refresh",
+  option: {
+    describe: "Forces incremental tables to be rebuilt from scratch.",
+    type: "boolean",
+    default: false
+  }
+};
+
+export const tagsOption: INamedOption<yargs.Options, IRunArgs> = {
+  name: "tags",
+  option: {
+    describe: "A list of tags to filter the actions to run.",
+    type: "array",
+    coerce: splitCommas
+  }
+};
+
+export const includeDepsOption: INamedOption<yargs.Options, IRunArgs> = {
+  name: "include-deps",
+  option: {
+    describe: "If set, dependencies for selected actions will also be run.",
+    type: "boolean"
+  },
+  check: requiresSelection("include-deps", actionsOption, tagsOption)
+};
+
+export const includeDependentsOption: INamedOption<yargs.Options, IRunArgs> = {
+  name: "include-dependents",
+  option: {
+    describe: "If set, dependents (downstream) for selected actions will also be run.",
+    type: "boolean"
+  },
+  check: requiresSelection("include-dependents", actionsOption, tagsOption)
+};
+
+export const emitLineageOption: INamedOption<yargs.Options, IRunArgs> = {
+  name: "emit-lineage",
+  option: {
+    describe:
+      "If set, emit OpenLineage RunEvents to Knowledge Catalog Lineage for each executed action. " +
+      "Overrides workflow_settings.yaml lineage.enabled when specified.",
+    type: "boolean"
+  }
+};
+
+export const executionTimeoutOption: INamedOption<yargs.Options, IRunArgs> = {
+  name: "execution-timeout",
+  option: {
+    describe:
+      "Wall-clock deadline for the entire run (compile + all actions). When it fires, " +
+      "in-flight actions are cancelled and pending actions are skipped. Off by default. " +
+      "Examples: '10m', '2h'.",
+    type: "string",
+    default: null,
+    coerce: coerceTimeout
+  }
+};
+
+export const jitTimeoutOption: INamedOption<yargs.Options, IRunArgs> = {
+  name: "jit-timeout",
+  option: {
+    describe:
+      "Per-model JiT compilation worker timeout. Each action with jitCode gets " +
+      "its own fresh deadline; independent of --execution-timeout. When unset, no " +
+      "per-model cap is applied and only --execution-timeout bounds JiT work. " +
+      "Examples: '30s', '2m'.",
+    type: "string",
+    default: null,
+    coerce: coerceTimeout
+  }
+};
+
+export const jobPrefixOption: INamedOption<yargs.Options, IRunArgs> = {
+  name: "job-prefix",
+  option: {
+    describe: "Adds an additional prefix in the form of `dataform-${jobPrefix}-`.",
+    type: "string",
+    default: null
+  }
+};
+
+export const bigqueryJobLabelsOption: INamedOption<yargs.Options, IRunArgs> = {
+  name: "job-labels",
+  option: {
+    describe:
+      "Comma-separated list of labels to add to BigQuery jobs, e.g. 'key1=val1,key2=val2'.",
+    type: "string",
+    coerce: (raw: string | null) => {
+      const labels: { [key: string]: string } = {};
+      raw?.split(",").forEach(kv => {
+        if (!kv) {
+          return;
+        }
+        const [key, ...rest] = kv.split("=");
+        labels[key] = rest.join("=") || "";
+      });
+      return labels;
+    }
+  }
+};
+
+export const runOptions: Array<INamedOption<yargs.Options, IRunArgs>> = [
+  dryRunOption,
+  runTestsOption,
+  actionRetryLimitOption,
+  actionsOption,
+  credentialsOption,
+  emitLineageOption,
+  fullRefreshOption,
+  includeDepsOption,
+  includeDependentsOption,
+  jsonOutputOption,
+  timeoutOption,
+  executionTimeoutOption,
+  jitTimeoutOption,
+  jobPrefixOption,
+  tagsOption,
+  bigqueryJobLabelsOption,
+  ...ProjectConfigOptions.allYargsOptions
+];

--- a/cli/commands/test_command.ts
+++ b/cli/commands/test_command.ts
@@ -2,9 +2,9 @@ import { compile, credentials, test } from "df/cli/api";
 import { BigQueryDbAdapter } from "df/cli/api/dbadapters/bigquery";
 import { prettyJsonStringify } from "df/cli/api/utils";
 import {
+  assertProjectDirExists,
   credentialsOption,
   jsonOutputOption,
-  projectDirMustExistOption,
   projectDirOption,
   timeoutOption
 } from "df/cli/common_options";
@@ -20,9 +20,10 @@ import { actuallyResolve, compiledGraphHasErrors } from "df/cli/util";
 import { ICommand } from "df/cli/yargswrapper";
 
 export const testCommand: ICommand = {
-  format: `test [${projectDirMustExistOption.name}]`,
+  format: `test [${projectDirOption.name}]`,
   description: "Run the dataform project's unit tests.",
-  positionalOptions: [projectDirMustExistOption],
+  positionalOptions: [projectDirOption],
+  check: [assertProjectDirExists],
   options: [
     credentialsOption,
     timeoutOption,
@@ -34,7 +35,7 @@ export const testCommand: ICommand = {
       print("Compiling...\n");
     }
     const compiledGraph = await compile({
-      projectDir: argv[projectDirMustExistOption.name],
+      projectDir: argv[projectDirOption.name],
       projectConfigOverride: ProjectConfigOptions.constructProjectConfigOverride(argv),
       timeoutMillis: argv[timeoutOption.name] || undefined
     });

--- a/cli/commands/test_command.ts
+++ b/cli/commands/test_command.ts
@@ -4,6 +4,10 @@ import { prettyJsonStringify } from "df/cli/api/utils";
 import {
   assertProjectDirExists,
   credentialsOption,
+  ICredentialsArgs,
+  IJsonOutputArgs,
+  IProjectDirArgs,
+  ITimeoutArgs,
   jsonOutputOption,
   projectDirOption,
   timeoutOption
@@ -15,11 +19,18 @@ import {
   printSuccess,
   printTestResult
 } from "df/cli/console";
-import { ProjectConfigOptions } from "df/cli/project_config_options";
+import { IProjectConfigArgs, ProjectConfigOptions } from "df/cli/project_config_options";
 import { actuallyResolve, compiledGraphHasErrors } from "df/cli/util";
 import { ICommand } from "df/cli/yargswrapper";
 
-export const testCommand: ICommand = {
+export interface ITestArgs
+  extends IProjectDirArgs,
+    ICredentialsArgs,
+    ITimeoutArgs,
+    IJsonOutputArgs,
+    IProjectConfigArgs {}
+
+export const testCommand: ICommand<ITestArgs> = {
   format: `test [${projectDirOption.name}]`,
   description: "Run the dataform project's unit tests.",
   positionalOptions: [projectDirOption],
@@ -31,23 +42,23 @@ export const testCommand: ICommand = {
     ...ProjectConfigOptions.allYargsOptions
   ],
   processFn: async argv => {
-    if (!argv[jsonOutputOption.name]) {
+    if (!argv.json) {
       print("Compiling...\n");
     }
     const compiledGraph = await compile({
-      projectDir: argv[projectDirOption.name],
+      projectDir: argv.projectDir,
       projectConfigOverride: ProjectConfigOptions.constructProjectConfigOverride(argv),
-      timeoutMillis: argv[timeoutOption.name] || undefined
+      timeoutMillis: argv.timeout || undefined
     });
     if (compiledGraphHasErrors(compiledGraph)) {
       printCompiledGraphErrors(compiledGraph.graphErrors);
       return 1;
     }
-    if (!argv[jsonOutputOption.name]) {
+    if (!argv.json) {
       printSuccess("Compiled successfully.\n");
     }
     const readCredentials = credentials.read(
-      actuallyResolve(argv[projectDirOption.name], argv[credentialsOption.name])
+      actuallyResolve(argv.projectDir, argv.credentials)
     );
 
     if (!compiledGraph.tests.length) {
@@ -55,12 +66,12 @@ export const testCommand: ICommand = {
       return 1;
     }
 
-    if (!argv[jsonOutputOption.name]) {
+    if (!argv.json) {
       print(`Running ${compiledGraph.tests.length} unit tests...\n`);
     }
     const dbadapter = new BigQueryDbAdapter(readCredentials);
     const testResults = await test(dbadapter, compiledGraph.tests);
-    if (!argv[jsonOutputOption.name]) {
+    if (!argv.json) {
       testResults.forEach(testResult => printTestResult(testResult));
     } else {
       // Print all results as JSON if the option is set.

--- a/cli/common_options.ts
+++ b/cli/common_options.ts
@@ -7,7 +7,11 @@ import { CREDENTIALS_FILENAME } from "df/cli/api/commands/credentials";
 import { actuallyResolve, assertPathExists } from "df/cli/util";
 import { INamedOption } from "df/cli/yargswrapper";
 
-export const projectDirOption: INamedOption<yargs.PositionalOptions> = {
+export interface IProjectDirArgs {
+  projectDir: string;
+}
+
+export const projectDirOption: INamedOption<yargs.PositionalOptions, IProjectDirArgs> = {
   name: "project-dir",
   option: {
     describe: "The Dataform project directory.",
@@ -16,14 +20,13 @@ export const projectDirOption: INamedOption<yargs.PositionalOptions> = {
   }
 };
 
-export const assertProjectDirExists = (argv: yargs.Arguments) => {
-  const projectDir = argv[projectDirOption.name] as string;
-  assertPathExists(projectDir);
-  const dataformJsonPath = path.resolve(projectDir, "dataform.json");
-  const workflowSettingsYamlPath = path.resolve(projectDir, "workflow_settings.yaml");
+export const assertProjectDirExists = (argv: yargs.Arguments<IProjectDirArgs>) => {
+  assertPathExists(argv.projectDir);
+  const dataformJsonPath = path.resolve(argv.projectDir, "dataform.json");
+  const workflowSettingsYamlPath = path.resolve(argv.projectDir, "workflow_settings.yaml");
   if (!fs.existsSync(dataformJsonPath) && !fs.existsSync(workflowSettingsYamlPath)) {
     throw new Error(
-      `${projectDir} does not appear to be a dataform directory (missing workflow_settings.yaml file).`
+      `${argv.projectDir} does not appear to be a dataform directory (missing workflow_settings.yaml file).`
     );
   }
 };

--- a/cli/common_options.ts
+++ b/cli/common_options.ts
@@ -49,17 +49,25 @@ export const actionsOption: INamedOption<yargs.Options, IActionsArgs> = {
   }
 };
 
-export const credentialsOption: INamedOption<yargs.Options> = {
+export interface ICredentialsArgs extends IProjectDirArgs {
+  credentials: string;
+}
+
+export const credentialsOption: INamedOption<yargs.Options, ICredentialsArgs> = {
   name: "credentials",
   option: {
     describe: "The location of the credentials JSON file to use.",
     default: CREDENTIALS_FILENAME
   },
-  check: (argv: yargs.Arguments<any>) =>
-    actuallyResolve(argv[projectDirOption.name], argv[credentialsOption.name])
+  check: (argv: yargs.Arguments<ICredentialsArgs>) =>
+    actuallyResolve(argv.projectDir, argv.credentials)
 };
 
-export const jsonOutputOption: INamedOption<yargs.Options> = {
+export interface IJsonOutputArgs {
+  json: boolean;
+}
+
+export const jsonOutputOption: INamedOption<yargs.Options, IJsonOutputArgs> = {
   name: "json",
   option: {
     describe: "Outputs a JSON representation of the compiled project or test results.",
@@ -71,7 +79,11 @@ export const jsonOutputOption: INamedOption<yargs.Options> = {
 export const coerceTimeout = (rawTimeoutString: string | null) =>
   rawTimeoutString ? parseDuration(rawTimeoutString) : null;
 
-export const timeoutOption: INamedOption<yargs.Options> = {
+export interface ITimeoutArgs {
+  timeout: number | null;
+}
+
+export const timeoutOption: INamedOption<yargs.Options, ITimeoutArgs> = {
   name: "timeout",
   option: {
     describe: "Duration to allow project compilation to complete. Examples: '1s', '10m', etc.",

--- a/cli/common_options.ts
+++ b/cli/common_options.ts
@@ -96,9 +96,9 @@ export const timeoutOption: INamedOption<yargs.Options, ITimeoutArgs> = {
 // It would be nice to use yargs' "implies" to implement this, but it doesn't work for some reason.
 export const requiresSelection = (
   name: string,
-  actions: INamedOption<yargs.Options>,
-  tags: INamedOption<yargs.Options>
-): INamedOption<yargs.Options>["check"] => (argv: yargs.Arguments) => {
+  actions: { name: string },
+  tags: { name: string }
+) => (argv: yargs.Arguments) => {
   if (argv[name] && !(argv[actions.name] || argv[tags.name])) {
     throw new Error(
       `The --${name} flag should only be supplied along with --${actions.name} or --${tags.name}.`

--- a/cli/common_options.ts
+++ b/cli/common_options.ts
@@ -16,22 +16,15 @@ export const projectDirOption: INamedOption<yargs.PositionalOptions> = {
   }
 };
 
-export const projectDirMustExistOption: INamedOption<yargs.PositionalOptions> = {
-  ...projectDirOption,
-  check: (argv: yargs.Arguments<any>) => {
-    assertPathExists(argv[projectDirOption.name]);
-    const dataformJsonPath = path.resolve(argv[projectDirOption.name], "dataform.json");
-    const workflowSettingsYamlPath = path.resolve(
-      argv[projectDirOption.name],
-      "workflow_settings.yaml"
+export const assertProjectDirExists = (argv: yargs.Arguments) => {
+  const projectDir = argv[projectDirOption.name] as string;
+  assertPathExists(projectDir);
+  const dataformJsonPath = path.resolve(projectDir, "dataform.json");
+  const workflowSettingsYamlPath = path.resolve(projectDir, "workflow_settings.yaml");
+  if (!fs.existsSync(dataformJsonPath) && !fs.existsSync(workflowSettingsYamlPath)) {
+    throw new Error(
+      `${projectDir} does not appear to be a dataform directory (missing workflow_settings.yaml file).`
     );
-    if (!fs.existsSync(dataformJsonPath) && !fs.existsSync(workflowSettingsYamlPath)) {
-      throw new Error(
-        `${
-          argv[projectDirOption.name]
-        } does not appear to be a dataform directory (missing workflow_settings.yaml file).`
-      );
-    }
   }
 };
 

--- a/cli/common_options.ts
+++ b/cli/common_options.ts
@@ -36,7 +36,11 @@ export const assertProjectDirExists = (argv: yargs.Arguments<IProjectDirArgs>) =
 export const splitCommas = (raw: string[] | null) =>
   raw ? raw.map(value => value.split(",")).flat() : [];
 
-export const actionsOption: INamedOption<yargs.Options> = {
+export interface IActionsArgs {
+  actions?: string[];
+}
+
+export const actionsOption: INamedOption<yargs.Options, IActionsArgs> = {
   name: "actions",
   option: {
     describe: "A list of action names or patterns to run. Can include '*' wildcards.",

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -9,15 +9,14 @@ import {
   testCommand
 } from "df/cli/commands";
 import { printError } from "df/cli/console";
-import { createYargsCli, ICommand } from "df/cli/yargswrapper";
+import { createYargsCli } from "df/cli/yargswrapper";
 
 process.on("unhandledRejection", async (reason: any) => {
   printError(`Unhandled promise rejection: ${reason?.stack || reason}`);
 });
 
-// TODO: Since yargs launched an actually well typed API in version 12, let's use it as this file is currently not type checked.
 export function runCli() {
-  const commands: ICommand[] = [
+  const commands = [
     initCommand,
     installCommand,
     initCredsCommand,

--- a/cli/project_config_options.ts
+++ b/cli/project_config_options.ts
@@ -3,8 +3,21 @@ import yargs from "yargs";
 import { INamedOption } from "df/cli/yargswrapper";
 import { dataform } from "df/protos/ts";
 
+export interface IProjectConfigArgs {
+  defaultDatabase?: string;
+  defaultSchema?: string;
+  defaultLocation?: string;
+  assertionSchema?: string;
+  vars?: { [key: string]: string };
+  databaseSuffix?: string;
+  schemaSuffix?: string;
+  tablePrefix?: string;
+  disableAssertions?: boolean;
+  defaultReservation?: string;
+}
+
 export class ProjectConfigOptions {
-  public static defaultDatabase: INamedOption<yargs.Options> = {
+  public static defaultDatabase: INamedOption<yargs.Options, IProjectConfigArgs> = {
     name: "default-database",
     option: {
       describe:
@@ -14,7 +27,7 @@ export class ProjectConfigOptions {
     }
   };
 
-  public static defaultSchema: INamedOption<yargs.Options> = {
+  public static defaultSchema: INamedOption<yargs.Options, IProjectConfigArgs> = {
     name: "default-schema",
     option: {
       describe:
@@ -22,7 +35,7 @@ export class ProjectConfigOptions {
     }
   };
 
-  public static defaultLocation: INamedOption<yargs.Options> = {
+  public static defaultLocation: INamedOption<yargs.Options, IProjectConfigArgs> = {
     name: "default-location",
     option: {
       describe:
@@ -32,14 +45,14 @@ export class ProjectConfigOptions {
     }
   };
 
-  public static assertionSchema: INamedOption<yargs.Options> = {
+  public static assertionSchema: INamedOption<yargs.Options, IProjectConfigArgs> = {
     name: "assertion-schema",
     option: {
       describe: "Default assertion schema. If unset, the value from workflow_settings.yaml is used."
     }
   };
 
-  public static databaseSuffix: INamedOption<yargs.Options> = {
+  public static databaseSuffix: INamedOption<yargs.Options, IProjectConfigArgs> = {
     name: "database-suffix",
     option: {
       describe:
@@ -47,7 +60,7 @@ export class ProjectConfigOptions {
     }
   };
 
-  public static vars: INamedOption<yargs.Options> = {
+  public static vars: INamedOption<yargs.Options, IProjectConfigArgs> = {
     name: "vars",
     option: {
       describe:
@@ -66,17 +79,17 @@ export class ProjectConfigOptions {
     }
   };
 
-  public static schemaSuffix: INamedOption<yargs.Options> = {
+  public static schemaSuffix: INamedOption<yargs.Options, IProjectConfigArgs> = {
     name: "schema-suffix",
     option: {
       describe:
         "A suffix to be appended to output schema names. If unset, the value from workflow_settings.yaml " +
         "is used."
     },
-    check: (argv: yargs.Arguments<any>) => {
+    check: (argv: yargs.Arguments<IProjectConfigArgs>) => {
       if (
-        argv[ProjectConfigOptions.schemaSuffix.name] &&
-        !/^[a-zA-Z_0-9]+$/.test(argv[ProjectConfigOptions.schemaSuffix.name])
+        argv.schemaSuffix &&
+        !/^[a-zA-Z_0-9]+$/.test(argv.schemaSuffix)
       ) {
         throw new Error(
           `--${ProjectConfigOptions.schemaSuffix.name} should contain only ` +
@@ -86,7 +99,7 @@ export class ProjectConfigOptions {
     }
   };
 
-  public static tablePrefix: INamedOption<yargs.Options> = {
+  public static tablePrefix: INamedOption<yargs.Options, IProjectConfigArgs> = {
     name: "table-prefix",
     option: {
       describe:
@@ -94,7 +107,7 @@ export class ProjectConfigOptions {
     }
   };
 
-  public static disableAssertions: INamedOption<yargs.Options> = {
+  public static disableAssertions: INamedOption<yargs.Options, IProjectConfigArgs> = {
     name: "disable-assertions",
     option: {
       describe:
@@ -104,7 +117,7 @@ export class ProjectConfigOptions {
     }
   };
 
-  public static defaultReservation: INamedOption<yargs.Options> = {
+  public static defaultReservation: INamedOption<yargs.Options, IProjectConfigArgs> = {
     name: "default-reservation",
     option: {
       describe:
@@ -114,7 +127,7 @@ export class ProjectConfigOptions {
     }
   };
 
-  public static allYargsOptions = [
+  public static allYargsOptions: Array<INamedOption<yargs.Options, IProjectConfigArgs>> = [
     ProjectConfigOptions.defaultDatabase,
     ProjectConfigOptions.defaultSchema,
     ProjectConfigOptions.defaultLocation,
@@ -128,39 +141,39 @@ export class ProjectConfigOptions {
   ];
 
   public static constructProjectConfigOverride(
-    argv: yargs.Arguments<any>
+    argv: yargs.Arguments<IProjectConfigArgs>
   ): dataform.IProjectConfig {
     const projectConfigOptions: dataform.IProjectConfig = {};
 
-    if (argv[ProjectConfigOptions.defaultDatabase.name]) {
-      projectConfigOptions.defaultDatabase = argv[ProjectConfigOptions.defaultDatabase.name];
+    if (argv.defaultDatabase) {
+      projectConfigOptions.defaultDatabase = argv.defaultDatabase;
     }
-    if (argv[ProjectConfigOptions.defaultSchema.name]) {
-      projectConfigOptions.defaultSchema = argv[ProjectConfigOptions.defaultSchema.name];
+    if (argv.defaultSchema) {
+      projectConfigOptions.defaultSchema = argv.defaultSchema;
     }
-    if (argv[ProjectConfigOptions.defaultLocation.name]) {
-      projectConfigOptions.defaultLocation = argv[ProjectConfigOptions.defaultLocation.name];
+    if (argv.defaultLocation) {
+      projectConfigOptions.defaultLocation = argv.defaultLocation;
     }
-    if (argv[ProjectConfigOptions.assertionSchema.name]) {
-      projectConfigOptions.assertionSchema = argv[ProjectConfigOptions.assertionSchema.name];
+    if (argv.assertionSchema) {
+      projectConfigOptions.assertionSchema = argv.assertionSchema;
     }
-    if (argv[ProjectConfigOptions.vars.name]) {
-      projectConfigOptions.vars = argv[ProjectConfigOptions.vars.name];
+    if (argv.vars) {
+      projectConfigOptions.vars = argv.vars;
     }
-    if (argv[ProjectConfigOptions.databaseSuffix.name]) {
-      projectConfigOptions.databaseSuffix = argv[ProjectConfigOptions.databaseSuffix.name];
+    if (argv.databaseSuffix) {
+      projectConfigOptions.databaseSuffix = argv.databaseSuffix;
     }
-    if (argv[ProjectConfigOptions.schemaSuffix.name]) {
-      projectConfigOptions.schemaSuffix = argv[ProjectConfigOptions.schemaSuffix.name];
+    if (argv.schemaSuffix) {
+      projectConfigOptions.schemaSuffix = argv.schemaSuffix;
     }
-    if (argv[ProjectConfigOptions.tablePrefix.name]) {
-      projectConfigOptions.tablePrefix = argv[ProjectConfigOptions.tablePrefix.name];
+    if (argv.tablePrefix) {
+      projectConfigOptions.tablePrefix = argv.tablePrefix;
     }
-    if (argv[ProjectConfigOptions.disableAssertions.name]) {
-      projectConfigOptions.disableAssertions = argv[ProjectConfigOptions.disableAssertions.name];
+    if (argv.disableAssertions) {
+      projectConfigOptions.disableAssertions = argv.disableAssertions;
     }
-    if (argv[ProjectConfigOptions.defaultReservation.name]) {
-      projectConfigOptions.defaultReservation = argv[ProjectConfigOptions.defaultReservation.name];
+    if (argv.defaultReservation) {
+      projectConfigOptions.defaultReservation = argv.defaultReservation;
     }
     return projectConfigOptions;
   }

--- a/cli/yargswrapper.ts
+++ b/cli/yargswrapper.ts
@@ -3,19 +3,26 @@ import yargs from "yargs";
 import { printError } from "df/cli/console";
 
 export interface ICli {
-  commands: Array<ICommand<any>>;
+  commands: ICommandBase[];
 }
 
-export interface ICommand<TArgs = any> {
+export interface ICommandBase {
   format: string;
   description: string;
+  positionalOptions: Array<INamedOption<yargs.PositionalOptions, any>>;
+  options: Array<INamedOption<yargs.Options, any>>;
+  check?: Array<(argv: yargs.Arguments<any>) => void>;
+  processFn: (argv: yargs.Arguments<any>) => Promise<number>;
+}
+
+export interface ICommand<TArgs> extends ICommandBase {
   positionalOptions: Array<INamedOption<yargs.PositionalOptions, TArgs>>;
   options: Array<INamedOption<yargs.Options, TArgs>>;
   check?: Array<(argv: yargs.Arguments<TArgs>) => void>;
   processFn: (argv: yargs.Arguments<TArgs>) => Promise<number>;
 }
 
-export interface INamedOption<TOption = yargs.Options | yargs.PositionalOptions, TArgs = any> {
+export interface INamedOption<TOption, TArgs> {
   name: string;
   option: TOption;
   check?: (args: yargs.Arguments<TArgs>) => void;
@@ -45,7 +52,7 @@ export function createYargsCli(cli: ICli) {
   return yargsInstance;
 }
 
-export function setupYargs(commands: Array<ICommand<any>>, args: string[]) {
+export function setupYargs(commands: ICommandBase[], args: string[]) {
   let yargsChain = yargs(args).scriptName("dataform").wrap(null);
   for (const command of commands) {
     yargsChain = yargsChain.command(
@@ -61,7 +68,7 @@ export function setupYargs(commands: Array<ICommand<any>>, args: string[]) {
   return yargsChain;
 }
 
-function buildCommand(yargsChain: yargs.Argv, command: ICommand<any>) {
+function buildCommand(yargsChain: yargs.Argv, command: ICommandBase) {
   const checks: Array<(args: yargs.Arguments<any>) => void> = [];
 
   if (command.check) {

--- a/cli/yargswrapper.ts
+++ b/cli/yargswrapper.ts
@@ -11,6 +11,7 @@ export interface ICommand {
   description: string;
   positionalOptions: Array<INamedOption<yargs.PositionalOptions>>;
   options: Array<INamedOption<yargs.Options>>;
+  check?: Array<(argv: yargs.Arguments) => void>;
   processFn: (argv: { [argumentName: string]: any }) => Promise<number>;
 }
 
@@ -50,7 +51,7 @@ export function setupYargs(commands: ICommand[], args: string[]) {
     yargsChain = yargsChain.command(
       command.format,
       command.description,
-      (yargsChainer: yargs.Argv) => createOptionsChain(yargsChainer, command),
+      (yargsChainer: yargs.Argv) => buildCommand(yargsChainer, command),
       async (argv: { [argumentName: string]: any }) => {
         const exitCode = await command.processFn(argv);
         process.exit(exitCode);
@@ -60,8 +61,12 @@ export function setupYargs(commands: ICommand[], args: string[]) {
   return yargsChain;
 }
 
-function createOptionsChain(yargsChain: yargs.Argv, command: ICommand) {
+function buildCommand(yargsChain: yargs.Argv, command: ICommand) {
   const checks: Array<(args: yargs.Arguments) => void> = [];
+
+  if (command.check) {
+    checks.push(...command.check);
+  }
 
   for (const positionalOption of command.positionalOptions) {
     yargsChain = yargsChain.positional(positionalOption.name, positionalOption.option);

--- a/cli/yargswrapper.ts
+++ b/cli/yargswrapper.ts
@@ -3,22 +3,22 @@ import yargs from "yargs";
 import { printError } from "df/cli/console";
 
 export interface ICli {
-  commands: ICommand[];
+  commands: Array<ICommand<any>>;
 }
 
-export interface ICommand {
+export interface ICommand<TArgs = any> {
   format: string;
   description: string;
-  positionalOptions: Array<INamedOption<yargs.PositionalOptions>>;
-  options: Array<INamedOption<yargs.Options>>;
-  check?: Array<(argv: yargs.Arguments) => void>;
-  processFn: (argv: { [argumentName: string]: any }) => Promise<number>;
+  positionalOptions: Array<INamedOption<yargs.PositionalOptions, TArgs>>;
+  options: Array<INamedOption<yargs.Options, TArgs>>;
+  check?: Array<(argv: yargs.Arguments<TArgs>) => void>;
+  processFn: (argv: yargs.Arguments<TArgs>) => Promise<number>;
 }
 
-export interface INamedOption<T> {
+export interface INamedOption<TOption = yargs.Options | yargs.PositionalOptions, TArgs = any> {
   name: string;
-  option: T;
-  check?: (args: yargs.Arguments) => void;
+  option: TOption;
+  check?: (args: yargs.Arguments<TArgs>) => void;
 }
 
 export function createYargsCli(cli: ICli) {
@@ -45,14 +45,14 @@ export function createYargsCli(cli: ICli) {
   return yargsInstance;
 }
 
-export function setupYargs(commands: ICommand[], args: string[]) {
+export function setupYargs(commands: Array<ICommand<any>>, args: string[]) {
   let yargsChain = yargs(args).scriptName("dataform").wrap(null);
   for (const command of commands) {
     yargsChain = yargsChain.command(
       command.format,
       command.description,
       (yargsChainer: yargs.Argv) => buildCommand(yargsChainer, command),
-      async (argv: { [argumentName: string]: any }) => {
+      async (argv: any) => {
         const exitCode = await command.processFn(argv);
         process.exit(exitCode);
       }
@@ -61,8 +61,8 @@ export function setupYargs(commands: ICommand[], args: string[]) {
   return yargsChain;
 }
 
-function buildCommand(yargsChain: yargs.Argv, command: ICommand) {
-  const checks: Array<(args: yargs.Arguments) => void> = [];
+function buildCommand(yargsChain: yargs.Argv, command: ICommand<any>) {
+  const checks: Array<(args: yargs.Arguments<any>) => void> = [];
 
   if (command.check) {
     checks.push(...command.check);


### PR DESCRIPTION
## Summary

Refactors Dataform CLI commands to be strongly typed with Yargs, replacing untyped `any` arguments and string lookups (`argv["flag-name"]`) with type-safe properties (`argv.flagName`).

## Changes

- **Strong typing**: Added dedicated argument interfaces for each command (e.g. `ICompileArgs`, `IRunArgs`) using a generic `ICommand<TArgs>`.
- **Consistent options**: Unified shared options in `common_options.ts` and extracted inline option objects into named constants across all commands.
- **Separated heavy options**: Moved option definitions for `compile` and `run` into dedicated files (`compile_options.ts`, `run_options.ts`) to keep the main command files clean and focused on execution logic.
- **Explicit exit codes**: Ensured all command handlers explicitly return numeric exit codes (`0` or `1`).

---
> **Note for the reviewer:**  
> Sorry for the big diff! ☕ To make the review easier, I split the work into small, logical commits. Going through them commit by commit should make much more sense than trying to read the whole diff at once!